### PR TITLE
Warn if path contains a hhast-lint.json

### DIFF
--- a/src/__Private/LinterCLI.php
+++ b/src/__Private/LinterCLI.php
@@ -162,10 +162,11 @@ final class LinterCLI extends CLIWithArguments {
           $config_file = $path.'/hhast-lint.json';
           if (\file_exists($config_file)) {
             \fwrite(
-              \STDERR,
-              "Warning: PATH arguments contain a hhast-lint.json\n",
+              \STDOUT,
+              "Warning: PATH arguments contain a hhast-lint.json, ".
+              "which modifies the linters used and customizes behavior. ".
+              "Consider 'cd ".$root."; vendor/bin/hhast-lint'\n\n",
             );
-            return 1;
           }
         }
       }

--- a/src/__Private/LinterCLI.php
+++ b/src/__Private/LinterCLI.php
@@ -156,6 +156,19 @@ final class LinterCLI extends CLIWithArguments {
         return 1;
       }
     } else {
+      foreach ($roots as $root) {
+        $path = \realpath($root);
+        if (\is_dir($path)) {
+          $config_file = $path.'/hhast-lint.json';
+          if (\file_exists($config_file)) {
+            \fwrite(
+              \STDERR,
+              "Warning: PATH arguments contain a hhast-lint.json\n",
+            );
+            return 1;
+          }
+        }
+      }
       $config = null;
     }
 


### PR DESCRIPTION
Hopefully this logic is correct:

- Running 'bin/hhast-lint' works as before
- If the user specifies a directory, check if the directory directly contains a hhast-lint.json. If so, print warning message, but still lint everything in the specified directory.
- If the user specifies a file, just lint the file.
- If the user specifies multiple PATH arguments, print warning message for each case it applies