### PR TITLE
remove slow invariant

### DIFF
--- a/src/find_offset_of_leading.php
+++ b/src/find_offset_of_leading.php
@@ -24,10 +24,6 @@ function find_offset_of_leading(
 
   $parents = null;
   $found = false;
-  invariant(
-    !C\is_empty($root->getDescendantsWhere(($it, $_p) ==> $it === $node)),
-    'node is not a descendant of root',
-  );
   $stack = $root->findWithParents($it ==> $it === $node);
   invariant(
     !C\is_empty($stack),


### PR DESCRIPTION
I've been working on a linter that disallows invocations of particular functions by name, and was testing it out on a ~5500 line source file. `getDescendantsWhere` consumes a very large amount of time (on the order of the number of lint errors and AST size).

I _think_ removing it would be okay as the `findWithParents` seems like enforces the same or a similar invariant. If not, maybe there's a cleaner way to enforce this? (i.e. not traversing from `$root` with every recursive call?)

Here's some XHPROF's from before and after!
![before](https://user-images.githubusercontent.com/4551889/31463905-826e0598-ae84-11e7-86b1-509159d2a831.png)
![after](https://user-images.githubusercontent.com/4551889/31463909-843c0280-ae84-11e7-9eca-7c4de4eee888.png)

In general, are you open to changes/alternative approaches in `find_offset_of_leading`?
