### PR TITLE
Suppress Linter error: Remove ReturnStatement from the list of statements to stop at

### DIFF
--- a/src/Linters/suppress_ast_linter_error.php
+++ b/src/Linters/suppress_ast_linter_error.php
@@ -106,14 +106,6 @@ function is_linter_suppressed_up_to_statement(
   $parents = Vec\reverse($parents);
 
   foreach ($parents as $parent) {
-    $token = $parent->getFirstToken();
-    if ($token !== null) {
-      $leading = $token->getCode();
-      if (Str\contains($leading, $fixme) || Str\contains($leading, $ignore)) {
-        return true;
-      }
-    }
-
     if (
       $parent instanceof IControlFlowStatement ||
       $parent instanceof BreakStatement ||
@@ -126,6 +118,14 @@ function is_linter_suppressed_up_to_statement(
       $parent instanceof UnsetStatement
     ) {
       return false;
+    }
+
+    $token = $parent->getFirstToken();
+    if ($token !== null) {
+      $leading = $token->getCode();
+      if (Str\contains($leading, $fixme) || Str\contains($leading, $ignore)) {
+        return true;
+      }
     }
   }
 

--- a/src/Linters/suppress_ast_linter_error.php
+++ b/src/Linters/suppress_ast_linter_error.php
@@ -88,6 +88,11 @@ function is_linter_suppressed_in_sibling_node(
     if (Str\contains($trailing, $fixme) || Str\contains($trailing, $ignore)) {
       return true;
     }
+
+    $leading = $token->getLeading()->getCode();
+    if (Str\contains($leading, $fixme) || Str\contains($leading, $ignore)) {
+      return true;
+    }
   }
 
   return false;
@@ -108,6 +113,7 @@ function is_linter_suppressed_up_to_statement(
       $parent instanceof ContinueStatement ||
       $parent instanceof EchoStatement ||
       $parent instanceof GotoStatement ||
+      $parent instanceof ReturnStatement ||
       $parent instanceof ThrowStatement ||
       $parent instanceof TryStatement ||
       $parent instanceof UnsetStatement

--- a/src/Linters/suppress_ast_linter_error.php
+++ b/src/Linters/suppress_ast_linter_error.php
@@ -84,7 +84,6 @@ function is_linter_suppressed_in_sibling_node(
   $token = $sibling->getLastToken();
   if ($token !== null) {
     $trailing = $token->getTrailing()->getCode();
-
     if (Str\contains($trailing, $fixme) || Str\contains($trailing, $ignore)) {
       return true;
     }
@@ -107,6 +106,14 @@ function is_linter_suppressed_up_to_statement(
   $parents = Vec\reverse($parents);
 
   foreach ($parents as $parent) {
+    $token = $parent->getFirstToken();
+    if ($token !== null) {
+      $leading = $token->getCode();
+      if (Str\contains($leading, $fixme) || Str\contains($leading, $ignore)) {
+        return true;
+      }
+    }
+
     if (
       $parent instanceof IControlFlowStatement ||
       $parent instanceof BreakStatement ||
@@ -119,14 +126,6 @@ function is_linter_suppressed_up_to_statement(
       $parent instanceof UnsetStatement
     ) {
       return false;
-    }
-
-    $token = $parent->getFirstToken();
-    if ($token !== null) {
-      $leading = $token->getCode();
-      if (Str\contains($leading, $fixme) || Str\contains($leading, $ignore)) {
-        return true;
-      }
     }
   }
 

--- a/src/Linters/suppress_ast_linter_error.php
+++ b/src/Linters/suppress_ast_linter_error.php
@@ -108,7 +108,6 @@ function is_linter_suppressed_up_to_statement(
       $parent instanceof ContinueStatement ||
       $parent instanceof EchoStatement ||
       $parent instanceof GotoStatement ||
-      $parent instanceof ReturnStatement ||
       $parent instanceof ThrowStatement ||
       $parent instanceof TryStatement ||
       $parent instanceof UnsetStatement

--- a/tests/fixtures/SuppressASTLinterAwait/await_in_while.php.in
+++ b/tests/fixtures/SuppressASTLinterAwait/await_in_while.php.in
@@ -18,9 +18,9 @@ async function spin_forever_async(
   }
 }
 
-// This one should fail since the FIXME is outside the loop.
+// This one should fail since the FIXME is outside the scope.
+/* HHAST_FIXME[DontAwaitInALoop] */
 async function spin_forever_async_fail(
 ): Awaitable<void> {
-  /* HHAST_FIXME[DontAwaitInALoop] */
   while(true) await HH\Asio\later();
 }

--- a/tests/fixtures/SuppressASTLinterAwait/await_in_while.php.in
+++ b/tests/fixtures/SuppressASTLinterAwait/await_in_while.php.in
@@ -18,9 +18,9 @@ async function spin_forever_async(
   }
 }
 
-// This one should fail since the FIXME is outside the scope.
-/* HHAST_FIXME[DontAwaitInALoop] */
+// This one should fail since the FIXME is outside the loop.
 async function spin_forever_async_fail(
 ): Awaitable<void> {
+  /* HHAST_FIXME[DontAwaitInALoop] */
   while(true) await HH\Asio\later();
 }


### PR DESCRIPTION
…when looking if we should suppress a linting error.

The simple example where having ReturnStatement in that list becomes troublesome:

```
...
  # HHAST_IGNORE_ERROR[BannedFunctions]
  return some_banned_function($param);
```

Since the error node is the function we immediately hit the ReturnStatement before the comment and stop. Alternatively I assume the comment could be inbetween return and the function, but that seems harder to read.