### PR TITLE
add additional fields to TSchema shape def

### DIFF
--- a/src/__Private/codegen/schema.php
+++ b/src/__Private/codegen/schema.php
@@ -34,4 +34,6 @@ type TSchema = shape(
   'trivia' => array<TTrivia>,
   'tokens' => array<TToken>,
   'AST' => array<TAST>,
+  ?'description' => string,
+  ?'version' => string,
 );


### PR DESCRIPTION
When I attempt to run `bin/update-codegen` on a fresh clone from master, I get the following:

```
[22] $> bin/update-codegen
#!/usr/bin/env hhvm

Fatal error: Uncaught exception 'Facebook\TypeAssert\IncorrectTypeException' with message 'Expected type 'no extra shape fields', got type 'string'
Type trace:
#0 shape[description]
' in /Users/bradleydavis/github/hhast_upstream/vendor/hhvm/type-assert/src/IncorrectTypeException.php:41
Stack trace:
#0 /Users/bradleydavis/github/hhast_upstream/vendor/hhvm/type-assert/src/IncorrectTypeException.php(53): Facebook\TypeAssert\IncorrectTypeException::withType()
#1 /Users/bradleydavis/github/hhast_upstream/vendor/hhvm/type-assert/src/TypeSpec/__Private/ShapeSpec.php(94): Facebook\TypeAssert\IncorrectTypeException::withValue()
#2 /Users/bradleydavis/github/hhast_upstream/vendor/hhvm/type-assert/src/TypeAssert.php(63): Facebook\TypeSpec\__Private\ShapeSpec->assertType()
#3 /Users/bradleydavis/github/hhast_upstream/src/__Private/CodegenCLI.php(67): Facebook\TypeAssert\matches_type_structure()
#4 /Users/bradleydavis/github/hhast_upstream/src/__Private/CodegenCLI.php(68): Facebook\HHAST\__Private\CodegenCLI->getSchema$memoize_impl()
#5 /Users/bradleydavis/github/hhast_upstream/src/__Private/CodegenCLI.php(43): Facebook\HHAST\__Private\CodegenCLI->getSchema()
#6 /Users/bradleydavis/github/hhast_upstream/bin/update-codegen(18): Facebook\HHAST\__Private\CodegenCLI->mainAsync()
#7 {main}
```

Looks like `TSchema`'s def didn't include the first two keys in `schema.json` so I've added them as optional shape fields. Hopefully that's the right thing to do! `bin/update-codegen` now exits cleanly.