### PR TITLE
fix blacklisted linter normalization typo

### DIFF
--- a/src/__Private/LinterCLIConfig.php
+++ b/src/__Private/LinterCLIConfig.php
@@ -156,7 +156,7 @@ final class LinterCLIConfig {
     );
 
     $linters = $normalize($linters);
-    $blacklist = $normalize($linters);
+    $blacklist = $normalize($blacklist);
     $autofix_blacklist = $normalize($autofix_blacklist);
 
     $linters = Keyset\union(


### PR DESCRIPTION
Hi there,

It looks like there might be a typo wrt the linter blacklist. I have a `hh-lint.json` like
```
...
"builtinLinters": "none",
"namespaceAliases": { "HHAST": "Facebook\\HHAST\\Linters" },
"extraLinters": [
  "HHAST\\CamelCasedMethodsUnderscoredFunctionsLinter",
  "HHAST\\MustUseBracesForControlFlowLinter"
]
...
```
and no linters were run against the target files :/
Changing this line fixed things for me!