### PR TITLE
make use of shouldLintFile

### DIFF
--- a/src/__Private/LinterCLI.php
+++ b/src/__Private/LinterCLI.php
@@ -49,6 +49,10 @@ final class LinterCLI extends CLIWithArguments {
     foreach ($config['linters'] as $class) {
       $this->verbosePrintf(2, " - %s\n", $class);
 
+      if (!$class::shouldLintFile($path)) {
+        continue;
+      }
+
       $c = new PerfCounter($class.'#construct');
       $linter = new $class($path);
       $c->end();


### PR DESCRIPTION
Overriding shouldLintFile a la
```
  <<__Override>>
  public static function shouldLintFile(string $file): bool {
    return false;
  }
```
doesn't appear to do anything (still runs the linter).