### PR TITLE
Improve the string interpolation linter; support sometimes-autofixing…

### DIFF
--- a/src/Linters/AutoFixingASTLinter.php
+++ b/src/Linters/AutoFixingASTLinter.php
@@ -17,7 +17,7 @@ abstract class AutoFixingASTLinter<Tnode as EditableNode>
 extends BaseASTLinter<Tnode, FixableASTLintError<Tnode>>
 implements AutoFixingLinter<FixableASTLintError<Tnode>> {
 
-  abstract public function getFixedNode(Tnode $node): EditableNode;
+  abstract public function getFixedNode(Tnode $node): ?EditableNode;
 
   final public function fixLintErrors(
     Traversable<FixableASTLintError<Tnode>> $errors,
@@ -34,6 +34,10 @@ implements AutoFixingLinter<FixableASTLintError<Tnode>> {
       );
       $old = $error->getBlameNode();
       $new = $this->getFixedNode($old);
+      invariant(
+        $new !== null,
+        "Shouldn't be attempting to fix a non-fixable error",
+      );
       $ast = $ast->replace($old, $new);
     }
     \file_put_contents(

--- a/src/Linters/NoStringInterpolationLinter.php
+++ b/src/Linters/NoStringInterpolationLinter.php
@@ -20,6 +20,7 @@ use type Facebook\HHAST\{
   EditableNode,
   EditableSyntax,
   EmbeddedBracedExpression,
+  HeredocStringLiteralHeadToken,
   LiteralExpression,
   NameToken,
   QualifiedNameExpression,
@@ -51,15 +52,15 @@ final class NoStringInterpolationLinter
 
     return new FixableASTLintError(
       $this,
-      'Do not use string interpolation - consider concatenation or Strormat() instead '.
-      'instead',
+      'Do not use string interpolation - consider concatenation or '.
+      'Str\format() instead ',
       $root_expr,
     );
     return null;
   }
 
   <<__Override>>
-  public function getFixedNode(LiteralExpression $root_expr): EditableNode {
+  public function getFixedNode(LiteralExpression $root_expr): ?EditableNode {
     $expr = $root_expr->getExpression();
     invariant(
       $expr instanceof EditableList,
@@ -75,6 +76,9 @@ final class NoStringInterpolationLinter
 
     for ($i = 0; $i < $child_count; ++$i) {
       $child = $children[$i];
+      if ($child instanceof HeredocStringLiteralHeadToken) {
+        return null;
+      }
       if ($child instanceof DoubleQuotedStringLiteralHeadToken) {
         if ($child->getText() === '"') {
           $leading = $child->getLeading();

--- a/tests/AutoFixingLinterTestTrait.php
+++ b/tests/AutoFixingLinterTestTrait.php
@@ -34,7 +34,11 @@ trait AutoFixingLinterTestTrait<Terror as Linters\FixableLintError> {
     \copy($in, $out);
     $linter = $this->getLinter($out);
 
-    $linter->fixLintErrors($linter->getLintErrors());
+    $all_errors = vec($linter->getLintErrors());
+    $fixable = Vec\filter($all_errors, $err ==> $err->isFixable());
+    $unfixable = Vec\filter($all_errors, $err ==> !$err->isFixable());
+    $linter->fixLintErrors($fixable);
+
     $code = \file_get_contents($out);
     expect($code)->toMatchExpectFileWithInputFile(
       $fixture.'.autofix.expect',
@@ -44,6 +48,8 @@ trait AutoFixingLinterTestTrait<Terror as Linters\FixableLintError> {
     $linter = $this->getLinter(
       __DIR__.'/fixtures/'.$fixture.'.autofix.expect'
     );
-    expect(vec($linter->getLintErrors()))->toBeSame(vec[]);
+
+    expect(Vec\map($linter->getLintErrors(), $e ==> self::getErrorAsShape($e)))
+      ->toBeSame(Vec\map($unfixable, $e ==> self::getErrorAsShape($e)));
   }
 }

--- a/tests/LinterTestTrait.php
+++ b/tests/LinterTestTrait.php
@@ -69,13 +69,19 @@ trait LinterTestTrait {
     $out = $linter->getLintErrors()
       |> Vec\map(
         $$,
-        $error ==> shape(
-          'blame' => $error->getBlameCode(),
-          'blame_pretty' => $error->getPrettyBlame(),
-          'description' => $error->getDescription(),
-        ),
+        $error ==> self::getErrorAsShape($error),
       )
       |> \json_encode($$, \JSON_PRETTY_PRINT)."\n";
     expect($out)->toMatchExpectFile($fixture.'.expect');
+  }
+
+  final protected static function getErrorAsShape(
+    Linters\LintError $e,
+   ): shape(...) {
+    return shape(
+      'blame' => $e->getBlameCode(),
+      'blame_pretty' => $e->getPrettyBlame(),
+      'description' => $e->getDescription(),
+    );
   }
 }

--- a/tests/fixtures/NoStringInterpolationLinter/heredoc.php.autofix.expect
+++ b/tests/fixtures/NoStringInterpolationLinter/heredoc.php.autofix.expect
@@ -1,0 +1,4 @@
+<?hh
+$foo = <<<EOF
+foo$bar
+EOF;

--- a/tests/fixtures/NoStringInterpolationLinter/heredoc.php.autofix.expect
+++ b/tests/fixtures/NoStringInterpolationLinter/heredoc.php.autofix.expect
@@ -1,4 +1,13 @@
 <?hh
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
 $foo = <<<EOF
 foo$bar
 EOF;

--- a/tests/fixtures/NoStringInterpolationLinter/heredoc.php.expect
+++ b/tests/fixtures/NoStringInterpolationLinter/heredoc.php.expect
@@ -1,0 +1,7 @@
+[
+    {
+        "blame": "<<<EOF\nfoo$bar\nEOF",
+        "blame_pretty": "<<<EOF\nfoo$bar\nEOF",
+        "description": "Do not use string interpolation - consider concatenation or Str\\format() instead "
+    }
+]

--- a/tests/fixtures/NoStringInterpolationLinter/heredoc.php.in
+++ b/tests/fixtures/NoStringInterpolationLinter/heredoc.php.in
@@ -1,0 +1,4 @@
+<?hh
+$foo = <<<EOF
+foo$bar
+EOF;

--- a/tests/fixtures/NoStringInterpolationLinter/heredoc.php.in
+++ b/tests/fixtures/NoStringInterpolationLinter/heredoc.php.in
@@ -1,4 +1,13 @@
 <?hh
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
 $foo = <<<EOF
 foo$bar
 EOF;

--- a/tests/fixtures/NoStringInterpolationLinter/simple_variables.php.expect
+++ b/tests/fixtures/NoStringInterpolationLinter/simple_variables.php.expect
@@ -2,36 +2,36 @@
     {
         "blame": "\"foo$bar\"",
         "blame_pretty": "\"foo$bar\"",
-        "description": "Do not use string interpolation - consider concatenation or Str\format() instead instead"
+        "description": "Do not use string interpolation - consider concatenation or Str\\format() instead "
     },
     {
         "blame": "\"foo$bar-baz\"",
         "blame_pretty": "\"foo$bar-baz\"",
-        "description": "Do not use string interpolation - consider concatenation or Str\format() instead instead"
+        "description": "Do not use string interpolation - consider concatenation or Str\\format() instead "
     },
     {
         "blame": "\"$foo\"",
         "blame_pretty": "\"$foo\"",
-        "description": "Do not use string interpolation - consider concatenation or Str\format() instead instead"
+        "description": "Do not use string interpolation - consider concatenation or Str\\format() instead "
     },
     {
         "blame": "\"${foo}bar\"",
         "blame_pretty": "\"${foo}bar\"",
-        "description": "Do not use string interpolation - consider concatenation or Str\format() instead instead"
+        "description": "Do not use string interpolation - consider concatenation or Str\\format() instead "
     },
     {
         "blame": "\"foo${bar}\"",
         "blame_pretty": "\"foo${bar}\"",
-        "description": "Do not use string interpolation - consider concatenation or Str\format() instead instead"
+        "description": "Do not use string interpolation - consider concatenation or Str\\format() instead "
     },
     {
         "blame": "\"foo${bar}baz${herp}derp\"",
         "blame_pretty": "\"foo${bar}baz${herp}derp\"",
-        "description": "Do not use string interpolation - consider concatenation or Str\format() instead instead"
+        "description": "Do not use string interpolation - consider concatenation or Str\\format() instead "
     },
     {
         "blame": "\"foo{$bar}\"",
         "blame_pretty": "\"foo{$bar}\"",
-        "description": "Do not use string interpolation - consider concatenation or Str\format() instead instead"
+        "description": "Do not use string interpolation - consider concatenation or Str\\format() instead "
     }
 ]


### PR DESCRIPTION
… AST linters

- fix bad sed leading to \f (escape character) when attempting to
reference `Str\format`
- don't autofix heredocs
- add tests