### PR TITLE
make find_offset_of_leading work for trivia

### DIFF
--- a/src/find_offset.php
+++ b/src/find_offset.php
@@ -25,7 +25,9 @@ function find_offset_after_leading(
   $leading_offset = find_offset_of_leading($root, $node);
 
   $first_token = $node->getFirstToken();
-  if ($first_token === null) { return $leading_offset; }
+  if ($first_token === null) {
+    return $leading_offset;
+  }
 
   return $leading_offset + $first_token->getLeading()->getWidth();
 }

--- a/src/find_offset.php
+++ b/src/find_offset.php
@@ -22,6 +22,10 @@ function find_offset_after_leading(
     return 0;
   }
 
-  return find_offset_of_leading($root, $node)
-    + $node->getFirstTokenx()->getLeading()->getWidth();
+  $leading_offset = find_offset_of_leading($root, $node);
+
+  $first_token = $node->getFirstToken();
+  if ($first_token === null) { return $leading_offset; }
+
+  return $leading_offset + $first_token->getLeading()->getWidth();
 }


### PR DESCRIPTION
Something I've run into:

Suppose you really, really dislike comments and so you write this:
```
class AllCodeIsSelfDocumentingLinter
  extends ASTLinter<SingleLineComment> {

  <<__Override>>
  protected static function getTargetType(): classname<SingleLineComment> {
    return SingleLineComment::class;
  }

  <<__Override>>
  public function getLintErrorForNode(
    SingleLineComment $node,
    vec<EditableNode> $parents,
  ): ?ASTLintError<SingleLineComment> {

    return new ASTLintError(
      $this,
      'bah humbug',
      $node,
    );
  }
}
```

whenever this error is triggered, you get an `IncorrectTypeException`:

```
Warning: Destructor threw an object exception: exception 'HH\InvariantException' with message 'counter Facebook\HHAST\Linters\AllCodeIsSelfDocumentingLinter#processErrors destroyed without calling ::end()' in /Users/bradleydavis/github/hhast/src/__Private/PerfCounter.php:51
Stack trace:
#0 /Users/bradleydavis/github/hhast/src/__Private/PerfCounter.php(51): HH\invariant_violation()
#1 /Users/bradleydavis/github/hhast/src/__Private/LinterCLI.php(67): Facebook\HHAST\__Private\PerfCounter->__destruct()
#2 /Users/bradleydavis/github/hhast/src/__Private/LinterCLI.php(95): Facebook\HHAST\__Private\LinterCLI::lintFile()
#3 /Users/bradleydavis/github/hhast/src/__Private/LinterCLI.php(130): Facebook\HHAST\__Private\LinterCLI->lintPath()
#4 /Users/bradleydavis/github/hhast/bin/hhast-lint(38): Facebook\HHAST\__Private\LinterCLI->mainAsync()
#5 {main} in /Users/bradleydavis/github/hhast/src/__Private/LinterCLI.php on line 67

Warning: Destructor threw an object exception: exception 'HH\InvariantException' with message 'counter Facebook\HHAST\__Private\LinterCLI destroyed without calling ::end()' in /Users/bradleydavis/github/hhast/src/__Private/PerfCounter.php:51
Stack trace:
#0 /Users/bradleydavis/github/hhast/src/__Private/PerfCounter.php(51): HH\invariant_violation()
#1 /Users/bradleydavis/github/hhast/src/__Private/LinterCLI.php(146): Facebook\HHAST\__Private\PerfCounter->__destruct()
#2 /Users/bradleydavis/github/hhast/bin/hhast-lint(38): Facebook\HHAST\__Private\LinterCLI::mainAsync()
#3 {main} in /Users/bradleydavis/github/hhast/src/__Private/LinterCLI.php on line 146

Fatal error: Uncaught exception 'Facebook\TypeAssert\IncorrectTypeException' with message 'Expected not-null, got null' in /Users/bradleydavis/github/hhast/vendor/hhvm/type-assert/src/TypeAssert.php:49
Stack trace:
#0 /Users/bradleydavis/github/hhast/src/EditableNode.php(205): Facebook\TypeAssert\not_null()
#1 /Users/bradleydavis/github/hhast/src/find_offset.php(26): Facebook\HHAST\EditableNode->getFirstTokenx()
#2 /Users/bradleydavis/github/hhast/src/find_position.php(21): Facebook\HHAST\find_offset_after_leading()
#3 /Users/bradleydavis/github/hhast/src/Linters/ASTLintError.php(38): Facebook\HHAST\find_position()
#4 /Users/bradleydavis/github/hhast/src/__Private/LinterCLI.php(161): Facebook\HHAST\Linters\ASTLintError->getPosition()
#5 (): Facebook\HHAST\__Private\LinterCLI->processErrors()
#6 /Users/bradleydavis/github/hhast/vendor/hhvm/hsl/src/vec/combine.php(27): Generator->rewind()
#7 /Users/bradleydavis/github/hhast/src/__Private/LinterCLI.php(63): HH\Lib\Vec\concat()
#8 /Users/bradleydavis/github/hhast/src/__Private/LinterCLI.php(95): Facebook\HHAST\__Private\LinterCLI->lintFile()
#9 /Users/bradleydavis/github/hhast/src/__Private/LinterCLI.php(130): Facebook\HHAST\__Private\LinterCLI->lintPath()
#10 /Users/bradleydavis/github/hhast/bin/hhast-lint(38): Facebook\HHAST\__Private\LinterCLI->mainAsync()
#11 {main}
```