### PR TITLE
cache traverseWithParents() in BaseASTLinter

### DIFF
--- a/codegen/syntax/AliasDeclaration.php
+++ b/codegen/syntax/AliasDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c4bd4bf45406a14a7fea5c95d669ed0b>>
+ * @generated SignedSource<<78490aee9e0b3479f03b7ab82d425268>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -115,7 +115,7 @@ final class AliasDeclaration extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'attribute_spec' => $this->_attribute_spec,
       'keyword' => $this->_keyword,
@@ -131,7 +131,7 @@ final class AliasDeclaration extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/AnonymousFunction.php
+++ b/codegen/syntax/AnonymousFunction.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<190d91c050de10cd8abb4fbc0585b382>>
+ * @generated SignedSource<<f0081f15ba98dc3d4c93b0a94fdc0653>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -148,7 +148,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'static_keyword' => $this->_static_keyword,
       'async_keyword' => $this->_async_keyword,
@@ -167,7 +167,7 @@ final class AnonymousFunction extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/AnonymousFunctionUseClause.php
+++ b/codegen/syntax/AnonymousFunctionUseClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d1e594fe7d2fa3c03b4dce2c2933f3d5>>
+ * @generated SignedSource<<31d33e95d278e0e7f32a2f3d46a331e9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class AnonymousFunctionUseClause extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -78,7 +78,7 @@ final class AnonymousFunctionUseClause extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ArrayCreationExpression.php
+++ b/codegen/syntax/ArrayCreationExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3780a35f79fe87fcc45b71d87fa02759>>
+ * @generated SignedSource<<a811e9744f0c48112169900436fa98c4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class ArrayCreationExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_bracket' => $this->_left_bracket,
       'members' => $this->_members,
@@ -67,7 +67,7 @@ final class ArrayCreationExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ArrayIntrinsicExpression.php
+++ b/codegen/syntax/ArrayIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d27482cca428ce4d40add5a173db8a88>>
+ * @generated SignedSource<<0ab84ce4e93490c2a3ff56e52a787b45>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class ArrayIntrinsicExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -78,7 +78,7 @@ final class ArrayIntrinsicExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/Attribute.php
+++ b/codegen/syntax/Attribute.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9021e8ecd51dbdc982fe83f10fb9fdb2>>
+ * @generated SignedSource<<970026d10e6d6aebe66e5058f489f33b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class Attribute extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'name' => $this->_name,
       'left_paren' => $this->_left_paren,
@@ -78,7 +78,7 @@ final class Attribute extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/AttributeSpecification.php
+++ b/codegen/syntax/AttributeSpecification.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a48d428f248708949cb8b431e9f8e23a>>
+ * @generated SignedSource<<9dc3ed1b094713b962976621b5dacfcb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class AttributeSpecification extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_double_angle' => $this->_left_double_angle,
       'attributes' => $this->_attributes,
@@ -67,7 +67,7 @@ final class AttributeSpecification extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/AwaitableCreationExpression.php
+++ b/codegen/syntax/AwaitableCreationExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<00033ebf8bfa22628d9e0bb8664eeb89>>
+ * @generated SignedSource<<7b3ab230bd48602e37eddf5171720c20>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class AwaitableCreationExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'async' => $this->_async,
       'coroutine' => $this->_coroutine,
@@ -67,7 +67,7 @@ final class AwaitableCreationExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/BinaryExpression.php
+++ b/codegen/syntax/BinaryExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3bb7e3846d9defef1dec0650b6f40466>>
+ * @generated SignedSource<<47c11136db51e7aa0fe00f0334c49e6c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class BinaryExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_operand' => $this->_left_operand,
       'operator' => $this->_operator,
@@ -67,7 +67,7 @@ final class BinaryExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/BracedExpression.php
+++ b/codegen/syntax/BracedExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d6a4ae83f2eebf9667eac451135e157f>>
+ * @generated SignedSource<<b584d718bceab3db2f926ad96610776b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class BracedExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_brace' => $this->_left_brace,
       'expression' => $this->_expression,
@@ -67,7 +67,7 @@ final class BracedExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/BreakStatement.php
+++ b/codegen/syntax/BreakStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<12211114c5028082fb1d01de58b2760f>>
+ * @generated SignedSource<<3e494f6a306770f5fb0fbdb37b67e05f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class BreakStatement extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'level' => $this->_level,
@@ -67,7 +67,7 @@ final class BreakStatement extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/CaseLabel.php
+++ b/codegen/syntax/CaseLabel.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0af3b2968d7d30074498b22135d203b1>>
+ * @generated SignedSource<<93f4331b53dd5d8836b5cd7424f1fbd6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class CaseLabel extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'expression' => $this->_expression,
@@ -67,7 +67,7 @@ final class CaseLabel extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/CastExpression.php
+++ b/codegen/syntax/CastExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f1de58176c43f521666ead388061e230>>
+ * @generated SignedSource<<d42833c1d2c8a761db1f293335f43918>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class CastExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_paren' => $this->_left_paren,
       'type' => $this->_type,
@@ -78,7 +78,7 @@ final class CastExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/CatchClause.php
+++ b/codegen/syntax/CatchClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6324667fe483d3e3eda098906064baea>>
+ * @generated SignedSource<<da6222e25f7129b882c05ec8b833ff38>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -87,7 +87,7 @@ final class CatchClause extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -101,7 +101,7 @@ final class CatchClause extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ClassishBody.php
+++ b/codegen/syntax/ClassishBody.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<04a75dd621232a1e698d9587d9fe8c09>>
+ * @generated SignedSource<<0061ed10338ae28af019964ba9b949a0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class ClassishBody extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_brace' => $this->_left_brace,
       'elements' => $this->_elements,
@@ -67,7 +67,7 @@ final class ClassishBody extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ClassishDeclaration.php
+++ b/codegen/syntax/ClassishDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0ee93e6d7f762953d77d3b7b58c3343f>>
+ * @generated SignedSource<<3740f9669c72931f1f8f134502825142>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -137,7 +137,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'attribute' => $this->_attribute,
       'modifiers' => $this->_modifiers,
@@ -155,7 +155,7 @@ final class ClassishDeclaration extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ClassnameTypeSpecifier.php
+++ b/codegen/syntax/ClassnameTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2a8f9137c00a2366e5d12e570bcef88c>>
+ * @generated SignedSource<<9be9c21d4c8277e4cb9e0328aa3d03f6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -77,7 +77,7 @@ final class ClassnameTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_angle' => $this->_left_angle,
@@ -90,7 +90,7 @@ final class ClassnameTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ClosureTypeSpecifier.php
+++ b/codegen/syntax/ClosureTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7a307b460d81b56e8063b820ab873063>>
+ * @generated SignedSource<<633c23863f255510fabfeb2db34773fd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -126,7 +126,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'outer_left_paren' => $this->_outer_left_paren,
       'coroutine' => $this->_coroutine,
@@ -143,7 +143,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/CollectionLiteralExpression.php
+++ b/codegen/syntax/CollectionLiteralExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<988b6ca5c85689af24b2badadb1a09bb>>
+ * @generated SignedSource<<54cc1d4998fccdf9f5a9652e73d3e0a2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class CollectionLiteralExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'name' => $this->_name,
       'left_brace' => $this->_left_brace,
@@ -78,7 +78,7 @@ final class CollectionLiteralExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/CompoundStatement.php
+++ b/codegen/syntax/CompoundStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c9434bb45507cea098968bafee8bc889>>
+ * @generated SignedSource<<0e3807f18fdd3d3bb2ab7d11729728be>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class CompoundStatement extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_brace' => $this->_left_brace,
       'statements' => $this->_statements,
@@ -67,7 +67,7 @@ final class CompoundStatement extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ConditionalExpression.php
+++ b/codegen/syntax/ConditionalExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5c83c0f3ff061f1b50390e97b5f2021c>>
+ * @generated SignedSource<<d0c0e0cef6e0bfc67929f8ccf1bccf0a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -76,7 +76,7 @@ final class ConditionalExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'test' => $this->_test,
       'question' => $this->_question,
@@ -89,7 +89,7 @@ final class ConditionalExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ConstDeclaration.php
+++ b/codegen/syntax/ConstDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<58095641918b90bf114d19addf5ffc13>>
+ * @generated SignedSource<<440c3718908dab13e575c726662b56dc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -77,7 +77,7 @@ final class ConstDeclaration extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'abstract' => $this->_abstract,
       'keyword' => $this->_keyword,
@@ -90,7 +90,7 @@ final class ConstDeclaration extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ConstantDeclarator.php
+++ b/codegen/syntax/ConstantDeclarator.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<627b81457cc727fdc5df189a2403daff>>
+ * @generated SignedSource<<72b78598ce19f50543636f3b8542dd20>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class ConstantDeclarator extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'name' => $this->_name,
       'initializer' => $this->_initializer,
@@ -53,7 +53,7 @@ final class ConstantDeclarator extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ContinueStatement.php
+++ b/codegen/syntax/ContinueStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<af1768ab363801726475450d13357e50>>
+ * @generated SignedSource<<b505b663c7becea0bde9674f68eefc27>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class ContinueStatement extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'level' => $this->_level,
@@ -67,7 +67,7 @@ final class ContinueStatement extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/DarrayIntrinsicExpression.php
+++ b/codegen/syntax/DarrayIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0e7680ef5558f9cfad490471b501a50d>>
+ * @generated SignedSource<<854849af8156d93feec65187ea813e41>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class DarrayIntrinsicExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_bracket' => $this->_left_bracket,
@@ -78,7 +78,7 @@ final class DarrayIntrinsicExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/DarrayTypeSpecifier.php
+++ b/codegen/syntax/DarrayTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<809bed933ce9e99c951cd57c16fa5fe0>>
+ * @generated SignedSource<<0eb540c44888a49a8d7e3bad7be7e325>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -104,7 +104,7 @@ final class DarrayTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_angle' => $this->_left_angle,
@@ -119,7 +119,7 @@ final class DarrayTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/DecoratedExpression.php
+++ b/codegen/syntax/DecoratedExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<aca09f1ec5aa18ffa4b1162b6c12c25c>>
+ * @generated SignedSource<<e2d6d5e6307ef557f86d485c79d0507a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -46,7 +46,7 @@ final class DecoratedExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'decorator' => $this->_decorator,
       'expression' => $this->_expression,
@@ -56,7 +56,7 @@ final class DecoratedExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/DefaultLabel.php
+++ b/codegen/syntax/DefaultLabel.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<75034b6e873aac7b593f56b0bd0e59f3>>
+ * @generated SignedSource<<50cc89f2b5877a15ee6b4d26679adebb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class DefaultLabel extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'colon' => $this->_colon,
@@ -53,7 +53,7 @@ final class DefaultLabel extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/DefineExpression.php
+++ b/codegen/syntax/DefineExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<779d1ddec333d404cbd402a22d79f8ee>>
+ * @generated SignedSource<<943f9854d58fe8ad2f90812b3efa805e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class DefineExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -78,7 +78,7 @@ final class DefineExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/DictionaryIntrinsicExpression.php
+++ b/codegen/syntax/DictionaryIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2a164caa9783abd8d3ac40498e236bb9>>
+ * @generated SignedSource<<54c9fc99bf5945c9bd4b9641bbc76f5c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class DictionaryIntrinsicExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_bracket' => $this->_left_bracket,
@@ -78,7 +78,7 @@ final class DictionaryIntrinsicExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/DictionaryTypeSpecifier.php
+++ b/codegen/syntax/DictionaryTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9062c676034f8b9d82dfb0edbcc3050e>>
+ * @generated SignedSource<<47494571ed5d84a31c35a7e2c86f5a67>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class DictionaryTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_angle' => $this->_left_angle,
@@ -78,7 +78,7 @@ final class DictionaryTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/DoStatement.php
+++ b/codegen/syntax/DoStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7a4e7a0f911a092e08cc4b1a0e82f5e3>>
+ * @generated SignedSource<<bf0a4ead7490258c12eb5a3fd910bd2a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -105,7 +105,7 @@ final class DoStatement extends EditableNode
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'body' => $this->_body,
@@ -120,7 +120,7 @@ final class DoStatement extends EditableNode
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/EchoStatement.php
+++ b/codegen/syntax/EchoStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ed8f68b737e6568b6d15eb0b44b848d2>>
+ * @generated SignedSource<<95a0b35030ad49f71d2c728d8085e241>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class EchoStatement extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'expressions' => $this->_expressions,
@@ -67,7 +67,7 @@ final class EchoStatement extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ElementInitializer.php
+++ b/codegen/syntax/ElementInitializer.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9025ad8ac3578619efe26edd7cae8d01>>
+ * @generated SignedSource<<484cb2c4d2575825f21cfdf850c48a1f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class ElementInitializer extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'key' => $this->_key,
       'arrow' => $this->_arrow,
@@ -67,7 +67,7 @@ final class ElementInitializer extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ElseClause.php
+++ b/codegen/syntax/ElseClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2fac6d52ab6b40aacc8dc3fc3442d6b5>>
+ * @generated SignedSource<<d6e4d411819dff590eeefc64473d974e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class ElseClause extends EditableNode implements IControlFlowStatement {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'statement' => $this->_statement,
@@ -53,7 +53,7 @@ final class ElseClause extends EditableNode implements IControlFlowStatement {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ElseifClause.php
+++ b/codegen/syntax/ElseifClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3505203654ec0f27462bc4ff94b59ce8>>
+ * @generated SignedSource<<4e0ff6d641a0f3d462e33ea7de6bbe5a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -77,7 +77,7 @@ final class ElseifClause extends EditableNode implements IControlFlowStatement {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -90,7 +90,7 @@ final class ElseifClause extends EditableNode implements IControlFlowStatement {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/EmbeddedBracedExpression.php
+++ b/codegen/syntax/EmbeddedBracedExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ff64fa34f5f9c1dfa388a157400d4b94>>
+ * @generated SignedSource<<95c2b5bd17382d4a0bbd0b1504812892>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class EmbeddedBracedExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_brace' => $this->_left_brace,
       'expression' => $this->_expression,
@@ -67,7 +67,7 @@ final class EmbeddedBracedExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/EmbeddedMemberSelectionExpression.php
+++ b/codegen/syntax/EmbeddedMemberSelectionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a851d8f0d8602349fc224bbf941bab12>>
+ * @generated SignedSource<<9312b318694b4790ed6ef21ec0bdc26a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class EmbeddedMemberSelectionExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'object' => $this->_object,
       'operator' => $this->_operator,
@@ -67,7 +67,7 @@ final class EmbeddedMemberSelectionExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/EmbeddedSubscriptExpression.php
+++ b/codegen/syntax/EmbeddedSubscriptExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<525629f3b69a796a3d6901522a1b0b34>>
+ * @generated SignedSource<<dec957ae101d8d3b3259e68b8e9ecf61>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class EmbeddedSubscriptExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'receiver' => $this->_receiver,
       'left_bracket' => $this->_left_bracket,
@@ -78,7 +78,7 @@ final class EmbeddedSubscriptExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/EmptyExpression.php
+++ b/codegen/syntax/EmptyExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1982302b7c33c31b0312e299005a545f>>
+ * @generated SignedSource<<0ba561a7cd54bb0c856e39528e9ddcba>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class EmptyExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -78,7 +78,7 @@ final class EmptyExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/EndOfFile.php
+++ b/codegen/syntax/EndOfFile.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1ff83f78dfca5d594a1ac91f5e79c22d>>
+ * @generated SignedSource<<85290d39fca52f3a04c7b4321adc47c4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -34,7 +34,7 @@ final class EndOfFile extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'token' => $this->_token,
     ];
@@ -43,7 +43,7 @@ final class EndOfFile extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/EnumDeclaration.php
+++ b/codegen/syntax/EnumDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<489fdaf4056d22acccc5a5ed541312ce>>
+ * @generated SignedSource<<8a36c756bd0b033746de6f92b1060ee1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -126,7 +126,7 @@ final class EnumDeclaration extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'attribute_spec' => $this->_attribute_spec,
       'keyword' => $this->_keyword,
@@ -143,7 +143,7 @@ final class EnumDeclaration extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/Enumerator.php
+++ b/codegen/syntax/Enumerator.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cadd4ca04406ea76c9dbf12220958a49>>
+ * @generated SignedSource<<913b74f09cdb0110caee60475887b39f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class Enumerator extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'name' => $this->_name,
       'equal' => $this->_equal,
@@ -78,7 +78,7 @@ final class Enumerator extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ErrorSyntax.php
+++ b/codegen/syntax/ErrorSyntax.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b94293a6c6bc2639116ff07290ba525a>>
+ * @generated SignedSource<<c10d51bb721de15b6c236f4dcb2f8f3f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -34,7 +34,7 @@ final class ErrorSyntax extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'error' => $this->_error,
     ];
@@ -43,7 +43,7 @@ final class ErrorSyntax extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/EvalExpression.php
+++ b/codegen/syntax/EvalExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<920f9c0baf68abc70a0c4769416412e0>>
+ * @generated SignedSource<<7d35b663b64a3cd63d6c8c222132a81b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class EvalExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -78,7 +78,7 @@ final class EvalExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ExpressionStatement.php
+++ b/codegen/syntax/ExpressionStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2de0a06b4efbe39105a2c0db802bd403>>
+ * @generated SignedSource<<0adc87863137f17c42a88c68a58dcf4d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -46,7 +46,7 @@ final class ExpressionStatement extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'expression' => $this->_expression,
       'semicolon' => $this->_semicolon,
@@ -56,7 +56,7 @@ final class ExpressionStatement extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/FieldInitializer.php
+++ b/codegen/syntax/FieldInitializer.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<56c0090ac3688285c5e0efc2327ac4ad>>
+ * @generated SignedSource<<568d1c7e326fc0a3ed5ff6ade00e7412>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class FieldInitializer extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'name' => $this->_name,
       'arrow' => $this->_arrow,
@@ -67,7 +67,7 @@ final class FieldInitializer extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/FieldSpecifier.php
+++ b/codegen/syntax/FieldSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<daf35e8f446b793bb873ef597aecda5f>>
+ * @generated SignedSource<<5322307faa42baa2a41460a375ed092a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class FieldSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'question' => $this->_question,
       'name' => $this->_name,
@@ -78,7 +78,7 @@ final class FieldSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/FinallyClause.php
+++ b/codegen/syntax/FinallyClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3d322c56090feae26e3dee4a1f25edff>>
+ * @generated SignedSource<<3e6e373352a8ba8b519ee2d42b8d4a61>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class FinallyClause extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'body' => $this->_body,
@@ -53,7 +53,7 @@ final class FinallyClause extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ForStatement.php
+++ b/codegen/syntax/ForStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<eacc02bed8ac08c7bbbf59e7fb764253>>
+ * @generated SignedSource<<8f4414e992c97af3638545a95ede928b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -127,7 +127,7 @@ final class ForStatement extends EditableNode
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -144,7 +144,7 @@ final class ForStatement extends EditableNode
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ForeachStatement.php
+++ b/codegen/syntax/ForeachStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e947e7ab7e8f50db65943a39118f6478>>
+ * @generated SignedSource<<814d057db68c2f4db21f8d9b57af5570>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -138,7 +138,7 @@ final class ForeachStatement extends EditableNode
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -156,7 +156,7 @@ final class ForeachStatement extends EditableNode
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/FunctionCallExpression.php
+++ b/codegen/syntax/FunctionCallExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ed6b7ad73a780f72008dcf78b949fcd9>>
+ * @generated SignedSource<<77c9ac2ecafdef9bb6f827637190d257>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class FunctionCallExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'receiver' => $this->_receiver,
       'left_paren' => $this->_left_paren,
@@ -78,7 +78,7 @@ final class FunctionCallExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/FunctionDeclaration.php
+++ b/codegen/syntax/FunctionDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<414e2a2421fcb74ac48838daacf98497>>
+ * @generated SignedSource<<6919e87e53d24cea2161b42f0740e645>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -57,7 +57,7 @@ final class FunctionDeclaration extends EditableNode
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'attribute_spec' => $this->_attribute_spec,
       'declaration_header' => $this->_declaration_header,
@@ -68,7 +68,7 @@ final class FunctionDeclaration extends EditableNode
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/FunctionDeclarationHeader.php
+++ b/codegen/syntax/FunctionDeclarationHeader.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b8d0eb52385c607d42026c73dde2eda3>>
+ * @generated SignedSource<<6437ad8795a7b0695800ea78302c3d23>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -159,7 +159,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'async' => $this->_async,
       'coroutine' => $this->_coroutine,
@@ -179,7 +179,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/FunctionStaticStatement.php
+++ b/codegen/syntax/FunctionStaticStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9baefdbcb3aa2c52657149db7e713dee>>
+ * @generated SignedSource<<32a37b9a5d77f0e940798d39d3cab9da>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class FunctionStaticStatement extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'static_keyword' => $this->_static_keyword,
       'declarations' => $this->_declarations,
@@ -67,7 +67,7 @@ final class FunctionStaticStatement extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/GenericTypeSpecifier.php
+++ b/codegen/syntax/GenericTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<289cce82decea79545adb3222f3d3ff8>>
+ * @generated SignedSource<<9b4e86e31eb77b312bd1ce6c8009310d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -46,7 +46,7 @@ final class GenericTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'class_type' => $this->_class_type,
       'argument_list' => $this->_argument_list,
@@ -56,7 +56,7 @@ final class GenericTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/GlobalStatement.php
+++ b/codegen/syntax/GlobalStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5551b2a97198292777ce601127350c46>>
+ * @generated SignedSource<<d35999534663dd6dee8844cb2fcaa1bb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class GlobalStatement extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'variables' => $this->_variables,
@@ -67,7 +67,7 @@ final class GlobalStatement extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/GotoLabel.php
+++ b/codegen/syntax/GotoLabel.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<000b51216a8a8fc0d85c4317596c0756>>
+ * @generated SignedSource<<dbb050c75ea3e4a0454fd3577b5138c5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class GotoLabel extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'name' => $this->_name,
       'colon' => $this->_colon,
@@ -53,7 +53,7 @@ final class GotoLabel extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/GotoStatement.php
+++ b/codegen/syntax/GotoStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<dcf55f6226808ba06aa174f540be08eb>>
+ * @generated SignedSource<<f8f5b4e2b5cf4e0d19cebaaa6be4da2f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class GotoStatement extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'label_name' => $this->_label_name,
@@ -67,7 +67,7 @@ final class GotoStatement extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/IfStatement.php
+++ b/codegen/syntax/IfStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d4371538ac688be7376bc743eed1f248>>
+ * @generated SignedSource<<5deb04c82100a0577731cae331546394>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -104,7 +104,7 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -119,7 +119,7 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/InclusionDirective.php
+++ b/codegen/syntax/InclusionDirective.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ba4088be2ed4854a798d88f3d6d74697>>
+ * @generated SignedSource<<bee3640157b3ec9404de40d0334e25b7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -46,7 +46,7 @@ final class InclusionDirective extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'expression' => $this->_expression,
       'semicolon' => $this->_semicolon,
@@ -56,7 +56,7 @@ final class InclusionDirective extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/InclusionExpression.php
+++ b/codegen/syntax/InclusionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7de5ed7d0be60b6e7b9b1e5aca0a28a1>>
+ * @generated SignedSource<<e46480e40d361b38d54db5453514b0e4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class InclusionExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'require' => $this->_require,
       'filename' => $this->_filename,
@@ -53,7 +53,7 @@ final class InclusionExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/InstanceofExpression.php
+++ b/codegen/syntax/InstanceofExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4bc525566959ddd16b6e4ac348fdc73b>>
+ * @generated SignedSource<<3f4df1c94d618ea21e706582faa8b626>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class InstanceofExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_operand' => $this->_left_operand,
       'operator' => $this->_operator,
@@ -67,7 +67,7 @@ final class InstanceofExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/IssetExpression.php
+++ b/codegen/syntax/IssetExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d62a48b7d5791b0f9dc3c89ca69f4e4e>>
+ * @generated SignedSource<<2f8c49cf601bc8c57d443e4130e0a182>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class IssetExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -78,7 +78,7 @@ final class IssetExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/KeysetIntrinsicExpression.php
+++ b/codegen/syntax/KeysetIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e0e15f4529166155b0f87354c069756c>>
+ * @generated SignedSource<<caa77d141abc863f8206e5ba594d23c5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class KeysetIntrinsicExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_bracket' => $this->_left_bracket,
@@ -78,7 +78,7 @@ final class KeysetIntrinsicExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/KeysetTypeSpecifier.php
+++ b/codegen/syntax/KeysetTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<903a35adcbe568821b40ade1e85c1dbd>>
+ * @generated SignedSource<<049e477e21690965a7aacb5b1c9df9d7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -77,7 +77,7 @@ final class KeysetTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_angle' => $this->_left_angle,
@@ -90,7 +90,7 @@ final class KeysetTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/LambdaExpression.php
+++ b/codegen/syntax/LambdaExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<70abe645d3f70844f7238734917119c9>>
+ * @generated SignedSource<<fec01f5dbd9b5261b760695a597355aa>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -76,7 +76,7 @@ final class LambdaExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'async' => $this->_async,
       'coroutine' => $this->_coroutine,
@@ -89,7 +89,7 @@ final class LambdaExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/LambdaSignature.php
+++ b/codegen/syntax/LambdaSignature.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<21a066cd0ffd53de60e1953fecf02bf0>>
+ * @generated SignedSource<<fbfed957d3fe487f9565b24c10d22f5d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -76,7 +76,7 @@ final class LambdaSignature extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_paren' => $this->_left_paren,
       'parameters' => $this->_parameters,
@@ -89,7 +89,7 @@ final class LambdaSignature extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ListExpression.php
+++ b/codegen/syntax/ListExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9770a5000905c0b3f299b84a094f9b07>>
+ * @generated SignedSource<<2bbd0cd2cc45040f58b67189437613d3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class ListExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -78,7 +78,7 @@ final class ListExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ListItem.php
+++ b/codegen/syntax/ListItem.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b3a4ffc711f6e1031ade44f02b9a2d56>>
+ * @generated SignedSource<<785fc81183edc687a1b6c16e9558088d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class ListItem extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'item' => $this->_item,
       'separator' => $this->_separator,
@@ -53,7 +53,7 @@ final class ListItem extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/LiteralExpression.php
+++ b/codegen/syntax/LiteralExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bedb63b8c1d11a99b19722d99fc90cb7>>
+ * @generated SignedSource<<be3ab5de28c6841b829222517bb0f485>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -34,7 +34,7 @@ final class LiteralExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'expression' => $this->_expression,
     ];
@@ -43,7 +43,7 @@ final class LiteralExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/MapArrayTypeSpecifier.php
+++ b/codegen/syntax/MapArrayTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<839dba7f047e959be6cab2f635809e46>>
+ * @generated SignedSource<<a3b4a1efa293c511085b1e560aeaeee4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -86,7 +86,7 @@ final class MapArrayTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_angle' => $this->_left_angle,
@@ -100,7 +100,7 @@ final class MapArrayTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/MarkupSection.php
+++ b/codegen/syntax/MarkupSection.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<198b058797aa134e926853138fabc69a>>
+ * @generated SignedSource<<703422a481657ddd3e1a7c3041d4dded>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class MarkupSection extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'prefix' => $this->_prefix,
       'text' => $this->_text,
@@ -78,7 +78,7 @@ final class MarkupSection extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/MarkupSuffix.php
+++ b/codegen/syntax/MarkupSuffix.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b4947663be40f406ff7a7596794dae07>>
+ * @generated SignedSource<<1eb733ac40292cd078c21022e87c56f7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -46,7 +46,7 @@ final class MarkupSuffix extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'less_than_question' => $this->_less_than_question,
       'name' => $this->_name,
@@ -56,7 +56,7 @@ final class MarkupSuffix extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/MemberSelectionExpression.php
+++ b/codegen/syntax/MemberSelectionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a121f83f3b28ff90082fce1ada70aa08>>
+ * @generated SignedSource<<ef7149c27b99f2547ab0f3229e193b5a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class MemberSelectionExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'object' => $this->_object,
       'operator' => $this->_operator,
@@ -67,7 +67,7 @@ final class MemberSelectionExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/MethodishDeclaration.php
+++ b/codegen/syntax/MethodishDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<187258450b4819b287c7926e8912dd44>>
+ * @generated SignedSource<<a314cf790a6c8519ebfb9cf8b74d7f35>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -83,7 +83,7 @@ final class MethodishDeclaration extends EditableNode
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'attribute' => $this->_attribute,
       'modifiers' => $this->_modifiers,
@@ -96,7 +96,7 @@ final class MethodishDeclaration extends EditableNode
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/NamespaceBody.php
+++ b/codegen/syntax/NamespaceBody.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<151eded19f3637e913ef6206b815e631>>
+ * @generated SignedSource<<4efa570588fa3da2594b32c5513e299b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class NamespaceBody extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_brace' => $this->_left_brace,
       'declarations' => $this->_declarations,
@@ -67,7 +67,7 @@ final class NamespaceBody extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/NamespaceDeclaration.php
+++ b/codegen/syntax/NamespaceDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8ba7e3fb5ac18abc86530f68f5d2db8f>>
+ * @generated SignedSource<<5f91525ff09a28d215597c03066e9f0f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class NamespaceDeclaration extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'name' => $this->_name,
@@ -67,7 +67,7 @@ final class NamespaceDeclaration extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/NamespaceEmptyBody.php
+++ b/codegen/syntax/NamespaceEmptyBody.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e21f29263fe0e0fb6f3f1b783e7b04d6>>
+ * @generated SignedSource<<64e474bc600c03014908f82db1c34dcf>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -34,7 +34,7 @@ final class NamespaceEmptyBody extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'semicolon' => $this->_semicolon,
     ];
@@ -43,7 +43,7 @@ final class NamespaceEmptyBody extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/NamespaceGroupUseDeclaration.php
+++ b/codegen/syntax/NamespaceGroupUseDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0ed16d30414e42d4e932059eda582ea6>>
+ * @generated SignedSource<<6177ecd1bfcd5396da0f09bcb2fe3bc7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -104,7 +104,7 @@ final class NamespaceGroupUseDeclaration extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'kind' => $this->_kind,
@@ -119,7 +119,7 @@ final class NamespaceGroupUseDeclaration extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/NamespaceUseClause.php
+++ b/codegen/syntax/NamespaceUseClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<879d180f8d38a4be8613b236bae1d27e>>
+ * @generated SignedSource<<ed095562db3303b697affcd341db8516>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class NamespaceUseClause extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'clause_kind' => $this->_clause_kind,
       'name' => $this->_name,
@@ -78,7 +78,7 @@ final class NamespaceUseClause extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/NamespaceUseDeclaration.php
+++ b/codegen/syntax/NamespaceUseDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<306f017d4825a1a3a692e01f3776439c>>
+ * @generated SignedSource<<b5d71df9df44d45df12860a9bb30fe26>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class NamespaceUseDeclaration extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'kind' => $this->_kind,
@@ -78,7 +78,7 @@ final class NamespaceUseDeclaration extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/NullableTypeSpecifier.php
+++ b/codegen/syntax/NullableTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d720abd0401fb9ae6af09c8d29b286ef>>
+ * @generated SignedSource<<3618a95df21469506b88cd9cc58102bb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class NullableTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'question' => $this->_question,
       'type' => $this->_type,
@@ -53,7 +53,7 @@ final class NullableTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ObjectCreationExpression.php
+++ b/codegen/syntax/ObjectCreationExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9236786c9589d1638b7c854430007717>>
+ * @generated SignedSource<<d6e274cb9a85f8c2296982e125a916d5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -77,7 +77,7 @@ final class ObjectCreationExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'new_keyword' => $this->_new_keyword,
       'type' => $this->_type,
@@ -90,7 +90,7 @@ final class ObjectCreationExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ParameterDeclaration.php
+++ b/codegen/syntax/ParameterDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3474aa756b80815b34e52c5414722344>>
+ * @generated SignedSource<<2d34cb8c675a42c5904bf285f902a53f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -76,7 +76,7 @@ final class ParameterDeclaration extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'attribute' => $this->_attribute,
       'visibility' => $this->_visibility,
@@ -89,7 +89,7 @@ final class ParameterDeclaration extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ParenthesizedExpression.php
+++ b/codegen/syntax/ParenthesizedExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4fee324195e469d83f55b56af63a466e>>
+ * @generated SignedSource<<d7bdfbb690c7aed210569dd10ee4a94e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class ParenthesizedExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_paren' => $this->_left_paren,
       'expression' => $this->_expression,
@@ -67,7 +67,7 @@ final class ParenthesizedExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/PipeVariableExpression.php
+++ b/codegen/syntax/PipeVariableExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8d06e7e158f1e030a60561a730f828be>>
+ * @generated SignedSource<<d906aceb49538dbaa8c97cd6e0df3336>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -34,7 +34,7 @@ final class PipeVariableExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'expression' => $this->_expression,
     ];
@@ -43,7 +43,7 @@ final class PipeVariableExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/PostfixUnaryExpression.php
+++ b/codegen/syntax/PostfixUnaryExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4b76882e9a1b4261a97ba58d9e3aeeda>>
+ * @generated SignedSource<<0a6f2cc7c8f97c742121c83856f91dfc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class PostfixUnaryExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'operand' => $this->_operand,
       'operator' => $this->_operator,
@@ -53,7 +53,7 @@ final class PostfixUnaryExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/PrefixUnaryExpression.php
+++ b/codegen/syntax/PrefixUnaryExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<36fbff0ce93652519b225a64f329f2aa>>
+ * @generated SignedSource<<fb971738b23d1cff635247014dfb1a82>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class PrefixUnaryExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'operator' => $this->_operator,
       'operand' => $this->_operand,
@@ -53,7 +53,7 @@ final class PrefixUnaryExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/PropertyDeclaration.php
+++ b/codegen/syntax/PropertyDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<535ece3a808bdfdc24248659aedae99b>>
+ * @generated SignedSource<<983fc005c224273fbd818ed47f81c8dc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class PropertyDeclaration extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'modifiers' => $this->_modifiers,
       'type' => $this->_type,
@@ -78,7 +78,7 @@ final class PropertyDeclaration extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/PropertyDeclarator.php
+++ b/codegen/syntax/PropertyDeclarator.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<655e86222f152e4dc0b29b28636e8289>>
+ * @generated SignedSource<<5b4f5db5efbb637574ec692c8d508680>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class PropertyDeclarator extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'name' => $this->_name,
       'initializer' => $this->_initializer,
@@ -53,7 +53,7 @@ final class PropertyDeclarator extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/QualifiedNameExpression.php
+++ b/codegen/syntax/QualifiedNameExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f6945ea3e8b0f8ab00c11455c8b9e0fb>>
+ * @generated SignedSource<<03341b348fb86a49b4901d5df9d19aec>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -34,7 +34,7 @@ final class QualifiedNameExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'expression' => $this->_expression,
     ];
@@ -43,7 +43,7 @@ final class QualifiedNameExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/RequireClause.php
+++ b/codegen/syntax/RequireClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<50ed921452d9a17b5d9321ef8f6fc485>>
+ * @generated SignedSource<<340c3a920e6970ea99a0c3b874a865a9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class RequireClause extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'kind' => $this->_kind,
@@ -78,7 +78,7 @@ final class RequireClause extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ReturnStatement.php
+++ b/codegen/syntax/ReturnStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4faeedb6234b1fbd26e1136f88afd3f2>>
+ * @generated SignedSource<<0f9fe1b1a1135e85894ff6a92d82f628>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class ReturnStatement extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'expression' => $this->_expression,
@@ -67,7 +67,7 @@ final class ReturnStatement extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/SafeMemberSelectionExpression.php
+++ b/codegen/syntax/SafeMemberSelectionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<469f913b99e354bde6c982eeda588364>>
+ * @generated SignedSource<<127bc2a87cb6dcaafc631c67032f44d3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class SafeMemberSelectionExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'object' => $this->_object,
       'operator' => $this->_operator,
@@ -67,7 +67,7 @@ final class SafeMemberSelectionExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ScopeResolutionExpression.php
+++ b/codegen/syntax/ScopeResolutionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<133139ea9b448dbb737cceef498c3127>>
+ * @generated SignedSource<<a7f93252be4008a05ec307895537a041>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class ScopeResolutionExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'qualifier' => $this->_qualifier,
       'operator' => $this->_operator,
@@ -67,7 +67,7 @@ final class ScopeResolutionExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/Script.php
+++ b/codegen/syntax/Script.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ce298b2e52adef7e96da6934c9f22805>>
+ * @generated SignedSource<<1893f4509dda6f2d9ce1e5982368e790>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -34,7 +34,7 @@ final class Script extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'declarations' => $this->_declarations,
     ];
@@ -43,7 +43,7 @@ final class Script extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ShapeExpression.php
+++ b/codegen/syntax/ShapeExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b91bf72e8ff78d70336353d9dd4f9142>>
+ * @generated SignedSource<<ff0ecaa8d7bc679d7b88cf321e0360ef>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class ShapeExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -78,7 +78,7 @@ final class ShapeExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ShapeTypeSpecifier.php
+++ b/codegen/syntax/ShapeTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<937a3f69a1987f86863c00df122229e3>>
+ * @generated SignedSource<<4d5b63b257011d6d8098accc088808cc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -76,7 +76,7 @@ final class ShapeTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -89,7 +89,7 @@ final class ShapeTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/SimpleInitializer.php
+++ b/codegen/syntax/SimpleInitializer.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5f1fc1a5a6940c1956b2245dc7717b78>>
+ * @generated SignedSource<<65338256728d653e27a0f76ed6a2c87d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class SimpleInitializer extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'equal' => $this->_equal,
       'value' => $this->_value,
@@ -53,7 +53,7 @@ final class SimpleInitializer extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/SimpleTypeSpecifier.php
+++ b/codegen/syntax/SimpleTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8b91d6d3115eb5093715d718fda80b22>>
+ * @generated SignedSource<<0dee6afa771831e99d3f30645be5a04c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -34,7 +34,7 @@ final class SimpleTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'specifier' => $this->_specifier,
     ];
@@ -43,7 +43,7 @@ final class SimpleTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/SoftTypeSpecifier.php
+++ b/codegen/syntax/SoftTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2bb9c2c5b1b461db3d125a4b2c1e5354>>
+ * @generated SignedSource<<31a36c4f5dc8808c85b8f55e96d42133>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class SoftTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'at' => $this->_at,
       'type' => $this->_type,
@@ -53,7 +53,7 @@ final class SoftTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/StaticDeclarator.php
+++ b/codegen/syntax/StaticDeclarator.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e15337596aa432b75017ade8b181f5d4>>
+ * @generated SignedSource<<c45ddb741efe994180882aecf40eea33>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class StaticDeclarator extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'name' => $this->_name,
       'initializer' => $this->_initializer,
@@ -53,7 +53,7 @@ final class StaticDeclarator extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/SubscriptExpression.php
+++ b/codegen/syntax/SubscriptExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0b210c39f681563f8707f535eeeac77e>>
+ * @generated SignedSource<<43ac7f5b476a172ea79d8dca166a7939>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class SubscriptExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'receiver' => $this->_receiver,
       'left_bracket' => $this->_left_bracket,
@@ -78,7 +78,7 @@ final class SubscriptExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/SwitchFallthrough.php
+++ b/codegen/syntax/SwitchFallthrough.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<64d823495ee38cddc045c57951e4090f>>
+ * @generated SignedSource<<821080b8659a63c9b81dba42090a47da>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class SwitchFallthrough extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'semicolon' => $this->_semicolon,
@@ -53,7 +53,7 @@ final class SwitchFallthrough extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/SwitchSection.php
+++ b/codegen/syntax/SwitchSection.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c162e02ae8d8adc79a9d6d3ff183e29b>>
+ * @generated SignedSource<<a602ef8f87de5530d4a48a94e7d63db5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class SwitchSection extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'labels' => $this->_labels,
       'statements' => $this->_statements,
@@ -67,7 +67,7 @@ final class SwitchSection extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/SwitchStatement.php
+++ b/codegen/syntax/SwitchStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<da60519a8d22407b56e2c06e8e8844bc>>
+ * @generated SignedSource<<c45ad448247616bff28ddf0751d7d2e8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -105,7 +105,7 @@ final class SwitchStatement extends EditableNode
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -120,7 +120,7 @@ final class SwitchStatement extends EditableNode
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/ThrowStatement.php
+++ b/codegen/syntax/ThrowStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9fa256c4831dce82656fda725466abb3>>
+ * @generated SignedSource<<9c4613f5382802f70735d3b8501a8352>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class ThrowStatement extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'expression' => $this->_expression,
@@ -67,7 +67,7 @@ final class ThrowStatement extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/TraitUse.php
+++ b/codegen/syntax/TraitUse.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<18f31c2b3047f0e7f63936b6d16df2ed>>
+ * @generated SignedSource<<252a683f635327dbc1cbb33ef766bc1b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class TraitUse extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'names' => $this->_names,
@@ -67,7 +67,7 @@ final class TraitUse extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/TraitUseConflictResolution.php
+++ b/codegen/syntax/TraitUseConflictResolution.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<344ca9e22535918d0d5a639e634f6453>>
+ * @generated SignedSource<<4f9fa453886b5ed4bcc1efd1f11b8edb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -76,7 +76,7 @@ final class TraitUseConflictResolution extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'names' => $this->_names,
@@ -89,7 +89,7 @@ final class TraitUseConflictResolution extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/TraitUseConflictResolutionItem.php
+++ b/codegen/syntax/TraitUseConflictResolutionItem.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5f80b5544676c1f2c751a140d3b4c06d>>
+ * @generated SignedSource<<85a0d6d99c83660a198ba35adb96753f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -62,7 +62,7 @@ final class TraitUseConflictResolutionItem extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'aliasing_name' => $this->_aliasing_name,
       'aliasing_keyword' => $this->_aliasing_keyword,
@@ -73,7 +73,7 @@ final class TraitUseConflictResolutionItem extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/TryStatement.php
+++ b/codegen/syntax/TryStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6e1af2e191db8cec0de6fca00291408d>>
+ * @generated SignedSource<<d3d4cbfec500c59df31b6a83093983ad>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -67,7 +67,7 @@ final class TryStatement extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'compound_statement' => $this->_compound_statement,
@@ -79,7 +79,7 @@ final class TryStatement extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/TupleExpression.php
+++ b/codegen/syntax/TupleExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9f81a55b4d1ae6b9ec1205f38f7b0542>>
+ * @generated SignedSource<<c2355945dada0ae10131b6aefc594074>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class TupleExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -78,7 +78,7 @@ final class TupleExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/TupleTypeExplicitSpecifier.php
+++ b/codegen/syntax/TupleTypeExplicitSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8875ce4d28a663c546467ecd3edf37d2>>
+ * @generated SignedSource<<f51a6a769e9c8490a7b205181e15dc8a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class TupleTypeExplicitSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_angle' => $this->_left_angle,
@@ -78,7 +78,7 @@ final class TupleTypeExplicitSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/TupleTypeSpecifier.php
+++ b/codegen/syntax/TupleTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<240135ab3c5793dfb62397cab56a1eda>>
+ * @generated SignedSource<<42c03889aef1167643b80fc31e75b346>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class TupleTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_paren' => $this->_left_paren,
       'types' => $this->_types,
@@ -67,7 +67,7 @@ final class TupleTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/TypeArguments.php
+++ b/codegen/syntax/TypeArguments.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f661649eabd701a938bc6ca336594968>>
+ * @generated SignedSource<<86df41707f1a14198913acac23caf5f3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class TypeArguments extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_angle' => $this->_left_angle,
       'types' => $this->_types,
@@ -67,7 +67,7 @@ final class TypeArguments extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/TypeConstDeclaration.php
+++ b/codegen/syntax/TypeConstDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<49aebe3acb8c3e0e43d8a04890a4ea04>>
+ * @generated SignedSource<<a81c89e4ea0a432597ea182610be300f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -115,7 +115,7 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'abstract' => $this->_abstract,
       'keyword' => $this->_keyword,
@@ -131,7 +131,7 @@ final class TypeConstDeclaration extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/TypeConstant.php
+++ b/codegen/syntax/TypeConstant.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8856f02d33737eff5e9cb49b43b0375a>>
+ * @generated SignedSource<<cd682b1d33157f4b9d10ec164ee51a6d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class TypeConstant extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_type' => $this->_left_type,
       'separator' => $this->_separator,
@@ -67,7 +67,7 @@ final class TypeConstant extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/TypeConstraint.php
+++ b/codegen/syntax/TypeConstraint.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e6278ffc65af8c7e80782050fabd2150>>
+ * @generated SignedSource<<f1f50da299be7b13820191729836a582>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class TypeConstraint extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'type' => $this->_type,
@@ -53,7 +53,7 @@ final class TypeConstraint extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/TypeParameter.php
+++ b/codegen/syntax/TypeParameter.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d95cbbca14a40e453aabe42aa857ab23>>
+ * @generated SignedSource<<26acce16420b971cc71e66ed54d8086a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class TypeParameter extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'variance' => $this->_variance,
       'name' => $this->_name,
@@ -67,7 +67,7 @@ final class TypeParameter extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/TypeParameters.php
+++ b/codegen/syntax/TypeParameters.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<79a6f108d8a695c3a750c777da8305ad>>
+ * @generated SignedSource<<02c52c7f2504b09dc947bb1494ad40e7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class TypeParameters extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_angle' => $this->_left_angle,
       'parameters' => $this->_parameters,
@@ -67,7 +67,7 @@ final class TypeParameters extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/UnsetStatement.php
+++ b/codegen/syntax/UnsetStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4be6c170582e25c438940f2e5be1c1de>>
+ * @generated SignedSource<<e94cf70425faa94b55964adf6d1caf74>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -77,7 +77,7 @@ final class UnsetStatement extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -90,7 +90,7 @@ final class UnsetStatement extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/VariableExpression.php
+++ b/codegen/syntax/VariableExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a4f3f1ebb4e6284b4f674fd21ddf58e6>>
+ * @generated SignedSource<<5f087e44823966e1851db9d78076c88c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -34,7 +34,7 @@ final class VariableExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'expression' => $this->_expression,
     ];
@@ -43,7 +43,7 @@ final class VariableExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/VariadicParameter.php
+++ b/codegen/syntax/VariadicParameter.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c07d3fbf99f77e2337ae89900c0f6dea>>
+ * @generated SignedSource<<a89ece80bfc0a1f9d5f5cbddbf8c00bc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -34,7 +34,7 @@ final class VariadicParameter extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'ellipsis' => $this->_ellipsis,
     ];
@@ -43,7 +43,7 @@ final class VariadicParameter extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/VarrayIntrinsicExpression.php
+++ b/codegen/syntax/VarrayIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b1f0c42f13ce2d6fc9779ffe64ba19df>>
+ * @generated SignedSource<<7094710528f493d21533ba6e059c2580>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class VarrayIntrinsicExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_bracket' => $this->_left_bracket,
@@ -78,7 +78,7 @@ final class VarrayIntrinsicExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/VarrayTypeSpecifier.php
+++ b/codegen/syntax/VarrayTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<14ba1c33f16bfc158a7d0b728e28a6ff>>
+ * @generated SignedSource<<429bc092b7e2e66057e9e4c9ed343db0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -77,7 +77,7 @@ final class VarrayTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_angle' => $this->_left_angle,
@@ -90,7 +90,7 @@ final class VarrayTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/VectorArrayTypeSpecifier.php
+++ b/codegen/syntax/VectorArrayTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<38280fdb38a6d203e369ff264b3dce45>>
+ * @generated SignedSource<<0782aa4f599cf6179989c68eaaacbecf>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class VectorArrayTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_angle' => $this->_left_angle,
@@ -78,7 +78,7 @@ final class VectorArrayTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/VectorIntrinsicExpression.php
+++ b/codegen/syntax/VectorIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7396b1289d14b24939f41b0c1f91f65f>>
+ * @generated SignedSource<<27fd1756f130306202bf7fe5df0e25fe>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class VectorIntrinsicExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_bracket' => $this->_left_bracket,
@@ -78,7 +78,7 @@ final class VectorIntrinsicExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/VectorTypeSpecifier.php
+++ b/codegen/syntax/VectorTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3e7eca4a9ea5472717b55e4beac563a5>>
+ * @generated SignedSource<<8146f981dc84b80fa93bc7e22c9bc4fb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -77,7 +77,7 @@ final class VectorTypeSpecifier extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_angle' => $this->_left_angle,
@@ -90,7 +90,7 @@ final class VectorTypeSpecifier extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/WhereClause.php
+++ b/codegen/syntax/WhereClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<46d327fe94522b1745ecd5b2ab4041f8>>
+ * @generated SignedSource<<1e919dd031e7c44470cb79844bbb8aa8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -46,7 +46,7 @@ final class WhereClause extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'constraints' => $this->_constraints,
@@ -56,7 +56,7 @@ final class WhereClause extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/WhereConstraint.php
+++ b/codegen/syntax/WhereConstraint.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<28838e46a75f17886601bded588d4534>>
+ * @generated SignedSource<<eb729411d86abed25cac07175d80e0df>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class WhereConstraint extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_type' => $this->_left_type,
       'operator' => $this->_operator,
@@ -67,7 +67,7 @@ final class WhereConstraint extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/WhileStatement.php
+++ b/codegen/syntax/WhileStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<111ada328cc09198ce91f8efff9f5e95>>
+ * @generated SignedSource<<f1d9a4e5f4cff2787a9709e7b73a3c4d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -77,7 +77,7 @@ final class WhileStatement extends EditableNode
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_paren' => $this->_left_paren,
@@ -90,7 +90,7 @@ final class WhileStatement extends EditableNode
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/XHPAttribute.php
+++ b/codegen/syntax/XHPAttribute.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fcc76974d02217b9e06be7e01e5988a0>>
+ * @generated SignedSource<<7a60e3204ad38817f14d121272f1b2a9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class XHPAttribute extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'name' => $this->_name,
       'equal' => $this->_equal,
@@ -67,7 +67,7 @@ final class XHPAttribute extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/XHPCategoryDeclaration.php
+++ b/codegen/syntax/XHPCategoryDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cab7052d8276bad001b2d2e2a90a32a8>>
+ * @generated SignedSource<<55bbd276a8bb9a39a711b0b1b2d44716>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class XHPCategoryDeclaration extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'categories' => $this->_categories,
@@ -67,7 +67,7 @@ final class XHPCategoryDeclaration extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/XHPChildrenDeclaration.php
+++ b/codegen/syntax/XHPChildrenDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<007a629458e07ad3de70b208436050ab>>
+ * @generated SignedSource<<e6271892c415086e43310c70637fd9b6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class XHPChildrenDeclaration extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'expression' => $this->_expression,
@@ -67,7 +67,7 @@ final class XHPChildrenDeclaration extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/XHPChildrenParenthesizedList.php
+++ b/codegen/syntax/XHPChildrenParenthesizedList.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<26b40216de6decf2bcc500cd3994c0ac>>
+ * @generated SignedSource<<dfe6c959e9ccae05d4132024d5faf8dc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class XHPChildrenParenthesizedList extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_paren' => $this->_left_paren,
       'xhp_children' => $this->_xhp_children,
@@ -67,7 +67,7 @@ final class XHPChildrenParenthesizedList extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/XHPClassAttribute.php
+++ b/codegen/syntax/XHPClassAttribute.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3f199c1c1cd1b33ce707a00493f02b39>>
+ * @generated SignedSource<<9586e509e9904d50682c4c80580c5d1e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class XHPClassAttribute extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'type' => $this->_type,
       'name' => $this->_name,
@@ -78,7 +78,7 @@ final class XHPClassAttribute extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/XHPClassAttributeDeclaration.php
+++ b/codegen/syntax/XHPClassAttributeDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3cb71bc3866a4b541b8d294b9c4a3ede>>
+ * @generated SignedSource<<39cf856d615ccd5ed39421c8089d5eff>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class XHPClassAttributeDeclaration extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'attributes' => $this->_attributes,
@@ -67,7 +67,7 @@ final class XHPClassAttributeDeclaration extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/XHPClose.php
+++ b/codegen/syntax/XHPClose.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2872afa77b81eb37ef5bf9d0caf53bb2>>
+ * @generated SignedSource<<81d38e8163682870f37159ef1f7d92e1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class XHPClose extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_angle' => $this->_left_angle,
       'name' => $this->_name,
@@ -67,7 +67,7 @@ final class XHPClose extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/XHPEnumType.php
+++ b/codegen/syntax/XHPEnumType.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9079f6d3549c385221873f196bbc7e36>>
+ * @generated SignedSource<<c79b9551e54861347313f2f374b771c5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class XHPEnumType extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'left_brace' => $this->_left_brace,
@@ -78,7 +78,7 @@ final class XHPEnumType extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/XHPExpression.php
+++ b/codegen/syntax/XHPExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e3ff6f2fbf1c1bf4282001cf395b337d>>
+ * @generated SignedSource<<62c539a17dcabe6e58749e12d3abbfa6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,7 +56,7 @@ final class XHPExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'open' => $this->_open,
       'body' => $this->_body,
@@ -67,7 +67,7 @@ final class XHPExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/XHPOpen.php
+++ b/codegen/syntax/XHPOpen.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<42ed30b11680c81851eddd9cc817c39f>>
+ * @generated SignedSource<<bf44d8c11687776fce2a2753a4716061>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -66,7 +66,7 @@ final class XHPOpen extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'left_angle' => $this->_left_angle,
       'name' => $this->_name,
@@ -78,7 +78,7 @@ final class XHPOpen extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/XHPRequired.php
+++ b/codegen/syntax/XHPRequired.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<dcd7df0fd9b398973f2ebe6b76b5f208>>
+ * @generated SignedSource<<ab893f1c9a4ef523f24f8b919c211b8c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class XHPRequired extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'at' => $this->_at,
       'keyword' => $this->_keyword,
@@ -53,7 +53,7 @@ final class XHPRequired extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/XHPSimpleClassAttribute.php
+++ b/codegen/syntax/XHPSimpleClassAttribute.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<06ff319f24164854b41f9e4f1116e89d>>
+ * @generated SignedSource<<32126451515cf26307b8b0fa9f295b4e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -34,7 +34,7 @@ final class XHPSimpleClassAttribute extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'type' => $this->_type,
     ];
@@ -43,7 +43,7 @@ final class XHPSimpleClassAttribute extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/syntax/YieldExpression.php
+++ b/codegen/syntax/YieldExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<76c6f8f70e93e5cd0a7ca80a581edca2>>
+ * @generated SignedSource<<e771f80ef610a8e7b502663e48260abb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -43,7 +43,7 @@ final class YieldExpression extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'keyword' => $this->_keyword,
       'operand' => $this->_operand,
@@ -53,7 +53,7 @@ final class YieldExpression extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/AbstractToken.php
+++ b/codegen/tokens/AbstractToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6b5427348b4b91fcefabb57377d4dcb6>>
+ * @generated SignedSource<<108f6f91f7444bf25aa243b370e63923>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class AbstractToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/AmpersandAmpersandToken.php
+++ b/codegen/tokens/AmpersandAmpersandToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<095b4f9220e2b261ab51f9ff5df29067>>
+ * @generated SignedSource<<2c433c9915f8240bc6e8c215e62ea9d8>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class AmpersandAmpersandToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/AmpersandEqualToken.php
+++ b/codegen/tokens/AmpersandEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1b44af0af206fd9c1210607c29f78983>>
+ * @generated SignedSource<<328635765c6d195738cf5cd6dd49936e>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class AmpersandEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/AmpersandToken.php
+++ b/codegen/tokens/AmpersandToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7bdc5668c5ff5e0da32093f9042c87ef>>
+ * @generated SignedSource<<8a62f15c71b0b61ef776383d63c86527>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class AmpersandToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/AndToken.php
+++ b/codegen/tokens/AndToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0304c3d1fd51add3fa5eae3f90657e38>>
+ * @generated SignedSource<<36225a9cdbfead15ab298a6737959a0f>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class AndToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ArrayToken.php
+++ b/codegen/tokens/ArrayToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3e167c988c5a8267330510985ca4c626>>
+ * @generated SignedSource<<9ca93eb5494795e19ee85a8317707f69>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ArrayToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ArraykeyToken.php
+++ b/codegen/tokens/ArraykeyToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<19aec051c9774aa9bb110165ff69ce3c>>
+ * @generated SignedSource<<f62e4cfd53bf7b85eccabfcacf0290ae>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ArraykeyToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/AsToken.php
+++ b/codegen/tokens/AsToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4b3e34561f39e0d74e45450a3f703ece>>
+ * @generated SignedSource<<966de30b5ae5342aebe546ca4feb44ec>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class AsToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/AsyncToken.php
+++ b/codegen/tokens/AsyncToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2c85188c948854dd7545cd47c468d686>>
+ * @generated SignedSource<<e58dc1365262b6c6fbd330a94d78e31d>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class AsyncToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/AtToken.php
+++ b/codegen/tokens/AtToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<564cd05d85753c98950823d49eac2139>>
+ * @generated SignedSource<<fc53fd25665ea7ec00367d79ceddc299>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class AtToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/AttributeToken.php
+++ b/codegen/tokens/AttributeToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4e7a3516219a9949381dfcbded297c39>>
+ * @generated SignedSource<<dde667dbc7d24e8c5f4a287e084d96ef>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class AttributeToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/AwaitToken.php
+++ b/codegen/tokens/AwaitToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f694a493889493f0ce01d988000086e3>>
+ * @generated SignedSource<<e602ab2015251845bf5bae0403015d06>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class AwaitToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/BarBarToken.php
+++ b/codegen/tokens/BarBarToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2e0937d72de45516f187b00e44446e3e>>
+ * @generated SignedSource<<40d042858cc01c91b89cb793e9bc2588>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class BarBarToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/BarEqualToken.php
+++ b/codegen/tokens/BarEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bc8c789f2834ce09abd521d965f1876b>>
+ * @generated SignedSource<<473d02309be20a7b79209ed410ae9d88>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class BarEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/BarGreaterThanToken.php
+++ b/codegen/tokens/BarGreaterThanToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f5550f016b265926f862aa8d509ef2da>>
+ * @generated SignedSource<<ca5b3c6eb42f271ac0765ad7c2ef4538>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class BarGreaterThanToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/BarToken.php
+++ b/codegen/tokens/BarToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a8f8cae4973e4667b177d590d223236a>>
+ * @generated SignedSource<<5d987d03dcdb522c537feb63dbe3ce7d>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class BarToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/BinaryLiteralToken.php
+++ b/codegen/tokens/BinaryLiteralToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c08b1c17c386c556dc62d818a7c6907b>>
+ * @generated SignedSource<<5102dd5abd43b24962d96521d67d7ac1>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class BinaryLiteralToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/BoolToken.php
+++ b/codegen/tokens/BoolToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c397d5e16222f32dbd0819945cc86293>>
+ * @generated SignedSource<<5297b6428ed22bef002ee08b82a85391>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class BoolToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/BooleanLiteralToken.php
+++ b/codegen/tokens/BooleanLiteralToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0ff82949bb3caeeda19130434a3dc907>>
+ * @generated SignedSource<<672751ca80f61c0bb78690cd99988bd5>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class BooleanLiteralToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/BreakToken.php
+++ b/codegen/tokens/BreakToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<331d23346c44cf1c278dab906cf2b884>>
+ * @generated SignedSource<<9a6730df8d9c115e5fa9613db2d34fc4>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class BreakToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/CaratEqualToken.php
+++ b/codegen/tokens/CaratEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<52c986456016a6ed42dcd7ae6df89517>>
+ * @generated SignedSource<<f0bd2ca888a514ed806d274245f12615>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class CaratEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/CaratToken.php
+++ b/codegen/tokens/CaratToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6d616ef9908d68dfb9515a97ab30a72f>>
+ * @generated SignedSource<<501d296545dca9876180d80818b49e7c>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class CaratToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/CaseToken.php
+++ b/codegen/tokens/CaseToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<764c07fa89e05470d1dc6b83f78c5012>>
+ * @generated SignedSource<<3b1684c6ff096435a2ccf07d36c8fc68>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class CaseToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/CatchToken.php
+++ b/codegen/tokens/CatchToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6de9f5bd16fa933e043b5d64471c290b>>
+ * @generated SignedSource<<ced6bb5127e1e1bfdeedacf890e71a10>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class CatchToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/CategoryToken.php
+++ b/codegen/tokens/CategoryToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d9762730178f2d9c2441c41bdf57d6aa>>
+ * @generated SignedSource<<7b1f573cac139cd5898cf60ac2b4c692>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class CategoryToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ChildrenToken.php
+++ b/codegen/tokens/ChildrenToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fd12f8e44af2da6928a261312814c6ef>>
+ * @generated SignedSource<<4ad160c25e04bb2eac1beb515eeb4e29>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ChildrenToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ClassToken.php
+++ b/codegen/tokens/ClassToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<686fa33b603eb447bf49e92b2ea77f8c>>
+ * @generated SignedSource<<b4f8f36cbe19b1ec4c07db57e48ab45e>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ClassToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ClassnameToken.php
+++ b/codegen/tokens/ClassnameToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3eed3d96159e280b1a1aa6d20c8d54a1>>
+ * @generated SignedSource<<3059fcac9cf8ed9f1d76dafe238b3ce7>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ClassnameToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/CloneToken.php
+++ b/codegen/tokens/CloneToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<03bbb29549c566705bfa517e6f708eee>>
+ * @generated SignedSource<<7319c46a309f8c3fbd7bae405cb4dd3c>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class CloneToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ColonColonToken.php
+++ b/codegen/tokens/ColonColonToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b8eda5645a82e94acdfcb3f5a40efd3b>>
+ * @generated SignedSource<<1a49d8f88aa02cee60badd8039b5dd5a>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class ColonColonToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ColonToken.php
+++ b/codegen/tokens/ColonToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<68fea3a2e9b3ddfe11bd8d28e4159f03>>
+ * @generated SignedSource<<7b29a3e817b054028efe47ac14feb26f>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class ColonToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/CommaToken.php
+++ b/codegen/tokens/CommaToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0ee5e1d7c7835d6ab8ceea96bbe4837d>>
+ * @generated SignedSource<<cd12287bd3a3da25054d7073c1ada813>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class CommaToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ConstToken.php
+++ b/codegen/tokens/ConstToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2a0c2ee1a14529c3b81b92b1604b11c5>>
+ * @generated SignedSource<<4e2a4ecbc281f1c680bb6cee11530de5>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ConstToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ConstructToken.php
+++ b/codegen/tokens/ConstructToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fb4a63f0514143ee2f7443200bb10636>>
+ * @generated SignedSource<<1415c16c355aa08079a7af1940bc3c0b>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ConstructToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ContinueToken.php
+++ b/codegen/tokens/ContinueToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5e2d497dda299fd8755d6e78dd3e196c>>
+ * @generated SignedSource<<5d1856e10112009f99184a3d73d3e93b>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ContinueToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/CoroutineToken.php
+++ b/codegen/tokens/CoroutineToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8bbbfc09e5b470c80307cb1a0b00d2cb>>
+ * @generated SignedSource<<faa12b15f2f839b71a6dad46ab21e861>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class CoroutineToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DarrayToken.php
+++ b/codegen/tokens/DarrayToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<74a4063f07abbadf3d186fad16af22c9>>
+ * @generated SignedSource<<dcd276936f4a5700689da460b5b27bdf>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class DarrayToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DecimalLiteralToken.php
+++ b/codegen/tokens/DecimalLiteralToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ae74f3dbeecf7337b08c3edb21174278>>
+ * @generated SignedSource<<353df4653399174cf493a48886333f8c>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class DecimalLiteralToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DefaultToken.php
+++ b/codegen/tokens/DefaultToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8ea9d84e7532e8dbd034f81fe53c7c1e>>
+ * @generated SignedSource<<092b0ffa7fcda4ec0a6d7018f82e9fe6>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class DefaultToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DefineToken.php
+++ b/codegen/tokens/DefineToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bae55fda0237c5d8961df6620ac147a7>>
+ * @generated SignedSource<<1d9e1d6c5dc96e144125371a371550b4>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class DefineToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DestructToken.php
+++ b/codegen/tokens/DestructToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e42d549eac274305416e0de65ff74a89>>
+ * @generated SignedSource<<d73ddf83481d12a23575aaf53924017c>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class DestructToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DictToken.php
+++ b/codegen/tokens/DictToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<df9167826952f4b8a83eb95d26fc6c41>>
+ * @generated SignedSource<<3871c08635f11951fd29f62f9f74a3c6>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class DictToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DoToken.php
+++ b/codegen/tokens/DoToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b93f3ecabf66b2fd2af90235a6b35c86>>
+ * @generated SignedSource<<30f964cd26169fcf128e19cf804d118c>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class DoToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DollarDollarToken.php
+++ b/codegen/tokens/DollarDollarToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<07a00f36da51ab79f7f7a740cc456cc7>>
+ * @generated SignedSource<<7dd7bb7e81d8413eafa3b30d766e1f63>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class DollarDollarToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DollarToken.php
+++ b/codegen/tokens/DollarToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5e7b5d7f5e8d8b9e227d46a700a87db3>>
+ * @generated SignedSource<<9137857cc97d039828470ef4bfa2a30b>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class DollarToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DotDotDotToken.php
+++ b/codegen/tokens/DotDotDotToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d1acd73f4c54132c01e7a04e943b1e62>>
+ * @generated SignedSource<<d06c64b78bf31a9d40d0e8c4f3f34774>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class DotDotDotToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DotEqualToken.php
+++ b/codegen/tokens/DotEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<df2cf5423a388741ebd558c264409989>>
+ * @generated SignedSource<<09e526ab37ca4db6744d90044d60f273>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class DotEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DotToken.php
+++ b/codegen/tokens/DotToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d4ac48b82dde43c157691b80d4c4f55d>>
+ * @generated SignedSource<<1cc7c6dbc72b0557b4ba0a2b7871fcf1>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class DotToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DoubleQuotedStringLiteralHeadToken.php
+++ b/codegen/tokens/DoubleQuotedStringLiteralHeadToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<92a50353cc25f143030c747881c7f1b7>>
+ * @generated SignedSource<<daba521411ebf41941adbb43ae3fb2a8>>
  */
 namespace Facebook\HHAST;
 
@@ -53,7 +53,7 @@ final class DoubleQuotedStringLiteralHeadToken
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DoubleQuotedStringLiteralTailToken.php
+++ b/codegen/tokens/DoubleQuotedStringLiteralTailToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d20910518489828b9e403adf3e7b5040>>
+ * @generated SignedSource<<455818d1a1c3fcabacd138f3f254101e>>
  */
 namespace Facebook\HHAST;
 
@@ -53,7 +53,7 @@ final class DoubleQuotedStringLiteralTailToken
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DoubleQuotedStringLiteralToken.php
+++ b/codegen/tokens/DoubleQuotedStringLiteralToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<49b5bb333426a84d971bfd90a90f0205>>
+ * @generated SignedSource<<a81108032d005501ae42d6a670761a8d>>
  */
 namespace Facebook\HHAST;
 
@@ -53,7 +53,7 @@ final class DoubleQuotedStringLiteralToken
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/DoubleToken.php
+++ b/codegen/tokens/DoubleToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e2ea61c40ae3a0e8baa8e2a12a4ecff7>>
+ * @generated SignedSource<<34c8d7dc6e073ce40067a078560072ce>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class DoubleToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/EchoToken.php
+++ b/codegen/tokens/EchoToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<439f75bba5cf085a83f79f2c83672986>>
+ * @generated SignedSource<<8c896440128912670f070946d71fcb0f>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class EchoToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ElseToken.php
+++ b/codegen/tokens/ElseToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f8351075e84cbbc747ce1868a76b6213>>
+ * @generated SignedSource<<24a04f094997ef594c50c365a3169d6b>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ElseToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ElseifToken.php
+++ b/codegen/tokens/ElseifToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<40925da7985b2d29f920350789114ace>>
+ * @generated SignedSource<<4c35e1a9cd59c698b7e7b8674c2c60e3>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ElseifToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/EmptyToken.php
+++ b/codegen/tokens/EmptyToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<556a7c31d625d2be582deeeb05717980>>
+ * @generated SignedSource<<7e9b8a34b8262f1c6f6db2ed44bb1fa4>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class EmptyToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/EndOfFileToken.php
+++ b/codegen/tokens/EndOfFileToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7cc8243a855c5769fb67a3b6ad8c1d62>>
+ * @generated SignedSource<<795e57963fabee4ad832993e59e5d52a>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class EndOfFileToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/EnumToken.php
+++ b/codegen/tokens/EnumToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d1c67c3174d79c828d072844165cb3e2>>
+ * @generated SignedSource<<e6419eb8ca47cb6a212203dfd1657e28>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class EnumToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/EqualEqualEqualToken.php
+++ b/codegen/tokens/EqualEqualEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a4338ef7a41e850bb2d2950c02598ebe>>
+ * @generated SignedSource<<7e7a0f243dbd4325a3079a23d8ac6975>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class EqualEqualEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/EqualEqualGreaterThanToken.php
+++ b/codegen/tokens/EqualEqualGreaterThanToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<11a0721036966d348fb202af7998f4a0>>
+ * @generated SignedSource<<cec2a0fa6b229a3d7f62730934e0780b>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class EqualEqualGreaterThanToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/EqualEqualToken.php
+++ b/codegen/tokens/EqualEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<adc456592455bd5ad43b085f79f863d5>>
+ * @generated SignedSource<<8934bc9d379c17fa7ad6e999a104b6b1>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class EqualEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/EqualGreaterThanToken.php
+++ b/codegen/tokens/EqualGreaterThanToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e255d719a2c696c28779b59b4823bff0>>
+ * @generated SignedSource<<ab55ba174eb63be2620ff014131c6efa>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class EqualGreaterThanToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/EqualToken.php
+++ b/codegen/tokens/EqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4a92e27edcfe57a716a559ff0c4814ac>>
+ * @generated SignedSource<<97a466cdb217d52884d0bec5222308c4>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class EqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ErrorTokenToken.php
+++ b/codegen/tokens/ErrorTokenToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<657e85e1e72ab02e1840d0da2c9f9944>>
+ * @generated SignedSource<<a472810e7c75d893988e8bab04d414c2>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class ErrorTokenToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/EvalToken.php
+++ b/codegen/tokens/EvalToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<42f32d0193c9b944f6ab9fccb4a7e308>>
+ * @generated SignedSource<<87a3669cdfef7778ede9726cbf55d22b>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class EvalToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ExclamationEqualEqualToken.php
+++ b/codegen/tokens/ExclamationEqualEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b242d81227b602a381980334b2a3d31c>>
+ * @generated SignedSource<<885f69338cef9bc9516d4a4b38987d72>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class ExclamationEqualEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ExclamationEqualToken.php
+++ b/codegen/tokens/ExclamationEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fbe3c8203be502d11e1d5987086c8f98>>
+ * @generated SignedSource<<da0a903201fc632ac00eb57d6475d71b>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class ExclamationEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ExclamationToken.php
+++ b/codegen/tokens/ExclamationToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<476bdc0462171269e652666695c5ed58>>
+ * @generated SignedSource<<2f7cbd7162c3e89d32dded377e273746>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class ExclamationToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ExecutionStringToken.php
+++ b/codegen/tokens/ExecutionStringToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<41c3bd872ff8e8f3d851dfc72d4a1994>>
+ * @generated SignedSource<<be97f34cdbd9f9547443b84db5ae20e7>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class ExecutionStringToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ExtendsToken.php
+++ b/codegen/tokens/ExtendsToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7801b5f528dc6a4b023f50bd6f5832cb>>
+ * @generated SignedSource<<a9399b21df3b448cf3f0a03ed73ab8b6>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ExtendsToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/FallthroughToken.php
+++ b/codegen/tokens/FallthroughToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d319e17c4f8468bb98b63b7b5f7cd5c3>>
+ * @generated SignedSource<<6658a2501630801d976e92cddd83f887>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class FallthroughToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/FinalToken.php
+++ b/codegen/tokens/FinalToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<832c030583c35172146ec9bda5728a41>>
+ * @generated SignedSource<<f87e01cc9c6df454a297ad45d13fd0a8>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class FinalToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/FinallyToken.php
+++ b/codegen/tokens/FinallyToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8ac27c40ce845073e7e21f2135c43a3f>>
+ * @generated SignedSource<<9852ad1e1a4063daa07cfdbe7835cc4c>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class FinallyToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/FloatToken.php
+++ b/codegen/tokens/FloatToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c3245f59b8202c1c9350a125c3891773>>
+ * @generated SignedSource<<67293a29d4af1680aaddb0bae4ad3729>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class FloatToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/FloatingLiteralToken.php
+++ b/codegen/tokens/FloatingLiteralToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<43c3cab88ba378934c815b99bc3fc4cf>>
+ * @generated SignedSource<<afd37d143ae3bbe200f0d6f14e42e82a>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class FloatingLiteralToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ForToken.php
+++ b/codegen/tokens/ForToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5a84225ccac63c01ae6a0967b4a628b9>>
+ * @generated SignedSource<<225f5b43ccf62e787512fb7ef4beb843>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ForToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ForeachToken.php
+++ b/codegen/tokens/ForeachToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<501af4301883094e81ecb6d742fa2ac3>>
+ * @generated SignedSource<<99c0fbc05f0be3e818de3d71ff7c71f6>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ForeachToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/FunctionToken.php
+++ b/codegen/tokens/FunctionToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<66e7415c7e87b5f8ec1a59b127ec3ee0>>
+ * @generated SignedSource<<66624dcc5f523bd462481c2a518441a0>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class FunctionToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/GlobalToken.php
+++ b/codegen/tokens/GlobalToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2351b6c79523c4e864c22b4db953ee0e>>
+ * @generated SignedSource<<bc6a8492ea951f14b8bca888a8003443>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class GlobalToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/GotoToken.php
+++ b/codegen/tokens/GotoToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e241f4af410b93ff0d01bec7170bf9b4>>
+ * @generated SignedSource<<d1d57baa3d84934deab2bdce248ec348>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class GotoToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/GreaterThanEqualToken.php
+++ b/codegen/tokens/GreaterThanEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<267beae86d976ef096a7a3d4c716f1d5>>
+ * @generated SignedSource<<a5db8887e3207315e3e680f1f6548ee7>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class GreaterThanEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/GreaterThanGreaterThanEqualToken.php
+++ b/codegen/tokens/GreaterThanGreaterThanEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7178a217106e1ef51ac0da7a81bb011a>>
+ * @generated SignedSource<<561507018ecebc2c1e1b95539a6613e3>>
  */
 namespace Facebook\HHAST;
 
@@ -43,7 +43,7 @@ final class GreaterThanGreaterThanEqualToken
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/GreaterThanGreaterThanToken.php
+++ b/codegen/tokens/GreaterThanGreaterThanToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e2ad0a9152c80e5c72055f11ce7a1620>>
+ * @generated SignedSource<<65ee737e958fe3a978c44e912a4eb44f>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class GreaterThanGreaterThanToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/GreaterThanToken.php
+++ b/codegen/tokens/GreaterThanToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b9c1e5be3d74d0800a7a666a79246d0e>>
+ * @generated SignedSource<<09f6da71582c017a84f427c92b8b26bd>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class GreaterThanToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/HeredocStringLiteralHeadToken.php
+++ b/codegen/tokens/HeredocStringLiteralHeadToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<dd55aeb0cff4850f8b3f905e42e550ff>>
+ * @generated SignedSource<<7389eff8584584ac796099d38e34713e>>
  */
 namespace Facebook\HHAST;
 
@@ -53,7 +53,7 @@ final class HeredocStringLiteralHeadToken
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/HeredocStringLiteralTailToken.php
+++ b/codegen/tokens/HeredocStringLiteralTailToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c61e7e06b440892d1a09ce97a853e144>>
+ * @generated SignedSource<<5ab39f298467a592f70aa45b541e5442>>
  */
 namespace Facebook\HHAST;
 
@@ -53,7 +53,7 @@ final class HeredocStringLiteralTailToken
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/HeredocStringLiteralToken.php
+++ b/codegen/tokens/HeredocStringLiteralToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<65cf6e74e780009d23c2a19b25780fd7>>
+ * @generated SignedSource<<033d68712fa7b0a06f188f75cf97f9bc>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class HeredocStringLiteralToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/HexadecimalLiteralToken.php
+++ b/codegen/tokens/HexadecimalLiteralToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f706172604a3698590c6f221606155ee>>
+ * @generated SignedSource<<3b218010d2b783d06c365cf1e6ad2cdc>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class HexadecimalLiteralToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/IfToken.php
+++ b/codegen/tokens/IfToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ec743be612e0e71ad07c7581207dd27d>>
+ * @generated SignedSource<<653540e2a2ef41ddd938441f18b01f60>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class IfToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ImplementsToken.php
+++ b/codegen/tokens/ImplementsToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<923deb22d12781c3a943e842b01b6741>>
+ * @generated SignedSource<<cbc387b73f6a3f9439e61434ef4eb020>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ImplementsToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/IncludeToken.php
+++ b/codegen/tokens/IncludeToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<179152ecf90033bc2ccf500ef83b0898>>
+ * @generated SignedSource<<ce7dab0b794498ee3a0c2cd5b875c91c>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class IncludeToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/Include_onceToken.php
+++ b/codegen/tokens/Include_onceToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<43de2330e15bc751ea02976a4542fbcf>>
+ * @generated SignedSource<<58b8308893de068991c5a5612d215c5e>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class Include_onceToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/InstanceofToken.php
+++ b/codegen/tokens/InstanceofToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c79423108e4b39125c75c8987b32e886>>
+ * @generated SignedSource<<c0514cca15b680874269db86bedf6ebf>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class InstanceofToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/InsteadofToken.php
+++ b/codegen/tokens/InsteadofToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<faec0b1a6069c837d8c43928e003d4b1>>
+ * @generated SignedSource<<c76de0d0f31ae22a76b394b362f521c8>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class InsteadofToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/IntToken.php
+++ b/codegen/tokens/IntToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0e0c25dd3c6965d2e9ff7776dc6ae16c>>
+ * @generated SignedSource<<02d2eec83a64dc8a1c45a7ceac903b33>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class IntToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/InterfaceToken.php
+++ b/codegen/tokens/InterfaceToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<618da9e38a90caea4308f25c0ed1a126>>
+ * @generated SignedSource<<d5c1f3391baadd63b5cb4b75d21a0ed7>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class InterfaceToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/IssetToken.php
+++ b/codegen/tokens/IssetToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<41af96c0778eb9904c31f1bdbf094e58>>
+ * @generated SignedSource<<0c260efb4d2e4701d5281448b93d00f6>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class IssetToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/KeysetToken.php
+++ b/codegen/tokens/KeysetToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<600ed847c1b173f7178079da0323ac5e>>
+ * @generated SignedSource<<35c6be750274a8f9af5df2967fa0e906>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class KeysetToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/LeftBraceToken.php
+++ b/codegen/tokens/LeftBraceToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fa36414c31a1f922014a50c3d3e15f27>>
+ * @generated SignedSource<<6bcfa249e5eeeca8920d468d47f2b738>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class LeftBraceToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/LeftBracketToken.php
+++ b/codegen/tokens/LeftBracketToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ba903954236a935dd936b93a2728d672>>
+ * @generated SignedSource<<f1d4934ea8c5dc3bc869d8ccd5104aca>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class LeftBracketToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/LeftParenToken.php
+++ b/codegen/tokens/LeftParenToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6bd30d03abdfff1732bb3568f9d06eb4>>
+ * @generated SignedSource<<35d8805d7254764d6acfe827b2f214c0>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class LeftParenToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/LessThanEqualGreaterThanToken.php
+++ b/codegen/tokens/LessThanEqualGreaterThanToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<41e09d37173d7762ff656c3a92eba43b>>
+ * @generated SignedSource<<08e1d2e418caeacb86fedc9542fd1c4f>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class LessThanEqualGreaterThanToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/LessThanEqualToken.php
+++ b/codegen/tokens/LessThanEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<204fc3ba10c85f5d392fc2b245cb3044>>
+ * @generated SignedSource<<39b9c16bd52f61cb14aa599296c9ce4d>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class LessThanEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/LessThanGreaterThanToken.php
+++ b/codegen/tokens/LessThanGreaterThanToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d9f20d98f4221cf27f13f4184969c39b>>
+ * @generated SignedSource<<3e495ff41b56abef5b31ffe5e231d880>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class LessThanGreaterThanToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/LessThanLessThanEqualToken.php
+++ b/codegen/tokens/LessThanLessThanEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b1ee67d8cac3de483f65669cb4323bef>>
+ * @generated SignedSource<<777ccd5545e5483c61f20d5e9e894c33>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class LessThanLessThanEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/LessThanLessThanToken.php
+++ b/codegen/tokens/LessThanLessThanToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2d7c36d8788a12b41b0c91653dd33291>>
+ * @generated SignedSource<<d24036e642d237450510ca07e6536651>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class LessThanLessThanToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/LessThanQuestionToken.php
+++ b/codegen/tokens/LessThanQuestionToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4caf0fe7c117511ea837f9d11471a3b7>>
+ * @generated SignedSource<<0fae2721b11ae056e580702f72a89aeb>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class LessThanQuestionToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/LessThanSlashToken.php
+++ b/codegen/tokens/LessThanSlashToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c7702a3eaf9fa70fbeff8b35370be915>>
+ * @generated SignedSource<<fef4dc7e891047b7aa78f6993654e058>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class LessThanSlashToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/LessThanToken.php
+++ b/codegen/tokens/LessThanToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0221a808419d02d05ebecf6168d4d76a>>
+ * @generated SignedSource<<6b14f0b40570e01f37a00a6487ab0f68>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class LessThanToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ListToken.php
+++ b/codegen/tokens/ListToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f3619ce4d4a75bcbf8c490c105e3d0eb>>
+ * @generated SignedSource<<a7ea95c40249b2a8e2ba741ae574ac7b>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ListToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/MarkupToken.php
+++ b/codegen/tokens/MarkupToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b43d306b30a2cbbfdcccab00ccfed5e5>>
+ * @generated SignedSource<<b5bc107b0c3e1d77fde5e9d4c63cd809>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class MarkupToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/MinusEqualToken.php
+++ b/codegen/tokens/MinusEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3dbcb6902ca20f6a5256b797d52a5f22>>
+ * @generated SignedSource<<e58cc92d87e32c46219cf2b20f29f435>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class MinusEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/MinusGreaterThanToken.php
+++ b/codegen/tokens/MinusGreaterThanToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0d6ae3478feda8769b68657e29560e78>>
+ * @generated SignedSource<<a2a196596c58a25c47c10229c41ee664>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class MinusGreaterThanToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/MinusMinusToken.php
+++ b/codegen/tokens/MinusMinusToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1a71f67c1a8494e7d3a3320d71021997>>
+ * @generated SignedSource<<b98ee10871689bc646412b2e8c9b3835>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class MinusMinusToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/MinusToken.php
+++ b/codegen/tokens/MinusToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<92398a0bd9a20e880db1f00992f1a0ac>>
+ * @generated SignedSource<<c143f09000b28a8b964a51aa72506ff7>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class MinusToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/MixedToken.php
+++ b/codegen/tokens/MixedToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<84f35ff585f351757ede85e0168e0ce8>>
+ * @generated SignedSource<<55a7fe5d6d7ebc95c3b32d3cf4fe2b07>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class MixedToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/NameToken.php
+++ b/codegen/tokens/NameToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<792c2ccce5706868e2601957a06f5019>>
+ * @generated SignedSource<<ec1563f1771f307f3816cc4584070b59>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class NameToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/NamespacePrefixToken.php
+++ b/codegen/tokens/NamespacePrefixToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2f53674c895dceb1156648d7629b94e4>>
+ * @generated SignedSource<<69566b36b98b6b6ee3f1e02a491eb1eb>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class NamespacePrefixToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/NamespaceToken.php
+++ b/codegen/tokens/NamespaceToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a00344d5d07e4e391e05a1b07a41abdd>>
+ * @generated SignedSource<<a3f1ff1377ce91867e3d39a350a1dee6>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class NamespaceToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/NewToken.php
+++ b/codegen/tokens/NewToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<10edb1921d6365f49c0ecb13033fde60>>
+ * @generated SignedSource<<a82f523b675bcc3b1d8d4ae12c0e2130>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class NewToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/NewtypeToken.php
+++ b/codegen/tokens/NewtypeToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b4aef5592c69afb1639a4f64affb0c79>>
+ * @generated SignedSource<<a3b67eeb2f36ae95e27d31368f05558e>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class NewtypeToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/NoreturnToken.php
+++ b/codegen/tokens/NoreturnToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f74566610e201bd3c5b67e9afca4cd40>>
+ * @generated SignedSource<<87325081ee763690eba2528aa9e836fa>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class NoreturnToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/NowdocStringLiteralToken.php
+++ b/codegen/tokens/NowdocStringLiteralToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d7c1825d74c12a0cdd80830eaee9d74d>>
+ * @generated SignedSource<<d19ecaf80c8765e217338d43be830fec>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class NowdocStringLiteralToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/NullLiteralToken.php
+++ b/codegen/tokens/NullLiteralToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2415258818b44c05687a2322ccdbdabd>>
+ * @generated SignedSource<<f1cc34bbb20e97083934fd679ab62803>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class NullLiteralToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/NumToken.php
+++ b/codegen/tokens/NumToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<71e7a2a4596dc24f71633024de8e7a6e>>
+ * @generated SignedSource<<31d71de0262ab8ff1663e7bed84f1c32>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class NumToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ObjectToken.php
+++ b/codegen/tokens/ObjectToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ee0a67034a28f7eb49a7ac2ab480ee5d>>
+ * @generated SignedSource<<8c620cc33e90fa40d86d4c62074ef422>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ObjectToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/OctalLiteralToken.php
+++ b/codegen/tokens/OctalLiteralToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<43b6e2c1f43a4997c3f4eaca906038c0>>
+ * @generated SignedSource<<ddb5f3a3bb330d83849c375ec4fc4f5e>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class OctalLiteralToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/OrToken.php
+++ b/codegen/tokens/OrToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<017f8f97d040f90cc12cd8a507a7e88a>>
+ * @generated SignedSource<<fcb8a1e13969a7d6db98395187114ddb>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class OrToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ParentToken.php
+++ b/codegen/tokens/ParentToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1c368a67cfb6a91f3709476484407bd6>>
+ * @generated SignedSource<<5833f2098128b93f7dd0f486c50d373d>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ParentToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/PercentEqualToken.php
+++ b/codegen/tokens/PercentEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<21d46369f4b14f57e3f1bbe825d8a881>>
+ * @generated SignedSource<<8e67dd198969c8969652d86f1944f619>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class PercentEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/PercentToken.php
+++ b/codegen/tokens/PercentToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0683161bf84adc09ff663e78209255f8>>
+ * @generated SignedSource<<f4634ca4b2bc9014a2c5f3f87a5c5a6a>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class PercentToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/PlusEqualToken.php
+++ b/codegen/tokens/PlusEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<064b5b21a65fbe11a194c4ce2043424f>>
+ * @generated SignedSource<<51d4e87f74886137d7a7933af9c2b9fc>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class PlusEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/PlusPlusToken.php
+++ b/codegen/tokens/PlusPlusToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c6616f4b7d1c76ae40f2e4db6cd5cbaf>>
+ * @generated SignedSource<<03d6da413b4b3c26a8c385b1658dc057>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class PlusPlusToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/PlusToken.php
+++ b/codegen/tokens/PlusToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<79d138cea7cf4f283a1da9ef54d08c67>>
+ * @generated SignedSource<<5e835e3a1536e9908eaf6f16279479fe>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class PlusToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/PrintToken.php
+++ b/codegen/tokens/PrintToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<13f88670123bc8ade455dd686b5ce80e>>
+ * @generated SignedSource<<2f7a3136750c70aaca08f5a8ebda37ee>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class PrintToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/PrivateToken.php
+++ b/codegen/tokens/PrivateToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<61156453ef6a09ccb0f6fb50071ece1d>>
+ * @generated SignedSource<<705f108256ccb7d2218db7de4bf98bcf>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class PrivateToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ProtectedToken.php
+++ b/codegen/tokens/ProtectedToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c3fb970d1714a54fb02271cb6c988dae>>
+ * @generated SignedSource<<f6f9b2bb33bb48f2a7e1d5ed676ce2d6>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ProtectedToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/PublicToken.php
+++ b/codegen/tokens/PublicToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<71405926b9447fa759d806e2d1af0fb9>>
+ * @generated SignedSource<<1bec0375639873fb381e9e591a146784>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class PublicToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/QualifiedNameToken.php
+++ b/codegen/tokens/QualifiedNameToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2ce5b329f9f4b12de6ec37bf6b2a26bc>>
+ * @generated SignedSource<<738550140738718d29085fd6098424d2>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class QualifiedNameToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/QuestionGreaterThanToken.php
+++ b/codegen/tokens/QuestionGreaterThanToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c58d97ce5282ea69ab06d9b7952dc3b9>>
+ * @generated SignedSource<<797c63f2c8ea8b3fa0341f57c4cd2ffe>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class QuestionGreaterThanToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/QuestionMinusGreaterThanToken.php
+++ b/codegen/tokens/QuestionMinusGreaterThanToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<278baacaf155687033b76ec99d7b6e88>>
+ * @generated SignedSource<<d64e04288182695506af5dfd5ab18457>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class QuestionMinusGreaterThanToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/QuestionQuestionToken.php
+++ b/codegen/tokens/QuestionQuestionToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3150fe33ac6614137420ba8ef51b3459>>
+ * @generated SignedSource<<56bf279972581732cdbb6f5579f35559>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class QuestionQuestionToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/QuestionToken.php
+++ b/codegen/tokens/QuestionToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6122347197480f60db8adff686b571ab>>
+ * @generated SignedSource<<b84770db0293b7ca49e89027c6ea6b25>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class QuestionToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/RequireToken.php
+++ b/codegen/tokens/RequireToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<541c12e41f5e91186d7dc9da2ce8811d>>
+ * @generated SignedSource<<9cba2f8190e389fd5effb2e62c3c8389>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class RequireToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/Require_onceToken.php
+++ b/codegen/tokens/Require_onceToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c09ca4e72812bf1328bea1f651b23f10>>
+ * @generated SignedSource<<237663ded115f0a036265fb61aa07235>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class Require_onceToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/RequiredToken.php
+++ b/codegen/tokens/RequiredToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e866bf1bf1c56b1caf42894810923128>>
+ * @generated SignedSource<<f5a4fe78fb1e65d5a4d454a23cd47af2>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class RequiredToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ResourceToken.php
+++ b/codegen/tokens/ResourceToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<87479de869ed7ba4a74f5d78094a1390>>
+ * @generated SignedSource<<578266e6c25166e4618632dbe36b5263>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ResourceToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ReturnToken.php
+++ b/codegen/tokens/ReturnToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f8001d8094f5d9fd02960862c046e258>>
+ * @generated SignedSource<<3334c1ace737b42f52e9c08225310035>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ReturnToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/RightBraceToken.php
+++ b/codegen/tokens/RightBraceToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9db46a4b468085f9bfda7b0f2de59d60>>
+ * @generated SignedSource<<0a47460ac0d105ac7f98bbf4ceb73c2e>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class RightBraceToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/RightBracketToken.php
+++ b/codegen/tokens/RightBracketToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<03bcef7d02ceedac7b64ca04fdc2e840>>
+ * @generated SignedSource<<fb436f7cb884f5988fc263918b833853>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class RightBracketToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/RightParenToken.php
+++ b/codegen/tokens/RightParenToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9e053590777a6b3bcff6e19f0937e6a5>>
+ * @generated SignedSource<<74c19dd218e641fc3334574185decc7c>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class RightParenToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/SelfToken.php
+++ b/codegen/tokens/SelfToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d415a044006160c34d089ac7109ccb84>>
+ * @generated SignedSource<<63fc7e6f6bc32d0a78f4adc93f35c262>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class SelfToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/SemicolonToken.php
+++ b/codegen/tokens/SemicolonToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<511995bdfbb2225b139d72587efcd429>>
+ * @generated SignedSource<<03990ae1d17a571c5c39bf582823c25f>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class SemicolonToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ShapeToken.php
+++ b/codegen/tokens/ShapeToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b727d34bd3a25548f6decff84260c96a>>
+ * @generated SignedSource<<9f91fff2cdd526df78fbb41bc1a352cf>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ShapeToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/SingleQuotedStringLiteralToken.php
+++ b/codegen/tokens/SingleQuotedStringLiteralToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b75a8166c850f597adea9582588cc903>>
+ * @generated SignedSource<<7e7207a73a02a87ef95a7d849408abf6>>
  */
 namespace Facebook\HHAST;
 
@@ -53,7 +53,7 @@ final class SingleQuotedStringLiteralToken
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/SlashEqualToken.php
+++ b/codegen/tokens/SlashEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fea89e2bcd22c37c02bab35ec2ed1760>>
+ * @generated SignedSource<<7c3c8ffaa61c470d00644860a11f9220>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class SlashEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/SlashGreaterThanToken.php
+++ b/codegen/tokens/SlashGreaterThanToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<89e91e7fa61485b1e8cab5237da46d40>>
+ * @generated SignedSource<<ae211fa65c16a4b9fd839f75b362c5f9>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class SlashGreaterThanToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/SlashToken.php
+++ b/codegen/tokens/SlashToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8d421edcde66fe4a14b2ec548c899138>>
+ * @generated SignedSource<<0453cf2aef6011d941d6f028800986eb>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class SlashToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/StarEqualToken.php
+++ b/codegen/tokens/StarEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9d4746c3b17e898996fd05ac965d265c>>
+ * @generated SignedSource<<b062a69c74e5f6057d1c2f994c598972>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class StarEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/StarStarEqualToken.php
+++ b/codegen/tokens/StarStarEqualToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6fdbae9e6824c46d2ec4fbc03ae6a1aa>>
+ * @generated SignedSource<<f8335770306ec2c1c59150aa865141f6>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class StarStarEqualToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/StarStarToken.php
+++ b/codegen/tokens/StarStarToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<198f044a0f83c7ad39dd0c4ba7cd6998>>
+ * @generated SignedSource<<22fe8ed978cb71ba452208580cd1eae4>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class StarStarToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/StarToken.php
+++ b/codegen/tokens/StarToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<70511f144ff53e066102eb729a6b538c>>
+ * @generated SignedSource<<dd77b2b8bbf0648acd0658b0470810ec>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class StarToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/StaticToken.php
+++ b/codegen/tokens/StaticToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ebaedc824ce2bfc5a487bbc4c0c5baa8>>
+ * @generated SignedSource<<a089af3b8d76104e59cf7df29fec484b>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class StaticToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/StringLiteralBodyToken.php
+++ b/codegen/tokens/StringLiteralBodyToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0a5ea14c9994833cb0dd78d2fe2c5f30>>
+ * @generated SignedSource<<7a84b0ba61cfd24d42f11ddb7bf742d2>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class StringLiteralBodyToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/StringToken.php
+++ b/codegen/tokens/StringToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ac3563b3997f7856fc9cc67c80296391>>
+ * @generated SignedSource<<6e9cbe781f1a27208f51b67fbcdee9d0>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class StringToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/SuperToken.php
+++ b/codegen/tokens/SuperToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a2d6f801d2c805c4e82d61977c2ba8fb>>
+ * @generated SignedSource<<83e865ae0d6b26d731ec301ecbcc84df>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class SuperToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/SuspendToken.php
+++ b/codegen/tokens/SuspendToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0cbbcfaca937586ae2d8aba0bef87168>>
+ * @generated SignedSource<<88cb887684e9bfd5708423c36a26493c>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class SuspendToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/SwitchToken.php
+++ b/codegen/tokens/SwitchToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<88cb528552b3aed25db5c86ed0eed285>>
+ * @generated SignedSource<<0315de91c0ba77994d718b1f81e90395>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class SwitchToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ThisToken.php
+++ b/codegen/tokens/ThisToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<21dacca26d9ef9c2acf42bf20f36d548>>
+ * @generated SignedSource<<848e903f1778e025a26a0531746eb7c8>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ThisToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/ThrowToken.php
+++ b/codegen/tokens/ThrowToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<81144b6091c3ddfe63f0b8a07f9f65ec>>
+ * @generated SignedSource<<4940c60c99cc13905eabb86edd818a30>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class ThrowToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/TildeToken.php
+++ b/codegen/tokens/TildeToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5c73016208d46d58d35db70d7e1acc86>>
+ * @generated SignedSource<<46853d426079cb2391938c7e06563b61>>
  */
 namespace Facebook\HHAST;
 
@@ -42,7 +42,7 @@ final class TildeToken extends EditableTokenWithFixedText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/TraitToken.php
+++ b/codegen/tokens/TraitToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<32d57f0edea7c32af4e4eef81bee0104>>
+ * @generated SignedSource<<ae6b89081787d6c587bd2e3cb076b4e7>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class TraitToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/TryToken.php
+++ b/codegen/tokens/TryToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<34787fa1fcfba73b1af11c2710b341c1>>
+ * @generated SignedSource<<6f96d53ad44b1323e7adfa4a73970df5>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class TryToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/TupleToken.php
+++ b/codegen/tokens/TupleToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fea4588d792960a0a5284728c7e8c7e9>>
+ * @generated SignedSource<<3a86db03cdcf68537b27ae2acc4ad7a8>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class TupleToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/TypeToken.php
+++ b/codegen/tokens/TypeToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f1d5ee1cf6a1bb482286a513b9b85e0c>>
+ * @generated SignedSource<<60c615b42cf4ca4e819171c337314f5a>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class TypeToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/UnsetToken.php
+++ b/codegen/tokens/UnsetToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a231cfa3802fad6b0591f904569c178e>>
+ * @generated SignedSource<<76faacca21baf19db71368c6aae215b1>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class UnsetToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/UseToken.php
+++ b/codegen/tokens/UseToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e20638d02a16789340b14a3b8add46c3>>
+ * @generated SignedSource<<cd465e38497982daaac508970494f537>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class UseToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/VarToken.php
+++ b/codegen/tokens/VarToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<aff31605dd63943e58e2fbafde886c7d>>
+ * @generated SignedSource<<4b2f43d8dc1835856d0b85f1c4f5fb9e>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class VarToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/VariableToken.php
+++ b/codegen/tokens/VariableToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c3ca922070126b9b54688d535a287a42>>
+ * @generated SignedSource<<2d1e8c50c376396211155695c455a7e2>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class VariableToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/VarrayToken.php
+++ b/codegen/tokens/VarrayToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5c367634be0c8ff49a95da77f58d9490>>
+ * @generated SignedSource<<93a083a84335c724819d15e602c31d06>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class VarrayToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/VecToken.php
+++ b/codegen/tokens/VecToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8c44777f6eb2df047da784d81a8879fc>>
+ * @generated SignedSource<<41a547f321642e88b0d7034b0c13cff8>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class VecToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/VoidToken.php
+++ b/codegen/tokens/VoidToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<67f14f6092d4ebb7da397dcb98f55bd5>>
+ * @generated SignedSource<<d18c2911ac9f157f3a3551e189d8b708>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class VoidToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/WhereToken.php
+++ b/codegen/tokens/WhereToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<41d3c2ca49b4d980199397b7227a2bc2>>
+ * @generated SignedSource<<9f3b42641e4af6cf484822b5d948261b>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class WhereToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/WhileToken.php
+++ b/codegen/tokens/WhileToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<91f805403afdcda810c6ed01c4072e09>>
+ * @generated SignedSource<<69cf78ce3709f1128b56b0361474224f>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class WhileToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/XHPBodyToken.php
+++ b/codegen/tokens/XHPBodyToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bdddeb0c0fe96b080b01e2ed0f2d0172>>
+ * @generated SignedSource<<3a66aa9928a1a85f83cd97c122a1fea1>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class XHPBodyToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/XHPCategoryNameToken.php
+++ b/codegen/tokens/XHPCategoryNameToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e5ecde3ad76cec9d3c2caa696f329701>>
+ * @generated SignedSource<<a348da8389fc0015eccf2c4ac52ddf1d>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class XHPCategoryNameToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/XHPClassNameToken.php
+++ b/codegen/tokens/XHPClassNameToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d78c36b72348b984ad12fbc5126a38a8>>
+ * @generated SignedSource<<75e9d34efa418a57e3b61d93eaa123b7>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class XHPClassNameToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/XHPCommentToken.php
+++ b/codegen/tokens/XHPCommentToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5bea34b675f97fdf9659b36a379e0fbe>>
+ * @generated SignedSource<<f55cf61d2535c48dd80032191b8df534>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class XHPCommentToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/XHPElementNameToken.php
+++ b/codegen/tokens/XHPElementNameToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f7fa81c1c5efb2f3c6757e9e00eb8217>>
+ * @generated SignedSource<<d4eb3c6230e6951facc686abdf5efa66>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class XHPElementNameToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/XHPStringLiteralToken.php
+++ b/codegen/tokens/XHPStringLiteralToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fef3036aa613a8fe14c4b8498d254b0e>>
+ * @generated SignedSource<<7784e338e4958a5ca326378abd01d0dd>>
  */
 namespace Facebook\HHAST;
 
@@ -52,7 +52,7 @@ final class XHPStringLiteralToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/XorToken.php
+++ b/codegen/tokens/XorToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<76b42890e4808e876838f97650695c81>>
+ * @generated SignedSource<<5ce396a70aca4e4679fc3dd480989601>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class XorToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/codegen/tokens/YieldToken.php
+++ b/codegen/tokens/YieldToken.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<57107299a3f03ddea47ba128c25c2208>>
+ * @generated SignedSource<<97938a089cb2c157302c7bc43f9bfbd9>>
  */
 namespace Facebook\HHAST;
 
@@ -45,7 +45,7 @@ final class YieldToken extends EditableTokenWithVariableText {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
     $parents[] = $this;

--- a/src/EditableList.php
+++ b/src/EditableList.php
@@ -17,7 +17,7 @@ use namespace HH\Lib\{C, Dict, Vec};
 final class EditableList extends EditableNode {
   private vec<EditableNode> $_children;
   <<__Override>>
-  public function __construct(Traversable<EditableNode> $children) {
+  public function __construct(vec<EditableNode> $children) {
     parent::__construct('list');
     $this->_children = vec($children);
   }
@@ -33,7 +33,7 @@ final class EditableList extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return Dict\pull_with_key(
       $this->_children,
       ($_, $v) ==> $v,
@@ -43,7 +43,7 @@ final class EditableList extends EditableNode {
 
   final public function getItemsOfType<T as EditableNode>(
     classname<T> $what,
-  ): Traversable<EditableNode> {
+  ): vec<EditableNode> {
     $out = vec[];
     foreach ($this->_children as $child) {
       if ($child instanceof ListItem) {
@@ -57,7 +57,7 @@ final class EditableList extends EditableNode {
   }
 
   public static function fromItems(
-    Traversable<EditableNode> $syntax_list,
+    vec<EditableNode> $syntax_list,
   ): EditableNode {
     $syntax_list = vec($syntax_list);
     if (C\count($syntax_list) === 0) {
@@ -101,7 +101,7 @@ final class EditableList extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     $parents = $parents === null ? vec[] : vec($parents);
 

--- a/src/EditableNode.php
+++ b/src/EditableNode.php
@@ -30,11 +30,11 @@ abstract class EditableNode {
   }
 
   public abstract function getChildren(
-  ): KeyedTraversable<string, EditableNode>;
+  ): dict<string, EditableNode>;
 
   public function getChildrenWhere(
     (function(EditableNode):bool) $filter,
-  ): KeyedTraversable<string, EditableNode> {
+  ): dict<string, EditableNode> {
     return Dict\filter(
       $this->getChildren(),
       $child ==> $filter($child),
@@ -43,7 +43,7 @@ abstract class EditableNode {
 
   final public function getChildrenOfType<T as EditableNode>(
     classname<T> $what,
-  ): KeyedTraversable<string, T> {
+  ): dict<string, T> {
     $out = dict[];
     foreach ($this->getChildren() as $k => $node) {
       if ($node instanceof $what) {
@@ -53,7 +53,7 @@ abstract class EditableNode {
     return $out;
   }
 
-  public function traverse(): Traversable<EditableNode> {
+  public function traverse(): vec<EditableNode> {
     $out = vec[$this];
     foreach ($this->getChildren() as $child) {
       foreach ($child->traverse() as $descendant) {
@@ -65,7 +65,7 @@ abstract class EditableNode {
 
   private function traverseImpl(
     vec<EditableNode> $parents,
-  ): Traversable<(EditableNode, vec<EditableNode>)> {
+  ): vec<(EditableNode, vec<EditableNode>)> {
     $new_parents = vec($parents);
     $new_parents[] = $this;
     $out = vec[tuple($this, $parents)];
@@ -78,7 +78,7 @@ abstract class EditableNode {
   }
 
   public function traverseWithParents(
-  ): Traversable<(EditableNode, vec<EditableNode>)> {
+  ): vec<(EditableNode, vec<EditableNode>)> {
     return $this->traverseImpl(vec[]);
   }
 
@@ -301,7 +301,7 @@ abstract class EditableNode {
 
   abstract public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this;
 
   public function rewrite(

--- a/src/EditableToken.php
+++ b/src/EditableToken.php
@@ -95,7 +95,7 @@ abstract class EditableToken extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[
       'leading' => $this->getLeading(),
       'trailing' => $this->getTrailing(),

--- a/src/EditableTrivia.php
+++ b/src/EditableTrivia.php
@@ -40,7 +40,7 @@ abstract class EditableTrivia extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[];
   }
 
@@ -57,7 +57,7 @@ abstract class EditableTrivia extends EditableNode {
   <<__Override>>
   final public function rewriteDescendants(
     self::TRewriter $_rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     // Trivia have no children
     return $this;

--- a/src/Linters/BaseASTLinter.php
+++ b/src/Linters/BaseASTLinter.php
@@ -50,7 +50,7 @@ abstract class BaseASTLinter<T as HHAST\EditableNode, +Terror as ASTLintError<T>
     return $ast;
   }
 
-  private function getASTWithParents(): Traversable<(EditableNode, vec<EditableNode>)> {
+  private function getASTWithParents(): vec<(EditableNode, vec<EditableNode>)> {
     static $cache = null;
 
     $hash = sha1(file_get_contents($this->getFile()), /* raw = */ true);

--- a/src/Linters/BaseASTLinter.php
+++ b/src/Linters/BaseASTLinter.php
@@ -50,6 +50,23 @@ abstract class BaseASTLinter<T as HHAST\EditableNode, +Terror as ASTLintError<T>
     return $ast;
   }
 
+  private function getASTWithParents(): Traversable<(EditableNode, vec<EditableNode>)> {
+    static $cache = null;
+
+    $hash = sha1(file_get_contents($this->getFile()), /* raw = */ true);
+    if ($cache !== null && $cache['hash'] === $hash) {
+      return $cache['astWithParents'];
+    }
+
+    $ast = $this->ast->traverseWithParents();
+
+    $cache = shape(
+      'hash' => $hash,
+      'astWithParents' => $ast,
+    );
+    return $ast;
+  }
+
   abstract protected static function getTargetType(): classname<T>;
 
   abstract protected function getLintErrorForNode(
@@ -73,7 +90,7 @@ abstract class BaseASTLinter<T as HHAST\EditableNode, +Terror as ASTLintError<T>
   ): Traversable<Terror> {
     $target = static::getTargetType();
 
-    foreach ($this->ast->traverseWithParents() as list($node, $parents)) {
+    foreach ($this->getASTWithParents() as list($node, $parents)) {
       if ($node instanceof $target) {
         $error = $this->getLintErrorForNode($node, $parents);
         if ($error !== null) {

--- a/src/Linters/DontAwaitInALoopLinter.php
+++ b/src/Linters/DontAwaitInALoopLinter.php
@@ -51,7 +51,7 @@ final class DontAwaitInALoopLinter
       return null;
     }
     $parents = Vec\reverse($parents);
-    $loops = [];
+    $loops = vec[];
     foreach ($parents as $parent) {
       if (self::isAsyncBoundary($parent)) {
         return null;

--- a/src/Missing.php
+++ b/src/Missing.php
@@ -24,7 +24,7 @@ final class Missing extends EditableNode {
   }
 
   <<__Override>>
-  public function getChildren(): KeyedTraversable<string, EditableNode> {
+  public function getChildren(): dict<string, EditableNode> {
     return dict[];
   }
 
@@ -46,7 +46,7 @@ final class Missing extends EditableNode {
   <<__Override>>
   public function rewriteDescendants(
     self::TRewriter $rewriter,
-    ?Traversable<EditableNode> $parents = null,
+    ?vec<EditableNode> $parents = null,
   ): this {
     return $this;
   }

--- a/src/__Private/codegen/CodegenSyntax.php
+++ b/src/__Private/codegen/CodegenSyntax.php
@@ -247,7 +247,7 @@ final class CodegenSyntax extends CodegenBase {
     return $cg
       ->codegenMethod('getChildren')
       ->setIsOverride()
-      ->setReturnType('KeyedTraversable<string, EditableNode>')
+      ->setReturnType('dict<string, EditableNode>')
       ->setBody(
         $cg
           ->codegenHackBuilder()
@@ -281,7 +281,7 @@ final class CodegenSyntax extends CodegenBase {
       ->codegenMethod('rewriteDescendants')
       ->setIsOverride()
       ->addParameter('self::TRewriter $rewriter')
-      ->addParameter('?Traversable<EditableNode> $parents = null')
+      ->addParameter('?vec<EditableNode> $parents = null')
       ->setReturnType('this')
       ->setBody(
         $cg

--- a/src/__Private/codegen/CodegenTokens.php
+++ b/src/__Private/codegen/CodegenTokens.php
@@ -246,7 +246,7 @@ final class CodegenTokens extends CodegenBase {
     return $cg->codegenMethod('rewriteDescendants')
       ->setIsOverride()
       ->addParameter('self::TRewriter $rewriter')
-      ->addParameter('?Traversable<EditableNode> $parents = null')
+      ->addParameter('?vec<EditableNode> $parents = null')
       ->setReturnType('this')
       ->setBody(
         $cg->codegenHackBuilder()


### PR DESCRIPTION
As we've added linters, things have slowed down a fair amount and one contributing factor seems to be recursively building `traverseWithParents()` for each linter on files that generate large-ish ASTs (> 3k LOC).

This PR shamelessly copies the static caching strategy used in `getASTFromFile()` and uses it for the `Traversable` of all nodes and their parents.

Here's an XHPROF with taken with `XHPROF_FLAGS_VTSC + XHPROF_FLAGS_TRACE`
Before:
![screen shot 2017-12-06 at 10 09 43 am](https://user-images.githubusercontent.com/4551889/33677501-da25994e-da6d-11e7-8898-8f3ed849f253.png)
After:
![screen shot 2017-12-06 at 10 10 03 am](https://user-images.githubusercontent.com/4551889/33677504-db7fae2e-da6d-11e7-84f3-c537b938471b.png)
