### PR TITLE
re-use stack while recursively calling find_offset_of_leading

### DIFF
--- a/src/find_offset_of_leading.php
+++ b/src/find_offset_of_leading.php
@@ -17,6 +17,7 @@ use namespace HH\Lib\{C, Vec};
 function find_offset_of_leading(
   EditableNode $root,
   EditableNode $node,
+  ?vec<EditableNode> $stack = null
 ): int {
   if ($root === $node) {
     return 0;
@@ -24,7 +25,10 @@ function find_offset_of_leading(
 
   $parents = null;
   $found = false;
-  $stack = $root->findWithParents($it ==> $it === $node);
+
+  if ($stack === null) {
+    $stack = $root->findWithParents($it ==> $it === $node);
+  }
   invariant(
     !C\is_empty($stack),
     'did not find node in root',
@@ -43,8 +47,11 @@ function find_offset_of_leading(
     $within_parent += $child->getWidth();
   }
 
+  array_pop($stack);
+
   return $within_parent + find_offset_of_leading(
     $root,
     $parent,
+    $stack
   );
 }

--- a/src/find_offset_of_leading.php
+++ b/src/find_offset_of_leading.php
@@ -37,7 +37,9 @@ function find_offset_of_leading(
     C\lastx($stack) === $node,
     'expected node at top of stack',
   );
-  $parent = $stack[C\count($stack) - 2];
+
+  $stack_count = C\count($stack);
+  $parent = $stack[$stack_count - 2];
 
   $within_parent = 0;
   foreach ($parent->getChildren() as $child) {
@@ -47,7 +49,7 @@ function find_offset_of_leading(
     $within_parent += $child->getWidth();
   }
 
-  array_pop($stack);
+  $stack = Vec\take($stack, $stack_count - 1);
 
   return $within_parent + find_offset_of_leading(
     $root,


### PR DESCRIPTION
Just looking for feedback here -- this is what I was envisioning for a follow up to #16. I'm assuming that an AST isn't able to be mutated while recursively calling `find_offset_of_leading` but ¯\\\_(ツ)\_/¯. I'm happy to write tests but frankly I don't know where to start or what to use as an example.

Thanks for indulging me here
![](https://user-images.githubusercontent.com/4551889/31559454-84638c9c-b005-11e7-80d3-c6b1fa36c227.jpg)

Oh and here's some more XHPROFs for this one:
![before](https://user-images.githubusercontent.com/4551889/31559424-5fea8b18-b005-11e7-90e6-383c47685e7f.png)
![after](https://user-images.githubusercontent.com/4551889/31559426-625f3006-b005-11e7-92c6-13a8de08b0f9.png)
