### PR TITLE
Always offer getFoox variants for field accessors

### DIFF
--- a/codegen/editable_node_from_json.php
+++ b/codegen/editable_node_from_json.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<11c3b1f3a374cb27985ded4433f573fd>>
+ * @generated SignedSource<<984d503ca9b95b765b443dd8ea9351f3>>
  */
 namespace Facebook\HHAST\__Private;
 use namespace Facebook\HHAST;
@@ -309,6 +309,8 @@ function editable_node_from_json(
       return HHAST\LambdaExpression::fromJSON($json, $file, $offset, $source);
     case 'lambda_signature':
       return HHAST\LambdaSignature::fromJSON($json, $file, $offset, $source);
+    case 'let_statement':
+      return HHAST\LetStatement::fromJSON($json, $file, $offset, $source);
     case 'list_expression':
       return HHAST\ListExpression::fromJSON($json, $file, $offset, $source);
     case 'list_item':

--- a/codegen/editable_token_from_data.php
+++ b/codegen/editable_token_from_data.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2513f697889fd384638d8a800507218e>>
+ * @generated SignedSource<<bfdc48a6e1ab9b3266d4d7c15c80711c>>
  */
 namespace Facebook\HHAST\__Private;
 use namespace Facebook\HHAST;
@@ -98,6 +98,7 @@ class TokenClassMap {
       'is' => HHAST\IsToken::class,
       'isset' => HHAST\IssetToken::class,
       'keyset' => HHAST\KeysetToken::class,
+      'let' => HHAST\LetToken::class,
       'list' => HHAST\ListToken::class,
       'mixed' => HHAST\MixedToken::class,
       'namespace' => HHAST\NamespaceToken::class,

--- a/codegen/inferred_relationships.php
+++ b/codegen/inferred_relationships.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1238d2bd59e348552eba7afbff27373a>>
+ * @generated SignedSource<<0f94ecb2af3774af0e6be15d5e0ddcc2>>
  */
 namespace Facebook\HHAST\__Private;
 
@@ -171,6 +171,7 @@ const dict<string, keyset<string>>
       'token:async',
     ],
     'anonymous_function.anonymous_attribute_spec' => keyset[
+      'attribute_specification',
       'missing',
     ],
     'anonymous_function.anonymous_body' => keyset[
@@ -295,6 +296,7 @@ const dict<string, keyset<string>>
       'token:async',
     ],
     'awaitable_creation_expression.awaitable_attribute_spec' => keyset[
+      'attribute_specification',
       'missing',
     ],
     'awaitable_creation_expression.awaitable_compound_statement' => keyset[
@@ -326,9 +328,9 @@ const dict<string, keyset<string>>
       'postfix_unary_expression',
       'prefix_unary_expression',
       'qualified_name',
-      'safe_member_selection_expression',
       'scope_resolution_expression',
       'subscript_expression',
+      'token:)',
       'token:name',
       'variable',
       'varray_intrinsic_expression',
@@ -529,6 +531,7 @@ const dict<string, keyset<string>>
       'simple_type_specifier',
     ],
     'catch_clause.catch_variable' => keyset[
+      'missing',
       'token:variable',
     ],
     'classish_body.classish_body_elements' => keyset[
@@ -1134,17 +1137,18 @@ const dict<string, keyset<string>>
     ],
     'enumerator.enumerator_value' => keyset[
       'binary_expression',
+      'function_call_expression',
       'literal',
+      'object_creation_expression',
       'scope_resolution_expression',
+      'token:name',
+      'variable',
     ],
     'error.error_error' => keyset[
       'token:;',
       'token:=',
       'token:decimal_literal',
-      'token:name',
-      'token:single_quoted_string_literal',
       'token:variable',
-      'token:{',
       'token:}',
     ],
     'eval_expression.eval_argument' => keyset[
@@ -1194,8 +1198,7 @@ const dict<string, keyset<string>>
       'token:,',
       'token::',
       'token:===',
-      'token:=>',
-      'token:]',
+      'token:?',
       'token:name',
       'token:}',
       'tuple_expression',
@@ -1322,6 +1325,7 @@ const dict<string, keyset<string>>
       'prefix_unary_expression',
       'scope_resolution_expression',
       'subscript_expression',
+      'token:name',
       'variable',
       'vector_intrinsic_expression',
     ],
@@ -1333,6 +1337,7 @@ const dict<string, keyset<string>>
       'prefix_unary_expression',
       'scope_resolution_expression',
       'subscript_expression',
+      'token:name',
       'variable',
     ],
     'foreach_statement.foreach_keyword' => keyset[
@@ -1352,6 +1357,7 @@ const dict<string, keyset<string>>
       'prefix_unary_expression',
       'scope_resolution_expression',
       'subscript_expression',
+      'token:name',
       'variable',
     ],
     'function_call_expression.function_call_argument_list' => keyset[
@@ -1386,6 +1392,7 @@ const dict<string, keyset<string>>
       ],
     'function_call_with_type_arguments_expression.function_call_with_type_arguments_left_paren' =>
       keyset[
+        'missing',
         'token:(',
       ],
     'function_call_with_type_arguments_expression.function_call_with_type_arguments_receiver' =>
@@ -1396,6 +1403,7 @@ const dict<string, keyset<string>>
       ],
     'function_call_with_type_arguments_expression.function_call_with_type_arguments_right_paren' =>
       keyset[
+        'missing',
         'token:)',
       ],
     'function_call_with_type_arguments_expression.function_call_with_type_arguments_type_args' =>
@@ -1629,12 +1637,17 @@ const dict<string, keyset<string>>
       'token:is',
     ],
     'is_expression.is_right_operand' => keyset[
+      'closure_type_specifier',
+      'dictionary_type_specifier',
       'generic_type_specifier',
+      'keyset_type_specifier',
       'nullable_type_specifier',
       'shape_type_specifier',
       'simple_type_specifier',
+      'soft_type_specifier',
       'tuple_type_specifier',
       'type_constant',
+      'vector_type_specifier',
     ],
     'isset_expression.isset_argument_list' => keyset[
       'list',
@@ -1687,6 +1700,7 @@ const dict<string, keyset<string>>
       'token:async',
     ],
     'lambda_expression.lambda_attribute_spec' => keyset[
+      'attribute_specification',
       'missing',
     ],
     'lambda_expression.lambda_body' => keyset[
@@ -1799,7 +1813,7 @@ const dict<string, keyset<string>>
       'simple_type_specifier',
       'static_declarator',
       'subscript_expression',
-      'token:%',
+      'token:=',
       'token:XHP_category_name',
       'token:name',
       'token:noreturn',
@@ -1890,6 +1904,7 @@ const dict<string, keyset<string>>
       'prefix_unary_expression',
       'scope_resolution_expression',
       'subscript_expression',
+      'token:name',
       'variable',
     ],
     'member_selection_expression.member_operator' => keyset[
@@ -2397,6 +2412,7 @@ const dict<string, keyset<string>>
       'subscript_expression',
       'token:name',
       'tuple_expression',
+      'variable',
       'varray_intrinsic_expression',
       'vector_intrinsic_expression',
       'xhp_expression',
@@ -2741,7 +2757,6 @@ const dict<string, keyset<string>>
       'list',
     ],
     'type_parameters.type_parameters_right_angle' => keyset[
-      'missing',
       'token:>',
     ],
     'unset_statement.unset_keyword' => keyset[

--- a/codegen/schema.json
+++ b/codegen/schema.json
@@ -1,6 +1,6 @@
 { "description" :
   "@generated JSON schema of the Hack Full Fidelity Parser AST",
-  "version" : "2018-03-15-0002",
+  "version" : "2018-05-18-0001",
   "trivia" : [
     { "trivia_kind_name" : "WhiteSpace",
       "trivia_type_name" : "whitespace" },
@@ -161,6 +161,8 @@
       "token_text" : "isset" },
     { "token_kind" : "Keyset",
       "token_text" : "keyset" },
+    { "token_kind" : "Let",
+      "token_text" : "let" },
     { "token_kind" : "List",
       "token_text" : "list" },
     { "token_kind" : "Mixed",
@@ -895,6 +897,18 @@
         { "field_name" : "left_paren" },
         { "field_name" : "variables" },
         { "field_name" : "right_paren" },
+        { "field_name" : "semicolon" }
+      ] },
+    { "kind_name" : "LetStatement",
+      "type_name" : "let_statement",
+      "description" : "let_statement",
+      "prefix" : "let_statement",
+      "fields" : [
+        { "field_name" : "keyword" },
+        { "field_name" : "name" },
+        { "field_name" : "colon" },
+        { "field_name" : "type" },
+        { "field_name" : "initializer" },
         { "field_name" : "semicolon" }
       ] },
     { "kind_name" : "UsingStatementBlockScoped",

--- a/codegen/syntax/AliasDeclaration.php
+++ b/codegen/syntax/AliasDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f69830ecdd12f1e786983ae6f5d3f353>>
+ * @generated SignedSource<<085f2f59dc3f208a6e641ee96cb2698e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -247,6 +247,13 @@ final class AliasDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns NewtypeToken | TypeToken
+   */
+  public function getKeywordx(): EditableToken {
+    return $this->getKeyword();
+  }
+
   public function getNameUNTYPED(): EditableNode {
     return $this->_name;
   }
@@ -276,6 +283,13 @@ final class AliasDeclaration extends EditableNode {
    */
   public function getName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
+  }
+
+  /**
+   * @returns NameToken
+   */
+  public function getNamex(): NameToken {
+    return $this->getName();
   }
 
   public function getGenericParameterUNTYPED(): EditableNode {
@@ -393,6 +407,13 @@ final class AliasDeclaration extends EditableNode {
     return TypeAssert\instance_of(EqualToken::class, $this->_equal);
   }
 
+  /**
+   * @returns EqualToken
+   */
+  public function getEqualx(): EqualToken {
+    return $this->getEqual();
+  }
+
   public function getTypeUNTYPED(): EditableNode {
     return $this->_type;
   }
@@ -427,6 +448,16 @@ final class AliasDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
   }
 
+  /**
+   * @returns ClosureTypeSpecifier | DictionaryTypeSpecifier |
+   * GenericTypeSpecifier | KeysetTypeSpecifier | MapArrayTypeSpecifier |
+   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
+   * TupleTypeSpecifier | VectorArrayTypeSpecifier | VectorTypeSpecifier
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -456,5 +487,12 @@ final class AliasDeclaration extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/AlternateElseClause.php
+++ b/codegen/syntax/AlternateElseClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cd0da0ac578824e44bbfafbdf4da606a>>
+ * @generated SignedSource<<53a765894511fc0f26c2792f28749f0b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -109,6 +109,13 @@ final class AlternateElseClause
     return TypeAssert\instance_of(ElseToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ElseToken
+   */
+  public function getKeywordx(): ElseToken {
+    return $this->getKeyword();
+  }
+
   public function getColonUNTYPED(): EditableNode {
     return $this->_colon;
   }
@@ -131,6 +138,13 @@ final class AlternateElseClause
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
   }
 
+  /**
+   * @returns ColonToken
+   */
+  public function getColonx(): ColonToken {
+    return $this->getColon();
+  }
+
   public function getStatementUNTYPED(): EditableNode {
     return $this->_statement;
   }
@@ -151,5 +165,12 @@ final class AlternateElseClause
    */
   public function getStatement(): EditableList {
     return TypeAssert\instance_of(EditableList::class, $this->_statement);
+  }
+
+  /**
+   * @returns EditableList
+   */
+  public function getStatementx(): EditableList {
+    return $this->getStatement();
   }
 }

--- a/codegen/syntax/AlternateElseifClause.php
+++ b/codegen/syntax/AlternateElseifClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cd9550f4cce1b61c8c7f3d7a4e89978e>>
+ * @generated SignedSource<<08f603ed0afa963da9ea3e5dbcd7f9dd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -169,6 +169,13 @@ final class AlternateElseifClause
     return TypeAssert\instance_of(EditableNode::class, $this->_keyword);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getKeywordx(): EditableNode {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -196,6 +203,13 @@ final class AlternateElseifClause
    */
   public function getLeftParen(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getLeftParenx(): EditableNode {
+    return $this->getLeftParen();
   }
 
   public function getConditionUNTYPED(): EditableNode {
@@ -227,6 +241,13 @@ final class AlternateElseifClause
     return TypeAssert\instance_of(EditableNode::class, $this->_condition);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getConditionx(): EditableNode {
+    return $this->getCondition();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -254,6 +275,13 @@ final class AlternateElseifClause
    */
   public function getRightParen(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getRightParenx(): EditableNode {
+    return $this->getRightParen();
   }
 
   public function getColonUNTYPED(): EditableNode {
@@ -285,6 +313,13 @@ final class AlternateElseifClause
     return TypeAssert\instance_of(EditableNode::class, $this->_colon);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getColonx(): EditableNode {
+    return $this->getColon();
+  }
+
   public function getStatementUNTYPED(): EditableNode {
     return $this->_statement;
   }
@@ -312,5 +347,12 @@ final class AlternateElseifClause
    */
   public function getStatement(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_statement);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getStatementx(): EditableNode {
+    return $this->getStatement();
   }
 }

--- a/codegen/syntax/AlternateIfStatement.php
+++ b/codegen/syntax/AlternateIfStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7b55a2f8cfc90f99473b4b220b005e3f>>
+ * @generated SignedSource<<def84d6265d2f9632e4280630ccc92c1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -231,6 +231,13 @@ final class AlternateIfStatement extends EditableNode {
     return TypeAssert\instance_of(IfToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns IfToken
+   */
+  public function getKeywordx(): IfToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -262,6 +269,13 @@ final class AlternateIfStatement extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getConditionUNTYPED(): EditableNode {
@@ -297,6 +311,13 @@ final class AlternateIfStatement extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_condition);
   }
 
+  /**
+   * @returns BinaryExpression | LiteralExpression | VariableExpression
+   */
+  public function getConditionx(): EditableNode {
+    return $this->getCondition();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -328,6 +349,13 @@ final class AlternateIfStatement extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 
   public function getColonUNTYPED(): EditableNode {
@@ -363,6 +391,13 @@ final class AlternateIfStatement extends EditableNode {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
   }
 
+  /**
+   * @returns ColonToken
+   */
+  public function getColonx(): ColonToken {
+    return $this->getColon();
+  }
+
   public function getStatementUNTYPED(): EditableNode {
     return $this->_statement;
   }
@@ -396,6 +431,13 @@ final class AlternateIfStatement extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_statement);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getStatementx(): EditableList {
+    return $this->getStatement();
+  }
+
   public function getElseifClausesUNTYPED(): EditableNode {
     return $this->_elseif_clauses;
   }
@@ -427,6 +469,13 @@ final class AlternateIfStatement extends EditableNode {
    */
   public function getElseifClauses(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_elseif_clauses);
+  }
+
+  /**
+   * @returns Missing
+   */
+  public function getElseifClausesx(): EditableNode {
+    return $this->getElseifClauses();
   }
 
   public function getElseClauseUNTYPED(): EditableNode {
@@ -507,6 +556,13 @@ final class AlternateIfStatement extends EditableNode {
     return TypeAssert\instance_of(EndifToken::class, $this->_endif_keyword);
   }
 
+  /**
+   * @returns EndifToken
+   */
+  public function getEndifKeywordx(): EndifToken {
+    return $this->getEndifKeyword();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -538,5 +594,12 @@ final class AlternateIfStatement extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/AlternateLoopStatement.php
+++ b/codegen/syntax/AlternateLoopStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e6792b122724b35c54a9be93c55072d1>>
+ * @generated SignedSource<<2cca892ebc190d1224e39121f5e37a78>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -138,6 +138,13 @@ abstract class AlternateLoopStatementGeneratedBase
     return TypeAssert\instance_of(ColonToken::class, $this->_opening_colon);
   }
 
+  /**
+   * @returns ColonToken
+   */
+  public function getOpeningColonx(): ColonToken {
+    return $this->getOpeningColon();
+  }
+
   public function getStatementsUNTYPED(): EditableNode {
     return $this->_statements;
   }
@@ -163,6 +170,13 @@ abstract class AlternateLoopStatementGeneratedBase
    */
   public function getStatements(): EditableList {
     return TypeAssert\instance_of(EditableList::class, $this->_statements);
+  }
+
+  /**
+   * @returns EditableList
+   */
+  public function getStatementsx(): EditableList {
+    return $this->getStatements();
   }
 
   public function getClosingKeywordUNTYPED(): EditableNode {
@@ -193,6 +207,13 @@ abstract class AlternateLoopStatementGeneratedBase
       TypeAssert\instance_of(EditableToken::class, $this->_closing_keyword);
   }
 
+  /**
+   * @returns EnddeclareToken | EndforToken | EndforeachToken | EndwhileToken
+   */
+  public function getClosingKeywordx(): EditableToken {
+    return $this->getClosingKeyword();
+  }
+
   public function getClosingSemicolonUNTYPED(): EditableNode {
     return $this->_closing_semicolon;
   }
@@ -219,5 +240,12 @@ abstract class AlternateLoopStatementGeneratedBase
   public function getClosingSemicolon(): SemicolonToken {
     return
       TypeAssert\instance_of(SemicolonToken::class, $this->_closing_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getClosingSemicolonx(): SemicolonToken {
+    return $this->getClosingSemicolon();
   }
 }

--- a/codegen/syntax/AlternateSwitchStatement.php
+++ b/codegen/syntax/AlternateSwitchStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<18ace2d9524ea91b4682f790d860c7d8>>
+ * @generated SignedSource<<338e973848ea9c7507eb8e002795a66c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -203,6 +203,13 @@ final class AlternateSwitchStatement
     return TypeAssert\instance_of(SwitchToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns SwitchToken
+   */
+  public function getKeywordx(): SwitchToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -232,6 +239,13 @@ final class AlternateSwitchStatement
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getExpressionUNTYPED(): EditableNode {
@@ -265,6 +279,13 @@ final class AlternateSwitchStatement
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
+  /**
+   * @returns LiteralExpression | VariableExpression
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -294,6 +315,13 @@ final class AlternateSwitchStatement
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 
   public function getOpeningColonUNTYPED(): EditableNode {
@@ -327,6 +355,13 @@ final class AlternateSwitchStatement
     return TypeAssert\instance_of(ColonToken::class, $this->_opening_colon);
   }
 
+  /**
+   * @returns ColonToken
+   */
+  public function getOpeningColonx(): ColonToken {
+    return $this->getOpeningColon();
+  }
+
   public function getSectionsUNTYPED(): EditableNode {
     return $this->_sections;
   }
@@ -356,6 +391,13 @@ final class AlternateSwitchStatement
    */
   public function getSections(): EditableList {
     return TypeAssert\instance_of(EditableList::class, $this->_sections);
+  }
+
+  /**
+   * @returns EditableList
+   */
+  public function getSectionsx(): EditableList {
+    return $this->getSections();
   }
 
   public function getClosingEndswitchUNTYPED(): EditableNode {
@@ -390,6 +432,13 @@ final class AlternateSwitchStatement
       TypeAssert\instance_of(EndswitchToken::class, $this->_closing_endswitch);
   }
 
+  /**
+   * @returns EndswitchToken
+   */
+  public function getClosingEndswitchx(): EndswitchToken {
+    return $this->getClosingEndswitch();
+  }
+
   public function getClosingSemicolonUNTYPED(): EditableNode {
     return $this->_closing_semicolon;
   }
@@ -420,5 +469,12 @@ final class AlternateSwitchStatement
   public function getClosingSemicolon(): SemicolonToken {
     return
       TypeAssert\instance_of(SemicolonToken::class, $this->_closing_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getClosingSemicolonx(): SemicolonToken {
+    return $this->getClosingSemicolon();
   }
 }

--- a/codegen/syntax/AnonymousClass.php
+++ b/codegen/syntax/AnonymousClass.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ea20040579472eea4f38df5f579b3c17>>
+ * @generated SignedSource<<d386ff95224718ca85acb15732d8b5cd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -214,6 +214,13 @@ final class AnonymousClass extends EditableNode {
    */
   public function getClassKeyword(): ClassToken {
     return TypeAssert\instance_of(ClassToken::class, $this->_class_keyword);
+  }
+
+  /**
+   * @returns ClassToken
+   */
+  public function getClassKeywordx(): ClassToken {
+    return $this->getClassKeyword();
   }
 
   public function getLeftParenUNTYPED(): EditableNode {
@@ -546,5 +553,12 @@ final class AnonymousClass extends EditableNode {
    */
   public function getBody(): ClassishBody {
     return TypeAssert\instance_of(ClassishBody::class, $this->_body);
+  }
+
+  /**
+   * @returns ClassishBody
+   */
+  public function getBodyx(): ClassishBody {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/AnonymousFunction.php
+++ b/codegen/syntax/AnonymousFunction.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ca3ba76079d304c7b4c98847010352e5>>
+ * @generated SignedSource<<7b06f65faa480132f953d32952f9e9cd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -473,6 +473,13 @@ final class AnonymousFunction extends EditableNode {
       TypeAssert\instance_of(FunctionToken::class, $this->_function_keyword);
   }
 
+  /**
+   * @returns FunctionToken
+   */
+  public function getFunctionKeywordx(): FunctionToken {
+    return $this->getFunctionKeyword();
+  }
+
   public function getAmpersandUNTYPED(): EditableNode {
     return $this->_ampersand;
   }
@@ -742,6 +749,16 @@ final class AnonymousFunction extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
   }
 
+  /**
+   * @returns ClosureTypeSpecifier | GenericTypeSpecifier |
+   * MapArrayTypeSpecifier | Missing | NullableTypeSpecifier |
+   * SimpleTypeSpecifier | SoftTypeSpecifier | TupleTypeSpecifier |
+   * VectorArrayTypeSpecifier
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
+  }
+
   public function getUseUNTYPED(): EditableNode {
     return $this->_use;
   }
@@ -824,5 +841,12 @@ final class AnonymousFunction extends EditableNode {
    */
   public function getBody(): CompoundStatement {
     return TypeAssert\instance_of(CompoundStatement::class, $this->_body);
+  }
+
+  /**
+   * @returns CompoundStatement
+   */
+  public function getBodyx(): CompoundStatement {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/AnonymousFunction.php
+++ b/codegen/syntax/AnonymousFunction.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<662ec02e5df231257742268e05be7eca>>
+ * @generated SignedSource<<ca3ba76079d304c7b4c98847010352e5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -274,10 +274,26 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @returns AttributeSpecification | Missing
    */
-  public function getAttributeSpec(): EditableNode {
-    return TypeAssert\instance_of(EditableNode::class, $this->_attribute_spec);
+  public function getAttributeSpec(): ?AttributeSpecification {
+    if ($this->_attribute_spec->isMissing()) {
+      return null;
+    }
+    return TypeAssert\instance_of(
+      AttributeSpecification::class,
+      $this->_attribute_spec,
+    );
+  }
+
+  /**
+   * @returns AttributeSpecification
+   */
+  public function getAttributeSpecx(): AttributeSpecification {
+    return TypeAssert\instance_of(
+      AttributeSpecification::class,
+      $this->_attribute_spec,
+    );
   }
 
   public function getStaticKeywordUNTYPED(): EditableNode {

--- a/codegen/syntax/AnonymousFunctionUseClause.php
+++ b/codegen/syntax/AnonymousFunctionUseClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<643122b244fea931d21c6d2d2be93d17>>
+ * @generated SignedSource<<64c51f92c79100e4d107b421c2baea21>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class AnonymousFunctionUseClause extends EditableNode {
     return TypeAssert\instance_of(UseToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns UseToken
+   */
+  public function getKeywordx(): UseToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -150,6 +157,13 @@ final class AnonymousFunctionUseClause extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getVariablesUNTYPED(): EditableNode {
@@ -179,6 +193,13 @@ final class AnonymousFunctionUseClause extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_variables);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getVariablesx(): EditableList {
+    return $this->getVariables();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -204,5 +225,12 @@ final class AnonymousFunctionUseClause extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 }

--- a/codegen/syntax/ArrayCreationExpression.php
+++ b/codegen/syntax/ArrayCreationExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6310b91ba8622821e690328bb0b84984>>
+ * @generated SignedSource<<74c3df32b3d1f5815a6882bd5651697f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -108,6 +108,13 @@ final class ArrayCreationExpression extends EditableNode {
       TypeAssert\instance_of(LeftBracketToken::class, $this->_left_bracket);
   }
 
+  /**
+   * @returns LeftBracketToken
+   */
+  public function getLeftBracketx(): LeftBracketToken {
+    return $this->getLeftBracket();
+  }
+
   public function getMembersUNTYPED(): EditableNode {
     return $this->_members;
   }
@@ -161,5 +168,12 @@ final class ArrayCreationExpression extends EditableNode {
   public function getRightBracket(): RightBracketToken {
     return
       TypeAssert\instance_of(RightBracketToken::class, $this->_right_bracket);
+  }
+
+  /**
+   * @returns RightBracketToken
+   */
+  public function getRightBracketx(): RightBracketToken {
+    return $this->getRightBracket();
   }
 }

--- a/codegen/syntax/ArrayIntrinsicExpression.php
+++ b/codegen/syntax/ArrayIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<30a064906fba4ccf5f186b3eeeb585a0>>
+ * @generated SignedSource<<0be8d859a6472024fde27230b4d6b61b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class ArrayIntrinsicExpression extends EditableNode {
     return TypeAssert\instance_of(ArrayToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ArrayToken
+   */
+  public function getKeywordx(): ArrayToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -146,6 +153,13 @@ final class ArrayIntrinsicExpression extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getMembersUNTYPED(): EditableNode {
@@ -206,5 +220,12 @@ final class ArrayIntrinsicExpression extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 }

--- a/codegen/syntax/AsExpression.php
+++ b/codegen/syntax/AsExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6935b8880078bebc5813c3dc8cdf22e9>>
+ * @generated SignedSource<<4d550283a3d95f85223e35005e5315d7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -108,6 +108,13 @@ final class AsExpression extends EditableNode {
       TypeAssert\instance_of(VariableExpression::class, $this->_left_operand);
   }
 
+  /**
+   * @returns VariableExpression
+   */
+  public function getLeftOperandx(): VariableExpression {
+    return $this->getLeftOperand();
+  }
+
   public function getOperatorUNTYPED(): EditableNode {
     return $this->_operator;
   }
@@ -128,6 +135,13 @@ final class AsExpression extends EditableNode {
    */
   public function getOperator(): AsToken {
     return TypeAssert\instance_of(AsToken::class, $this->_operator);
+  }
+
+  /**
+   * @returns AsToken
+   */
+  public function getOperatorx(): AsToken {
+    return $this->getOperator();
   }
 
   public function getRightOperandUNTYPED(): EditableNode {
@@ -151,5 +165,13 @@ final class AsExpression extends EditableNode {
    */
   public function getRightOperand(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_operand);
+  }
+
+  /**
+   * @returns NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier
+   * | TupleTypeSpecifier
+   */
+  public function getRightOperandx(): EditableNode {
+    return $this->getRightOperand();
   }
 }

--- a/codegen/syntax/Attribute.php
+++ b/codegen/syntax/Attribute.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e5ab4b4b46c7cc8509fc48ee59b392db>>
+ * @generated SignedSource<<456e3a3bb64052a1ce51ef93fe599e74>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -123,6 +123,13 @@ final class Attribute extends EditableNode {
    */
   public function getName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
+  }
+
+  /**
+   * @returns NameToken
+   */
+  public function getNamex(): NameToken {
+    return $this->getName();
   }
 
   public function getLeftParenUNTYPED(): EditableNode {

--- a/codegen/syntax/AttributeSpecification.php
+++ b/codegen/syntax/AttributeSpecification.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0ef2e559ed47cd2d7163d9770aa57fff>>
+ * @generated SignedSource<<d68d72d3e0d450d23e9157cea44e094c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -112,6 +112,13 @@ final class AttributeSpecification extends EditableNode {
     );
   }
 
+  /**
+   * @returns LessThanLessThanToken
+   */
+  public function getLeftDoubleAnglex(): LessThanLessThanToken {
+    return $this->getLeftDoubleAngle();
+  }
+
   public function getAttributesUNTYPED(): EditableNode {
     return $this->_attributes;
   }
@@ -133,6 +140,13 @@ final class AttributeSpecification extends EditableNode {
    */
   public function getAttributes(): EditableList {
     return TypeAssert\instance_of(EditableList::class, $this->_attributes);
+  }
+
+  /**
+   * @returns EditableList
+   */
+  public function getAttributesx(): EditableList {
+    return $this->getAttributes();
   }
 
   public function getRightDoubleAngleUNTYPED(): EditableNode {
@@ -158,5 +172,12 @@ final class AttributeSpecification extends EditableNode {
       GreaterThanGreaterThanToken::class,
       $this->_right_double_angle,
     );
+  }
+
+  /**
+   * @returns GreaterThanGreaterThanToken
+   */
+  public function getRightDoubleAnglex(): GreaterThanGreaterThanToken {
+    return $this->getRightDoubleAngle();
   }
 }

--- a/codegen/syntax/AwaitableCreationExpression.php
+++ b/codegen/syntax/AwaitableCreationExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d715b339b50dc5b1d3fede9b5226285c>>
+ * @generated SignedSource<<4c05d516d4402601bc43605b8afaebba>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -169,6 +169,13 @@ final class AwaitableCreationExpression extends EditableNode {
     return TypeAssert\instance_of(AsyncToken::class, $this->_async);
   }
 
+  /**
+   * @returns AsyncToken
+   */
+  public function getAsyncx(): AsyncToken {
+    return $this->getAsync();
+  }
+
   public function getCoroutineUNTYPED(): EditableNode {
     return $this->_coroutine;
   }
@@ -194,6 +201,13 @@ final class AwaitableCreationExpression extends EditableNode {
    */
   public function getCoroutine(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_coroutine);
+  }
+
+  /**
+   * @returns Missing
+   */
+  public function getCoroutinex(): EditableNode {
+    return $this->getCoroutine();
   }
 
   public function getCompoundStatementUNTYPED(): EditableNode {
@@ -224,5 +238,12 @@ final class AwaitableCreationExpression extends EditableNode {
       CompoundStatement::class,
       $this->_compound_statement,
     );
+  }
+
+  /**
+   * @returns CompoundStatement
+   */
+  public function getCompoundStatementx(): CompoundStatement {
+    return $this->getCompoundStatement();
   }
 }

--- a/codegen/syntax/AwaitableCreationExpression.php
+++ b/codegen/syntax/AwaitableCreationExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3de282b31b9af19a9d3d2c65146a5556>>
+ * @generated SignedSource<<d715b339b50dc5b1d3fede9b5226285c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -120,10 +120,26 @@ final class AwaitableCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @returns AttributeSpecification | Missing
    */
-  public function getAttributeSpec(): EditableNode {
-    return TypeAssert\instance_of(EditableNode::class, $this->_attribute_spec);
+  public function getAttributeSpec(): ?AttributeSpecification {
+    if ($this->_attribute_spec->isMissing()) {
+      return null;
+    }
+    return TypeAssert\instance_of(
+      AttributeSpecification::class,
+      $this->_attribute_spec,
+    );
+  }
+
+  /**
+   * @returns AttributeSpecification
+   */
+  public function getAttributeSpecx(): AttributeSpecification {
+    return TypeAssert\instance_of(
+      AttributeSpecification::class,
+      $this->_attribute_spec,
+    );
   }
 
   public function getAsyncUNTYPED(): EditableNode {

--- a/codegen/syntax/BinaryExpression.php
+++ b/codegen/syntax/BinaryExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<57018da364d7d8bc3d4992355a769141>>
+ * @generated SignedSource<<4e147f2dc13be1f4a2a15e4c04147b00>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -109,8 +109,8 @@ final class BinaryExpression extends EditableNode {
    * ListExpression | LiteralExpression | MemberSelectionExpression |
    * ObjectCreationExpression | ParenthesizedExpression |
    * PipeVariableExpression | PostfixUnaryExpression | PrefixUnaryExpression |
-   * QualifiedName | SafeMemberSelectionExpression | ScopeResolutionExpression
-   * | SubscriptExpression | NameToken | VariableExpression |
+   * QualifiedName | ScopeResolutionExpression | SubscriptExpression |
+   * RightParenToken | NameToken | VariableExpression |
    * VarrayIntrinsicExpression | VectorIntrinsicExpression
    */
   public function getLeftOperand(): EditableNode {

--- a/codegen/syntax/BinaryExpression.php
+++ b/codegen/syntax/BinaryExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4e147f2dc13be1f4a2a15e4c04147b00>>
+ * @generated SignedSource<<2edd9df3f0491b7ab90aba59f942d42f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -117,6 +117,23 @@ final class BinaryExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_operand);
   }
 
+  /**
+   * @returns AnonymousFunction | ArrayCreationExpression |
+   * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
+   * CollectionLiteralExpression | DarrayIntrinsicExpression |
+   * DictionaryIntrinsicExpression | EmptyExpression | FunctionCallExpression |
+   * InstanceofExpression | IssetExpression | KeysetIntrinsicExpression |
+   * ListExpression | LiteralExpression | MemberSelectionExpression |
+   * ObjectCreationExpression | ParenthesizedExpression |
+   * PipeVariableExpression | PostfixUnaryExpression | PrefixUnaryExpression |
+   * QualifiedName | ScopeResolutionExpression | SubscriptExpression |
+   * RightParenToken | NameToken | VariableExpression |
+   * VarrayIntrinsicExpression | VectorIntrinsicExpression
+   */
+  public function getLeftOperandx(): EditableNode {
+    return $this->getLeftOperand();
+  }
+
   public function getOperatorUNTYPED(): EditableNode {
     return $this->_operator;
   }
@@ -148,6 +165,24 @@ final class BinaryExpression extends EditableNode {
    */
   public function getOperator(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_operator);
+  }
+
+  /**
+   * @returns ExclamationEqualToken | ExclamationEqualEqualToken | PercentToken
+   * | PercentEqualToken | AmpersandToken | AmpersandAmpersandToken |
+   * AmpersandEqualToken | StarToken | StarStarToken | StarStarEqualToken |
+   * StarEqualToken | PlusToken | PlusEqualToken | MinusToken | MinusEqualToken
+   * | DotToken | DotEqualToken | SlashToken | SlashEqualToken | LessThanToken
+   * | LessThanLessThanToken | LessThanLessThanEqualToken | LessThanEqualToken
+   * | LessThanEqualGreaterThanToken | LessThanGreaterThanToken | EqualToken |
+   * EqualEqualToken | EqualEqualEqualToken | GreaterThanToken |
+   * GreaterThanEqualToken | GreaterThanGreaterThanToken |
+   * GreaterThanGreaterThanEqualToken | QuestionColonToken |
+   * QuestionQuestionToken | CaratToken | CaratEqualToken | AndToken | OrToken
+   * | XorToken | BarToken | BarEqualToken | BarGreaterThanToken | BarBarToken
+   */
+  public function getOperatorx(): EditableToken {
+    return $this->getOperator();
   }
 
   public function getRightOperandUNTYPED(): EditableNode {
@@ -185,5 +220,27 @@ final class BinaryExpression extends EditableNode {
    */
   public function getRightOperand(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_operand);
+  }
+
+  /**
+   * @returns AnonymousFunction | ArrayCreationExpression |
+   * ArrayIntrinsicExpression | AwaitableCreationExpression | BinaryExpression
+   * | CastExpression | CollectionLiteralExpression | ConditionalExpression |
+   * DarrayIntrinsicExpression | DictionaryIntrinsicExpression |
+   * EmptyExpression | EvalExpression | FunctionCallExpression |
+   * FunctionCallWithTypeArgumentsExpression | InclusionExpression |
+   * InstanceofExpression | IssetExpression | KeysetIntrinsicExpression |
+   * LambdaExpression | LiteralExpression | MemberSelectionExpression | Missing
+   * | NullableAsExpression | ObjectCreationExpression |
+   * ParenthesizedExpression | Php7AnonymousFunction | PipeVariableExpression |
+   * PostfixUnaryExpression | PrefixUnaryExpression | QualifiedName |
+   * SafeMemberSelectionExpression | ScopeResolutionExpression |
+   * ShapeExpression | SubscriptExpression | QuestionToken | EndOfFileToken |
+   * NameToken | TupleExpression | VariableExpression |
+   * VarrayIntrinsicExpression | VectorIntrinsicExpression | XHPExpression |
+   * YieldExpression | YieldFromExpression
+   */
+  public function getRightOperandx(): EditableNode {
+    return $this->getRightOperand();
   }
 }

--- a/codegen/syntax/BracedExpression.php
+++ b/codegen/syntax/BracedExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<78c204740eecdb395b0b8877e760dd34>>
+ * @generated SignedSource<<f1f81fb6264ff288d313ed18704fee23>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class BracedExpression extends EditableNode {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
+  /**
+   * @returns LeftBraceToken
+   */
+  public function getLeftBracex(): LeftBraceToken {
+    return $this->getLeftBrace();
+  }
+
   public function getExpressionUNTYPED(): EditableNode {
     return $this->_expression;
   }
@@ -132,6 +139,16 @@ final class BracedExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
+  /**
+   * @returns ArrayIntrinsicExpression | BinaryExpression |
+   * CollectionLiteralExpression | FunctionCallExpression | LiteralExpression |
+   * ObjectCreationExpression | PrefixUnaryExpression | SubscriptExpression |
+   * NameToken | VariableExpression
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
+  }
+
   public function getRightBraceUNTYPED(): EditableNode {
     return $this->_right_brace;
   }
@@ -152,5 +169,12 @@ final class BracedExpression extends EditableNode {
    */
   public function getRightBrace(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
+  }
+
+  /**
+   * @returns RightBraceToken
+   */
+  public function getRightBracex(): RightBraceToken {
+    return $this->getRightBrace();
   }
 }

--- a/codegen/syntax/BreakStatement.php
+++ b/codegen/syntax/BreakStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<daf912da6c02896b8127d5a01e18b748>>
+ * @generated SignedSource<<02dcfe295cc34efdc788a07a6045aa56>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class BreakStatement extends EditableNode {
     return TypeAssert\instance_of(BreakToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns BreakToken
+   */
+  public function getKeywordx(): BreakToken {
+    return $this->getKeyword();
+  }
+
   public function getLevelUNTYPED(): EditableNode {
     return $this->_level;
   }
@@ -129,6 +136,13 @@ final class BreakStatement extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_level);
   }
 
+  /**
+   * @returns LiteralExpression | Missing | VariableExpression
+   */
+  public function getLevelx(): EditableNode {
+    return $this->getLevel();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -149,5 +163,12 @@ final class BreakStatement extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/CaseLabel.php
+++ b/codegen/syntax/CaseLabel.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6b7de9c81c79ac433c32d53d501ba864>>
+ * @generated SignedSource<<95ba351dd1e2416868685f615e77dcfc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class CaseLabel extends EditableNode {
     return TypeAssert\instance_of(CaseToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns CaseToken
+   */
+  public function getKeywordx(): CaseToken {
+    return $this->getKeyword();
+  }
+
   public function getExpressionUNTYPED(): EditableNode {
     return $this->_expression;
   }
@@ -131,6 +138,15 @@ final class CaseLabel extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
+  /**
+   * @returns ArrayIntrinsicExpression | FunctionCallExpression |
+   * InstanceofExpression | LiteralExpression | PrefixUnaryExpression |
+   * ScopeResolutionExpression | NameToken | VariableExpression
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
+  }
+
   public function getColonUNTYPED(): EditableNode {
     return $this->_colon;
   }
@@ -151,5 +167,12 @@ final class CaseLabel extends EditableNode {
    */
   public function getColon(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_colon);
+  }
+
+  /**
+   * @returns ColonToken | SemicolonToken
+   */
+  public function getColonx(): EditableToken {
+    return $this->getColon();
   }
 }

--- a/codegen/syntax/CastExpression.php
+++ b/codegen/syntax/CastExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4973b214e45d7c229355920270501df9>>
+ * @generated SignedSource<<8dd5f2ff611b1a1199460338933e50e7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -121,6 +121,13 @@ final class CastExpression extends EditableNode {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
+  }
+
   public function getTypeUNTYPED(): EditableNode {
     return $this->_type;
   }
@@ -150,6 +157,15 @@ final class CastExpression extends EditableNode {
     return TypeAssert\instance_of(EditableToken::class, $this->_type);
   }
 
+  /**
+   * @returns ArrayToken | BinaryToken | BoolToken | BooleanToken | DoubleToken
+   * | FloatToken | IntToken | IntegerToken | ObjectToken | RealToken |
+   * StringToken | UnsetToken
+   */
+  public function getTypex(): EditableToken {
+    return $this->getType();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -171,6 +187,13 @@ final class CastExpression extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 
   public function getOperandUNTYPED(): EditableNode {
@@ -201,5 +224,19 @@ final class CastExpression extends EditableNode {
    */
   public function getOperand(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_operand);
+  }
+
+  /**
+   * @returns AnonymousFunction | ArrayCreationExpression |
+   * ArrayIntrinsicExpression | CastExpression | CollectionLiteralExpression |
+   * DictionaryIntrinsicExpression | FunctionCallExpression |
+   * KeysetIntrinsicExpression | LiteralExpression | MemberSelectionExpression
+   * | ObjectCreationExpression | ParenthesizedExpression |
+   * PostfixUnaryExpression | PrefixUnaryExpression | ScopeResolutionExpression
+   * | SubscriptExpression | NameToken | VariableExpression |
+   * VectorIntrinsicExpression | XHPExpression
+   */
+  public function getOperandx(): EditableNode {
+    return $this->getOperand();
   }
 }

--- a/codegen/syntax/CatchClause.php
+++ b/codegen/syntax/CatchClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<73991e449bfd207a5e8b16af4a0126d2>>
+ * @generated SignedSource<<01c82cc7311f4a11b17b7ef7cb00ebf9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -155,6 +155,13 @@ final class CatchClause extends EditableNode {
     return TypeAssert\instance_of(CatchToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns CatchToken
+   */
+  public function getKeywordx(): CatchToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -184,6 +191,13 @@ final class CatchClause extends EditableNode {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
+  }
+
   public function getTypeUNTYPED(): EditableNode {
     return $this->_type;
   }
@@ -211,6 +225,13 @@ final class CatchClause extends EditableNode {
    */
   public function getType(): SimpleTypeSpecifier {
     return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_type);
+  }
+
+  /**
+   * @returns SimpleTypeSpecifier
+   */
+  public function getTypex(): SimpleTypeSpecifier {
+    return $this->getType();
   }
 
   public function getVariableUNTYPED(): EditableNode {
@@ -281,6 +302,13 @@ final class CatchClause extends EditableNode {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
+  }
+
   public function getBodyUNTYPED(): EditableNode {
     return $this->_body;
   }
@@ -308,5 +336,12 @@ final class CatchClause extends EditableNode {
    */
   public function getBody(): CompoundStatement {
     return TypeAssert\instance_of(CompoundStatement::class, $this->_body);
+  }
+
+  /**
+   * @returns CompoundStatement
+   */
+  public function getBodyx(): CompoundStatement {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/CatchClause.php
+++ b/codegen/syntax/CatchClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e7f8d78d62d9671086fb1bc6007d9909>>
+ * @generated SignedSource<<73991e449bfd207a5e8b16af4a0126d2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -236,9 +236,19 @@ final class CatchClause extends EditableNode {
   }
 
   /**
+   * @returns Missing | VariableToken
+   */
+  public function getVariable(): ?VariableToken {
+    if ($this->_variable->isMissing()) {
+      return null;
+    }
+    return TypeAssert\instance_of(VariableToken::class, $this->_variable);
+  }
+
+  /**
    * @returns VariableToken
    */
-  public function getVariable(): VariableToken {
+  public function getVariablex(): VariableToken {
     return TypeAssert\instance_of(VariableToken::class, $this->_variable);
   }
 

--- a/codegen/syntax/ClassishBody.php
+++ b/codegen/syntax/ClassishBody.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<808b2712dc0a577930341602b1efc9eb>>
+ * @generated SignedSource<<5232838f8ff60af319dd79d5ebec4efe>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -105,6 +105,13 @@ final class ClassishBody extends EditableNode {
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
+  }
+
+  /**
+   * @returns LeftBraceToken
+   */
+  public function getLeftBracex(): LeftBraceToken {
+    return $this->getLeftBrace();
   }
 
   public function getElementsUNTYPED(): EditableNode {

--- a/codegen/syntax/ClassishDeclaration.php
+++ b/codegen/syntax/ClassishDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9810cd1b4a962d468be25c7408a5ae41>>
+ * @generated SignedSource<<aacc19a02f718f9debd29967252ab4da>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -320,6 +320,13 @@ final class ClassishDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ClassToken | InterfaceToken | TraitToken
+   */
+  public function getKeywordx(): EditableToken {
+    return $this->getKeyword();
+  }
+
   public function getNameUNTYPED(): EditableNode {
     return $this->_name;
   }
@@ -351,6 +358,13 @@ final class ClassishDeclaration extends EditableNode {
    */
   public function getName(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_name);
+  }
+
+  /**
+   * @returns XHPClassNameToken | NameToken
+   */
+  public function getNamex(): EditableToken {
+    return $this->getName();
   }
 
   public function getTypeParametersUNTYPED(): EditableNode {
@@ -607,5 +621,12 @@ final class ClassishDeclaration extends EditableNode {
    */
   public function getBody(): ClassishBody {
     return TypeAssert\instance_of(ClassishBody::class, $this->_body);
+  }
+
+  /**
+   * @returns ClassishBody
+   */
+  public function getBodyx(): ClassishBody {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/ClassnameTypeSpecifier.php
+++ b/codegen/syntax/ClassnameTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b44ab76d838f0600d6d4b5f833a1539a>>
+ * @generated SignedSource<<4f8e9dd2cfd49b584d10e29c42d591cf>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -141,6 +141,13 @@ final class ClassnameTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(ClassnameToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ClassnameToken
+   */
+  public function getKeywordx(): ClassnameToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftAngleUNTYPED(): EditableNode {
     return $this->_left_angle;
   }
@@ -207,6 +214,13 @@ final class ClassnameTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
   }
 
+  /**
+   * @returns Missing | SimpleTypeSpecifier | TypeConstant
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
+  }
+
   public function getTrailingCommaUNTYPED(): EditableNode {
     return $this->_trailing_comma;
   }
@@ -233,6 +247,13 @@ final class ClassnameTypeSpecifier extends EditableNode {
    */
   public function getTrailingComma(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_trailing_comma);
+  }
+
+  /**
+   * @returns Missing
+   */
+  public function getTrailingCommax(): EditableNode {
+    return $this->getTrailingComma();
   }
 
   public function getRightAngleUNTYPED(): EditableNode {

--- a/codegen/syntax/ClosureParameterTypeSpecifier.php
+++ b/codegen/syntax/ClosureParameterTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<43b216148c0cf2402f5a0762f1d8d5a5>>
+ * @generated SignedSource<<a4ab78d71700014e147c44ec6c1d44ee>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -124,5 +124,13 @@ final class ClosureParameterTypeSpecifier extends EditableNode {
    */
   public function getType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
+  }
+
+  /**
+   * @returns GenericTypeSpecifier | NullableTypeSpecifier |
+   * SimpleTypeSpecifier | SoftTypeSpecifier | TupleTypeSpecifier | TypeConstant
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
   }
 }

--- a/codegen/syntax/ClosureTypeSpecifier.php
+++ b/codegen/syntax/ClosureTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d3f7279078bcd4efd354a9f507058a54>>
+ * @generated SignedSource<<ee6842306caf0301d345f5bd831deab8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -218,6 +218,13 @@ final class ClosureTypeSpecifier extends EditableNode {
       TypeAssert\instance_of(LeftParenToken::class, $this->_outer_left_paren);
   }
 
+  /**
+   * @returns LeftParenToken
+   */
+  public function getOuterLeftParenx(): LeftParenToken {
+    return $this->getOuterLeftParen();
+  }
+
   public function getCoroutineUNTYPED(): EditableNode {
     return $this->_coroutine;
   }
@@ -293,6 +300,13 @@ final class ClosureTypeSpecifier extends EditableNode {
       TypeAssert\instance_of(FunctionToken::class, $this->_function_keyword);
   }
 
+  /**
+   * @returns FunctionToken
+   */
+  public function getFunctionKeywordx(): FunctionToken {
+    return $this->getFunctionKeyword();
+  }
+
   public function getInnerLeftParenUNTYPED(): EditableNode {
     return $this->_inner_left_paren;
   }
@@ -324,6 +338,13 @@ final class ClosureTypeSpecifier extends EditableNode {
   public function getInnerLeftParen(): LeftParenToken {
     return
       TypeAssert\instance_of(LeftParenToken::class, $this->_inner_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getInnerLeftParenx(): LeftParenToken {
+    return $this->getInnerLeftParen();
   }
 
   public function getParameterListUNTYPED(): EditableNode {
@@ -401,6 +422,13 @@ final class ClosureTypeSpecifier extends EditableNode {
       TypeAssert\instance_of(RightParenToken::class, $this->_inner_right_paren);
   }
 
+  /**
+   * @returns RightParenToken
+   */
+  public function getInnerRightParenx(): RightParenToken {
+    return $this->getInnerRightParen();
+  }
+
   public function getColonUNTYPED(): EditableNode {
     return $this->_colon;
   }
@@ -431,6 +459,13 @@ final class ClosureTypeSpecifier extends EditableNode {
    */
   public function getColon(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
+  }
+
+  /**
+   * @returns ColonToken
+   */
+  public function getColonx(): ColonToken {
+    return $this->getColon();
   }
 
   public function getReturnTypeUNTYPED(): EditableNode {
@@ -466,6 +501,14 @@ final class ClosureTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_return_type);
   }
 
+  /**
+   * @returns ClosureTypeSpecifier | GenericTypeSpecifier |
+   * NullableTypeSpecifier | SimpleTypeSpecifier
+   */
+  public function getReturnTypex(): EditableNode {
+    return $this->getReturnType();
+  }
+
   public function getOuterRightParenUNTYPED(): EditableNode {
     return $this->_outer_right_paren;
   }
@@ -497,5 +540,12 @@ final class ClosureTypeSpecifier extends EditableNode {
   public function getOuterRightParen(): RightParenToken {
     return
       TypeAssert\instance_of(RightParenToken::class, $this->_outer_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getOuterRightParenx(): RightParenToken {
+    return $this->getOuterRightParen();
   }
 }

--- a/codegen/syntax/CollectionLiteralExpression.php
+++ b/codegen/syntax/CollectionLiteralExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d2208f88e93ed2c16037910d65a7c137>>
+ * @generated SignedSource<<3cfdd153df3dea802ca68c6cb24d9106>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class CollectionLiteralExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
   }
 
+  /**
+   * @returns GenericTypeSpecifier | SimpleTypeSpecifier
+   */
+  public function getNamex(): EditableNode {
+    return $this->getName();
+  }
+
   public function getLeftBraceUNTYPED(): EditableNode {
     return $this->_left_brace;
   }
@@ -150,6 +157,13 @@ final class CollectionLiteralExpression extends EditableNode {
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
+  }
+
+  /**
+   * @returns LeftBraceToken
+   */
+  public function getLeftBracex(): LeftBraceToken {
+    return $this->getLeftBrace();
   }
 
   public function getInitializersUNTYPED(): EditableNode {

--- a/codegen/syntax/ConditionalExpression.php
+++ b/codegen/syntax/ConditionalExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c575c5bc984b1984d24ba5326657f279>>
+ * @generated SignedSource<<79a66821bfee55c48d1e1a0e0f5d81a0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -143,6 +143,17 @@ final class ConditionalExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_test);
   }
 
+  /**
+   * @returns BinaryExpression | ConditionalExpression | EmptyExpression |
+   * FunctionCallExpression | InstanceofExpression | IssetExpression |
+   * LiteralExpression | MemberSelectionExpression | ParenthesizedExpression |
+   * PrefixUnaryExpression | ScopeResolutionExpression | SubscriptExpression |
+   * LessThanToken | NameToken | VariableExpression
+   */
+  public function getTestx(): EditableNode {
+    return $this->getTest();
+  }
+
   public function getQuestionUNTYPED(): EditableNode {
     return $this->_question;
   }
@@ -169,6 +180,13 @@ final class ConditionalExpression extends EditableNode {
    */
   public function getQuestion(): QuestionToken {
     return TypeAssert\instance_of(QuestionToken::class, $this->_question);
+  }
+
+  /**
+   * @returns QuestionToken
+   */
+  public function getQuestionx(): QuestionToken {
+    return $this->getQuestion();
   }
 
   public function getConsequenceUNTYPED(): EditableNode {
@@ -203,6 +221,19 @@ final class ConditionalExpression extends EditableNode {
    */
   public function getConsequence(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_consequence);
+  }
+
+  /**
+   * @returns ArrayCreationExpression | ArrayIntrinsicExpression |
+   * BinaryExpression | CastExpression | CollectionLiteralExpression |
+   * FunctionCallExpression | LambdaExpression | LiteralExpression |
+   * MemberSelectionExpression | Missing | ObjectCreationExpression |
+   * ParenthesizedExpression | PrefixUnaryExpression |
+   * ScopeResolutionExpression | SubscriptExpression | NameToken |
+   * VariableExpression
+   */
+  public function getConsequencex(): EditableNode {
+    return $this->getConsequence();
   }
 
   public function getColonUNTYPED(): EditableNode {
@@ -275,5 +306,18 @@ final class ConditionalExpression extends EditableNode {
    */
   public function getAlternative(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_alternative);
+  }
+
+  /**
+   * @returns AnonymousFunction | ArrayCreationExpression |
+   * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
+   * CollectionLiteralExpression | FunctionCallExpression | IssetExpression |
+   * LambdaExpression | LiteralExpression | Missing | ObjectCreationExpression
+   * | ParenthesizedExpression | PrefixUnaryExpression |
+   * ScopeResolutionExpression | SubscriptExpression | NameToken |
+   * TupleExpression | VariableExpression
+   */
+  public function getAlternativex(): EditableNode {
+    return $this->getAlternative();
   }
 }

--- a/codegen/syntax/ConstDeclaration.php
+++ b/codegen/syntax/ConstDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<17e7d4f27ac10e240824a6ba268a5a44>>
+ * @generated SignedSource<<435d290990552f26b47e556c8a120531>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -245,6 +245,13 @@ final class ConstDeclaration extends EditableNode {
     return TypeAssert\instance_of(ConstToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ConstToken
+   */
+  public function getKeywordx(): ConstToken {
+    return $this->getKeyword();
+  }
+
   public function getTypeSpecifierUNTYPED(): EditableNode {
     return $this->_type_specifier;
   }
@@ -276,6 +283,15 @@ final class ConstDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type_specifier);
   }
 
+  /**
+   * @returns ClassnameTypeSpecifier | GenericTypeSpecifier |
+   * KeysetTypeSpecifier | Missing | NullableTypeSpecifier |
+   * SimpleTypeSpecifier | TypeConstant | VectorTypeSpecifier
+   */
+  public function getTypeSpecifierx(): EditableNode {
+    return $this->getTypeSpecifier();
+  }
+
   public function getDeclaratorsUNTYPED(): EditableNode {
     return $this->_declarators;
   }
@@ -305,6 +321,13 @@ final class ConstDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_declarators);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getDeclaratorsx(): EditableList {
+    return $this->getDeclarators();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -332,5 +355,12 @@ final class ConstDeclaration extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/ConstantDeclarator.php
+++ b/codegen/syntax/ConstantDeclarator.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7296058cd62f920b6b206b8ac020141b>>
+ * @generated SignedSource<<5f75ffe89b07fe5e63803feda803e31f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -86,6 +86,13 @@ final class ConstantDeclarator extends EditableNode {
    */
   public function getName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
+  }
+
+  /**
+   * @returns NameToken
+   */
+  public function getNamex(): NameToken {
+    return $this->getName();
   }
 
   public function getInitializerUNTYPED(): EditableNode {

--- a/codegen/syntax/ConstructorCall.php
+++ b/codegen/syntax/ConstructorCall.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2678ae69d62cce7bbef60386306eac27>>
+ * @generated SignedSource<<d05451641bf279755644819c1e0b6ea1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -126,6 +126,16 @@ final class ConstructorCall extends EditableNode {
    */
   public function getType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
+  }
+
+  /**
+   * @returns GenericTypeSpecifier | MemberSelectionExpression |
+   * ParenthesizedExpression | QualifiedName | ScopeResolutionExpression |
+   * SimpleTypeSpecifier | SubscriptExpression | NameToken | ParentToken |
+   * SelfToken | StaticToken | VariableExpression
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
   }
 
   public function getLeftParenUNTYPED(): EditableNode {

--- a/codegen/syntax/ContinueStatement.php
+++ b/codegen/syntax/ContinueStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<dbcb606a61cb80ac4f9b6aa311f84258>>
+ * @generated SignedSource<<9896f323817e6f2a4018fe1ab83ca9ef>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class ContinueStatement extends EditableNode {
     return TypeAssert\instance_of(ContinueToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ContinueToken
+   */
+  public function getKeywordx(): ContinueToken {
+    return $this->getKeyword();
+  }
+
   public function getLevelUNTYPED(): EditableNode {
     return $this->_level;
   }
@@ -129,6 +136,13 @@ final class ContinueStatement extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_level);
   }
 
+  /**
+   * @returns LiteralExpression | Missing | VariableExpression
+   */
+  public function getLevelx(): EditableNode {
+    return $this->getLevel();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -149,5 +163,12 @@ final class ContinueStatement extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/DarrayIntrinsicExpression.php
+++ b/codegen/syntax/DarrayIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c22c8015353ac488a9fb83ee4e83b209>>
+ * @generated SignedSource<<4731e47103175d985586adcaa21f89c0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -151,6 +151,13 @@ final class DarrayIntrinsicExpression extends EditableNode {
     return TypeAssert\instance_of(DarrayToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns DarrayToken
+   */
+  public function getKeywordx(): DarrayToken {
+    return $this->getKeyword();
+  }
+
   public function getExplicitTypeUNTYPED(): EditableNode {
     return $this->_explicit_type;
   }
@@ -177,6 +184,13 @@ final class DarrayIntrinsicExpression extends EditableNode {
    */
   public function getExplicitType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_explicit_type);
+  }
+
+  /**
+   * @returns Missing
+   */
+  public function getExplicitTypex(): EditableNode {
+    return $this->getExplicitType();
   }
 
   public function getLeftBracketUNTYPED(): EditableNode {
@@ -206,6 +220,13 @@ final class DarrayIntrinsicExpression extends EditableNode {
   public function getLeftBracket(): LeftBracketToken {
     return
       TypeAssert\instance_of(LeftBracketToken::class, $this->_left_bracket);
+  }
+
+  /**
+   * @returns LeftBracketToken
+   */
+  public function getLeftBracketx(): LeftBracketToken {
+    return $this->getLeftBracket();
   }
 
   public function getMembersUNTYPED(): EditableNode {
@@ -273,5 +294,12 @@ final class DarrayIntrinsicExpression extends EditableNode {
   public function getRightBracket(): RightBracketToken {
     return
       TypeAssert\instance_of(RightBracketToken::class, $this->_right_bracket);
+  }
+
+  /**
+   * @returns RightBracketToken
+   */
+  public function getRightBracketx(): RightBracketToken {
+    return $this->getRightBracket();
   }
 }

--- a/codegen/syntax/DarrayTypeSpecifier.php
+++ b/codegen/syntax/DarrayTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0472b3a475307c333fcbff46eafb2aaa>>
+ * @generated SignedSource<<ad559af92bbaf5892cc23878b3fc01ae>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -183,6 +183,13 @@ final class DarrayTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(DarrayToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns DarrayToken
+   */
+  public function getKeywordx(): DarrayToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftAngleUNTYPED(): EditableNode {
     return $this->_left_angle;
   }
@@ -211,6 +218,13 @@ final class DarrayTypeSpecifier extends EditableNode {
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
+  }
+
+  /**
+   * @returns LessThanToken
+   */
+  public function getLeftAnglex(): LessThanToken {
+    return $this->getLeftAngle();
   }
 
   public function getKeyUNTYPED(): EditableNode {
@@ -243,6 +257,13 @@ final class DarrayTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_key);
   }
 
+  /**
+   * @returns SimpleTypeSpecifier
+   */
+  public function getKeyx(): SimpleTypeSpecifier {
+    return $this->getKey();
+  }
+
   public function getCommaUNTYPED(): EditableNode {
     return $this->_comma;
   }
@@ -271,6 +292,13 @@ final class DarrayTypeSpecifier extends EditableNode {
    */
   public function getComma(): CommaToken {
     return TypeAssert\instance_of(CommaToken::class, $this->_comma);
+  }
+
+  /**
+   * @returns CommaToken
+   */
+  public function getCommax(): CommaToken {
+    return $this->getComma();
   }
 
   public function getValueUNTYPED(): EditableNode {
@@ -304,6 +332,14 @@ final class DarrayTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_value);
   }
 
+  /**
+   * @returns DarrayTypeSpecifier | SimpleTypeSpecifier | VarrayTypeSpecifier |
+   * VectorArrayTypeSpecifier
+   */
+  public function getValuex(): EditableNode {
+    return $this->getValue();
+  }
+
   public function getTrailingCommaUNTYPED(): EditableNode {
     return $this->_trailing_comma;
   }
@@ -334,6 +370,13 @@ final class DarrayTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_trailing_comma);
   }
 
+  /**
+   * @returns Missing
+   */
+  public function getTrailingCommax(): EditableNode {
+    return $this->getTrailingComma();
+  }
+
   public function getRightAngleUNTYPED(): EditableNode {
     return $this->_right_angle;
   }
@@ -362,5 +405,12 @@ final class DarrayTypeSpecifier extends EditableNode {
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
+  }
+
+  /**
+   * @returns GreaterThanToken
+   */
+  public function getRightAnglex(): GreaterThanToken {
+    return $this->getRightAngle();
   }
 }

--- a/codegen/syntax/DeclareBlockStatement.php
+++ b/codegen/syntax/DeclareBlockStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<13413fa5e68a851b5e255dfd764746e8>>
+ * @generated SignedSource<<3349405ffb9eb9d60befa607625b5239>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -139,6 +139,13 @@ final class DeclareBlockStatement extends EditableNode {
     return TypeAssert\instance_of(DeclareToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns DeclareToken
+   */
+  public function getKeywordx(): DeclareToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -165,6 +172,13 @@ final class DeclareBlockStatement extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getExpressionUNTYPED(): EditableNode {
@@ -195,6 +209,13 @@ final class DeclareBlockStatement extends EditableNode {
     return TypeAssert\instance_of(BinaryExpression::class, $this->_expression);
   }
 
+  /**
+   * @returns BinaryExpression
+   */
+  public function getExpressionx(): BinaryExpression {
+    return $this->getExpression();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -223,6 +244,13 @@ final class DeclareBlockStatement extends EditableNode {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
+  }
+
   public function getBodyUNTYPED(): EditableNode {
     return $this->_body;
   }
@@ -249,5 +277,12 @@ final class DeclareBlockStatement extends EditableNode {
    */
   public function getBody(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_body);
+  }
+
+  /**
+   * @returns AlternateLoopStatement | CompoundStatement
+   */
+  public function getBodyx(): EditableNode {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/DeclareDirectiveStatement.php
+++ b/codegen/syntax/DeclareDirectiveStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a1cd19d65edf2084bfcd5fcc7b7eb424>>
+ * @generated SignedSource<<7d8c2c9395b8ed9305920fb0503663f7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -141,6 +141,13 @@ final class DeclareDirectiveStatement extends EditableNode {
     return TypeAssert\instance_of(DeclareToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns DeclareToken
+   */
+  public function getKeywordx(): DeclareToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -167,6 +174,13 @@ final class DeclareDirectiveStatement extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getExpressionUNTYPED(): EditableNode {
@@ -197,6 +211,13 @@ final class DeclareDirectiveStatement extends EditableNode {
     return TypeAssert\instance_of(BinaryExpression::class, $this->_expression);
   }
 
+  /**
+   * @returns BinaryExpression
+   */
+  public function getExpressionx(): BinaryExpression {
+    return $this->getExpression();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -225,6 +246,13 @@ final class DeclareDirectiveStatement extends EditableNode {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -251,5 +279,12 @@ final class DeclareDirectiveStatement extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/DecoratedExpression.php
+++ b/codegen/syntax/DecoratedExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<15c0b7610bd73908c28b1756846921b0>>
+ * @generated SignedSource<<4631f5bb8f95d42c329389474931b0f3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -93,6 +93,13 @@ final class DecoratedExpression extends EditableNode {
     return TypeAssert\instance_of(EditableToken::class, $this->_decorator);
   }
 
+  /**
+   * @returns AmpersandToken | DotDotDotToken | InoutToken
+   */
+  public function getDecoratorx(): EditableToken {
+    return $this->getDecorator();
+  }
+
   public function getExpressionUNTYPED(): EditableNode {
     return $this->_expression;
   }
@@ -115,5 +122,14 @@ final class DecoratedExpression extends EditableNode {
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
+  }
+
+  /**
+   * @returns ArrayCreationExpression | ArrayIntrinsicExpression |
+   * DecoratedExpression | FunctionCallExpression | ScopeResolutionExpression |
+   * SubscriptExpression | VariableToken | VariableExpression
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
   }
 }

--- a/codegen/syntax/DefaultLabel.php
+++ b/codegen/syntax/DefaultLabel.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bf0010407186cbd4c16374b8aa7875f9>>
+ * @generated SignedSource<<d9bac9601f00d81a1848e52e1c61111a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -88,6 +88,13 @@ final class DefaultLabel extends EditableNode {
     return TypeAssert\instance_of(DefaultToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns DefaultToken
+   */
+  public function getKeywordx(): DefaultToken {
+    return $this->getKeyword();
+  }
+
   public function getColonUNTYPED(): EditableNode {
     return $this->_colon;
   }
@@ -108,5 +115,12 @@ final class DefaultLabel extends EditableNode {
    */
   public function getColon(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_colon);
+  }
+
+  /**
+   * @returns ColonToken | SemicolonToken
+   */
+  public function getColonx(): EditableToken {
+    return $this->getColon();
   }
 }

--- a/codegen/syntax/DefineExpression.php
+++ b/codegen/syntax/DefineExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<10923c70f983ffcd61aa17763757fe27>>
+ * @generated SignedSource<<2605ea4cfecba2e8f18808b07cb2e7e2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class DefineExpression extends EditableNode {
     return TypeAssert\instance_of(DefineToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns DefineToken
+   */
+  public function getKeywordx(): DefineToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -150,6 +157,13 @@ final class DefineExpression extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getArgumentListUNTYPED(): EditableNode {
@@ -214,5 +228,12 @@ final class DefineExpression extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 }

--- a/codegen/syntax/DictionaryIntrinsicExpression.php
+++ b/codegen/syntax/DictionaryIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<706f2197d99c4d013e61fb0603e09ad5>>
+ * @generated SignedSource<<e0f50a896c775a630fe50b1dd6c48d71>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -151,6 +151,13 @@ final class DictionaryIntrinsicExpression extends EditableNode {
     return TypeAssert\instance_of(DictToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns DictToken
+   */
+  public function getKeywordx(): DictToken {
+    return $this->getKeyword();
+  }
+
   public function getExplicitTypeUNTYPED(): EditableNode {
     return $this->_explicit_type;
   }
@@ -177,6 +184,13 @@ final class DictionaryIntrinsicExpression extends EditableNode {
    */
   public function getExplicitType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_explicit_type);
+  }
+
+  /**
+   * @returns Missing
+   */
+  public function getExplicitTypex(): EditableNode {
+    return $this->getExplicitType();
   }
 
   public function getLeftBracketUNTYPED(): EditableNode {
@@ -206,6 +220,13 @@ final class DictionaryIntrinsicExpression extends EditableNode {
   public function getLeftBracket(): LeftBracketToken {
     return
       TypeAssert\instance_of(LeftBracketToken::class, $this->_left_bracket);
+  }
+
+  /**
+   * @returns LeftBracketToken
+   */
+  public function getLeftBracketx(): LeftBracketToken {
+    return $this->getLeftBracket();
   }
 
   public function getMembersUNTYPED(): EditableNode {
@@ -273,5 +294,12 @@ final class DictionaryIntrinsicExpression extends EditableNode {
   public function getRightBracket(): RightBracketToken {
     return
       TypeAssert\instance_of(RightBracketToken::class, $this->_right_bracket);
+  }
+
+  /**
+   * @returns RightBracketToken
+   */
+  public function getRightBracketx(): RightBracketToken {
+    return $this->getRightBracket();
   }
 }

--- a/codegen/syntax/DictionaryTypeSpecifier.php
+++ b/codegen/syntax/DictionaryTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<91d758ed6e69cd48a5b0098a361b814e>>
+ * @generated SignedSource<<e72b20aa22ea0ac65e888726ae273622>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class DictionaryTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(DictToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns DictToken
+   */
+  public function getKeywordx(): DictToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftAngleUNTYPED(): EditableNode {
     return $this->_left_angle;
   }
@@ -146,6 +153,13 @@ final class DictionaryTypeSpecifier extends EditableNode {
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
+  }
+
+  /**
+   * @returns LessThanToken
+   */
+  public function getLeftAnglex(): LessThanToken {
+    return $this->getLeftAngle();
   }
 
   public function getMembersUNTYPED(): EditableNode {
@@ -175,6 +189,13 @@ final class DictionaryTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_members);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getMembersx(): EditableList {
+    return $this->getMembers();
+  }
+
   public function getRightAngleUNTYPED(): EditableNode {
     return $this->_right_angle;
   }
@@ -196,5 +217,12 @@ final class DictionaryTypeSpecifier extends EditableNode {
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
+  }
+
+  /**
+   * @returns GreaterThanToken
+   */
+  public function getRightAnglex(): GreaterThanToken {
+    return $this->getRightAngle();
   }
 }

--- a/codegen/syntax/DoStatement.php
+++ b/codegen/syntax/DoStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f8353810afeb482038ea6a842235405e>>
+ * @generated SignedSource<<210cc98a634bbd2f1b95432e25adab1b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -185,6 +185,13 @@ final class DoStatement
     return TypeAssert\instance_of(DoToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns DoToken
+   */
+  public function getKeywordx(): DoToken {
+    return $this->getKeyword();
+  }
+
   public function getBodyUNTYPED(): EditableNode {
     return $this->_body;
   }
@@ -213,6 +220,13 @@ final class DoStatement
    */
   public function getBody(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_body);
+  }
+
+  /**
+   * @returns CompoundStatement | ExpressionStatement
+   */
+  public function getBodyx(): EditableNode {
+    return $this->getBody();
   }
 
   public function getWhileKeywordUNTYPED(): EditableNode {
@@ -245,6 +259,13 @@ final class DoStatement
     return TypeAssert\instance_of(WhileToken::class, $this->_while_keyword);
   }
 
+  /**
+   * @returns WhileToken
+   */
+  public function getWhileKeywordx(): WhileToken {
+    return $this->getWhileKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -273,6 +294,13 @@ final class DoStatement
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getConditionUNTYPED(): EditableNode {
@@ -306,6 +334,14 @@ final class DoStatement
     return TypeAssert\instance_of(EditableNode::class, $this->_condition);
   }
 
+  /**
+   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * PrefixUnaryExpression | SubscriptExpression | VariableExpression
+   */
+  public function getConditionx(): EditableNode {
+    return $this->getCondition();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -336,6 +372,13 @@ final class DoStatement
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -364,5 +407,12 @@ final class DoStatement
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/EchoStatement.php
+++ b/codegen/syntax/EchoStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<479f97fb3b87fdf8d3a1d9d23ec79444>>
+ * @generated SignedSource<<a2d8557afab5c3c4e79c8bc9c4196c1f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class EchoStatement extends EditableNode {
     return TypeAssert\instance_of(EchoToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns EchoToken
+   */
+  public function getKeywordx(): EchoToken {
+    return $this->getKeyword();
+  }
+
   public function getExpressionsUNTYPED(): EditableNode {
     return $this->_expressions;
   }
@@ -127,6 +134,13 @@ final class EchoStatement extends EditableNode {
    */
   public function getExpressions(): EditableList {
     return TypeAssert\instance_of(EditableList::class, $this->_expressions);
+  }
+
+  /**
+   * @returns EditableList
+   */
+  public function getExpressionsx(): EditableList {
+    return $this->getExpressions();
   }
 
   public function getSemicolonUNTYPED(): EditableNode {

--- a/codegen/syntax/ElementInitializer.php
+++ b/codegen/syntax/ElementInitializer.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9c94bb6e8816923cbf58e6a8aea431f2>>
+ * @generated SignedSource<<23b0ec3cd1d7b9ae07b8ce5b25dfad83>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -113,6 +113,19 @@ final class ElementInitializer extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_key);
   }
 
+  /**
+   * @returns AnonymousFunction | ArrayCreationExpression |
+   * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
+   * CollectionLiteralExpression | DictionaryIntrinsicExpression |
+   * FunctionCallExpression | KeysetIntrinsicExpression | LiteralExpression |
+   * ObjectCreationExpression | ParenthesizedExpression | PrefixUnaryExpression
+   * | QualifiedName | ScopeResolutionExpression | NameToken |
+   * VariableExpression | VectorIntrinsicExpression
+   */
+  public function getKeyx(): EditableNode {
+    return $this->getKey();
+  }
+
   public function getArrowUNTYPED(): EditableNode {
     return $this->_arrow;
   }
@@ -133,6 +146,13 @@ final class ElementInitializer extends EditableNode {
    */
   public function getArrow(): EqualGreaterThanToken {
     return TypeAssert\instance_of(EqualGreaterThanToken::class, $this->_arrow);
+  }
+
+  /**
+   * @returns EqualGreaterThanToken
+   */
+  public function getArrowx(): EqualGreaterThanToken {
+    return $this->getArrow();
   }
 
   public function getValueUNTYPED(): EditableNode {
@@ -164,5 +184,21 @@ final class ElementInitializer extends EditableNode {
    */
   public function getValue(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_value);
+  }
+
+  /**
+   * @returns AnonymousFunction | ArrayCreationExpression |
+   * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
+   * CollectionLiteralExpression | ConditionalExpression |
+   * DarrayIntrinsicExpression | DictionaryIntrinsicExpression |
+   * FunctionCallExpression | IssetExpression | KeysetIntrinsicExpression |
+   * LiteralExpression | MemberSelectionExpression | ObjectCreationExpression |
+   * ParenthesizedExpression | PrefixUnaryExpression | QualifiedName |
+   * ScopeResolutionExpression | SubscriptExpression | NameToken |
+   * TupleExpression | VariableExpression | VarrayIntrinsicExpression |
+   * VectorIntrinsicExpression
+   */
+  public function getValuex(): EditableNode {
+    return $this->getValue();
   }
 }

--- a/codegen/syntax/ElseClause.php
+++ b/codegen/syntax/ElseClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1f0b8669d3d137f44ee59a19816652fb>>
+ * @generated SignedSource<<9699fd92dfc4cc119a4ba5aa0ce70091>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -88,6 +88,13 @@ final class ElseClause extends EditableNode implements IControlFlowStatement {
     return TypeAssert\instance_of(ElseToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ElseToken
+   */
+  public function getKeywordx(): ElseToken {
+    return $this->getKeyword();
+  }
+
   public function getStatementUNTYPED(): EditableNode {
     return $this->_statement;
   }
@@ -109,5 +116,13 @@ final class ElseClause extends EditableNode implements IControlFlowStatement {
    */
   public function getStatement(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_statement);
+  }
+
+  /**
+   * @returns CompoundStatement | EchoStatement | ExpressionStatement |
+   * IfStatement | ReturnStatement
+   */
+  public function getStatementx(): EditableNode {
+    return $this->getStatement();
   }
 }

--- a/codegen/syntax/ElseifClause.php
+++ b/codegen/syntax/ElseifClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d47c15a3900b0984a9925d816bdd7709>>
+ * @generated SignedSource<<37a60033eb697cbd6a30f7c16d580d7b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -141,6 +141,13 @@ final class ElseifClause extends EditableNode implements IControlFlowStatement {
     return TypeAssert\instance_of(ElseifToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ElseifToken
+   */
+  public function getKeywordx(): ElseifToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -167,6 +174,13 @@ final class ElseifClause extends EditableNode implements IControlFlowStatement {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getConditionUNTYPED(): EditableNode {
@@ -198,6 +212,14 @@ final class ElseifClause extends EditableNode implements IControlFlowStatement {
     return TypeAssert\instance_of(EditableNode::class, $this->_condition);
   }
 
+  /**
+   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * VariableExpression
+   */
+  public function getConditionx(): EditableNode {
+    return $this->getCondition();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -226,6 +248,13 @@ final class ElseifClause extends EditableNode implements IControlFlowStatement {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
+  }
+
   public function getStatementUNTYPED(): EditableNode {
     return $this->_statement;
   }
@@ -252,5 +281,12 @@ final class ElseifClause extends EditableNode implements IControlFlowStatement {
    */
   public function getStatement(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_statement);
+  }
+
+  /**
+   * @returns CompoundStatement | ExpressionStatement
+   */
+  public function getStatementx(): EditableNode {
+    return $this->getStatement();
   }
 }

--- a/codegen/syntax/EmbeddedBracedExpression.php
+++ b/codegen/syntax/EmbeddedBracedExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8192bba6de7fd7b962df68305e6edf8b>>
+ * @generated SignedSource<<6aedcde9623d7eef999d29547c7e8136>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class EmbeddedBracedExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_brace);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getLeftBracex(): EditableNode {
+    return $this->getLeftBrace();
+  }
+
   public function getExpressionUNTYPED(): EditableNode {
     return $this->_expression;
   }
@@ -129,6 +136,13 @@ final class EmbeddedBracedExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
+  }
+
   public function getRightBraceUNTYPED(): EditableNode {
     return $this->_right_brace;
   }
@@ -149,5 +163,12 @@ final class EmbeddedBracedExpression extends EditableNode {
    */
   public function getRightBrace(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_brace);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getRightBracex(): EditableNode {
+    return $this->getRightBrace();
   }
 }

--- a/codegen/syntax/EmbeddedMemberSelectionExpression.php
+++ b/codegen/syntax/EmbeddedMemberSelectionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6e20c743da5dc3342c606ea16de0bf1c>>
+ * @generated SignedSource<<b52c96f6a540d86e8fdcc65b7bee57d8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class EmbeddedMemberSelectionExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_object);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getObjectx(): EditableNode {
+    return $this->getObject();
+  }
+
   public function getOperatorUNTYPED(): EditableNode {
     return $this->_operator;
   }
@@ -129,6 +136,13 @@ final class EmbeddedMemberSelectionExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_operator);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getOperatorx(): EditableNode {
+    return $this->getOperator();
+  }
+
   public function getNameUNTYPED(): EditableNode {
     return $this->_name;
   }
@@ -149,5 +163,12 @@ final class EmbeddedMemberSelectionExpression extends EditableNode {
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getNamex(): EditableNode {
+    return $this->getName();
   }
 }

--- a/codegen/syntax/EmbeddedSubscriptExpression.php
+++ b/codegen/syntax/EmbeddedSubscriptExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<91a02bfc4ecc2086565c34931e9342c0>>
+ * @generated SignedSource<<eb64c2d5fe88012704c27434f0a4dead>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class EmbeddedSubscriptExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_receiver);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getReceiverx(): EditableNode {
+    return $this->getReceiver();
+  }
+
   public function getLeftBracketUNTYPED(): EditableNode {
     return $this->_left_bracket;
   }
@@ -150,6 +157,13 @@ final class EmbeddedSubscriptExpression extends EditableNode {
    */
   public function getLeftBracket(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_bracket);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getLeftBracketx(): EditableNode {
+    return $this->getLeftBracket();
   }
 
   public function getIndexUNTYPED(): EditableNode {
@@ -179,6 +193,13 @@ final class EmbeddedSubscriptExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_index);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getIndexx(): EditableNode {
+    return $this->getIndex();
+  }
+
   public function getRightBracketUNTYPED(): EditableNode {
     return $this->_right_bracket;
   }
@@ -200,5 +221,12 @@ final class EmbeddedSubscriptExpression extends EditableNode {
    */
   public function getRightBracket(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_bracket);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getRightBracketx(): EditableNode {
+    return $this->getRightBracket();
   }
 }

--- a/codegen/syntax/EmptyExpression.php
+++ b/codegen/syntax/EmptyExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4320de36889bf43a8b7487b59d4e7fda>>
+ * @generated SignedSource<<30c83cc9eb68ecdf52c6425ea4e80397>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class EmptyExpression extends EditableNode {
     return TypeAssert\instance_of(EmptyToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns EmptyToken
+   */
+  public function getKeywordx(): EmptyToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -150,6 +157,13 @@ final class EmptyExpression extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getArgumentUNTYPED(): EditableNode {
@@ -184,6 +198,18 @@ final class EmptyExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_argument);
   }
 
+  /**
+   * @returns ArrayCreationExpression | ArrayIntrinsicExpression |
+   * BinaryExpression | CollectionLiteralExpression | FunctionCallExpression |
+   * LiteralExpression | MemberSelectionExpression | ObjectCreationExpression |
+   * ParenthesizedExpression | PrefixUnaryExpression |
+   * SafeMemberSelectionExpression | ScopeResolutionExpression |
+   * SubscriptExpression | VariableExpression | XHPExpression
+   */
+  public function getArgumentx(): EditableNode {
+    return $this->getArgument();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -205,5 +231,12 @@ final class EmptyExpression extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 }

--- a/codegen/syntax/EndOfFile.php
+++ b/codegen/syntax/EndOfFile.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d31bc6d08d4acac53b309207c3eb8068>>
+ * @generated SignedSource<<3df2e3b3b1510e2b52c2cb05407af0b0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,5 +75,12 @@ final class EndOfFile extends EditableNode {
    */
   public function getToken(): EndOfFileToken {
     return TypeAssert\instance_of(EndOfFileToken::class, $this->_token);
+  }
+
+  /**
+   * @returns EndOfFileToken
+   */
+  public function getTokenx(): EndOfFileToken {
+    return $this->getToken();
   }
 }

--- a/codegen/syntax/EnumDeclaration.php
+++ b/codegen/syntax/EnumDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2fcb592543cddef5cea9aeda13fc6327>>
+ * @generated SignedSource<<8a8c8be80b3dff997f8176b6f02ec7ae>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -263,6 +263,13 @@ final class EnumDeclaration extends EditableNode {
     return TypeAssert\instance_of(EnumToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns EnumToken
+   */
+  public function getKeywordx(): EnumToken {
+    return $this->getKeyword();
+  }
+
   public function getNameUNTYPED(): EditableNode {
     return $this->_name;
   }
@@ -293,6 +300,13 @@ final class EnumDeclaration extends EditableNode {
    */
   public function getName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
+  }
+
+  /**
+   * @returns NameToken
+   */
+  public function getNamex(): NameToken {
+    return $this->getName();
   }
 
   public function getColonUNTYPED(): EditableNode {
@@ -327,6 +341,13 @@ final class EnumDeclaration extends EditableNode {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
   }
 
+  /**
+   * @returns ColonToken
+   */
+  public function getColonx(): ColonToken {
+    return $this->getColon();
+  }
+
   public function getBaseUNTYPED(): EditableNode {
     return $this->_base;
   }
@@ -358,6 +379,14 @@ final class EnumDeclaration extends EditableNode {
    */
   public function getBase(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_base);
+  }
+
+  /**
+   * @returns ClassnameTypeSpecifier | GenericTypeSpecifier |
+   * SimpleTypeSpecifier
+   */
+  public function getBasex(): EditableNode {
+    return $this->getBase();
   }
 
   public function getTypeUNTYPED(): EditableNode {
@@ -434,6 +463,13 @@ final class EnumDeclaration extends EditableNode {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
+  /**
+   * @returns LeftBraceToken
+   */
+  public function getLeftBracex(): LeftBraceToken {
+    return $this->getLeftBrace();
+  }
+
   public function getEnumeratorsUNTYPED(): EditableNode {
     return $this->_enumerators;
   }
@@ -506,5 +542,12 @@ final class EnumDeclaration extends EditableNode {
    */
   public function getRightBrace(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
+  }
+
+  /**
+   * @returns RightBraceToken
+   */
+  public function getRightBracex(): RightBraceToken {
+    return $this->getRightBrace();
   }
 }

--- a/codegen/syntax/Enumerator.php
+++ b/codegen/syntax/Enumerator.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4382ad41c66d3bdf7c5942c21161ba26>>
+ * @generated SignedSource<<2671fc02b823a6b6d4e4b3a79d3c1952>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -120,6 +120,13 @@ final class Enumerator extends EditableNode {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
   }
 
+  /**
+   * @returns NameToken
+   */
+  public function getNamex(): NameToken {
+    return $this->getName();
+  }
+
   public function getEqualUNTYPED(): EditableNode {
     return $this->_equal;
   }
@@ -140,6 +147,13 @@ final class Enumerator extends EditableNode {
    */
   public function getEqual(): EqualToken {
     return TypeAssert\instance_of(EqualToken::class, $this->_equal);
+  }
+
+  /**
+   * @returns EqualToken
+   */
+  public function getEqualx(): EqualToken {
+    return $this->getEqual();
   }
 
   public function getValueUNTYPED(): EditableNode {
@@ -166,6 +180,15 @@ final class Enumerator extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_value);
   }
 
+  /**
+   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * ObjectCreationExpression | ScopeResolutionExpression | NameToken |
+   * VariableExpression
+   */
+  public function getValuex(): EditableNode {
+    return $this->getValue();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -186,5 +209,12 @@ final class Enumerator extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/Enumerator.php
+++ b/codegen/syntax/Enumerator.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f37edf40d9da7485a22bf09e53526ed3>>
+ * @generated SignedSource<<4382ad41c66d3bdf7c5942c21161ba26>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -158,7 +158,9 @@ final class Enumerator extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression | LiteralExpression | ScopeResolutionExpression
+   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * ObjectCreationExpression | ScopeResolutionExpression | NameToken |
+   * VariableExpression
    */
   public function getValue(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_value);

--- a/codegen/syntax/ErrorSyntax.php
+++ b/codegen/syntax/ErrorSyntax.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e79882ce91eeeab40b1004e7f73cd680>>
+ * @generated SignedSource<<253f742bdd0ff87a4ef6a98ea419c79e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -76,5 +76,13 @@ final class ErrorSyntax extends EditableNode {
    */
   public function getError(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_error);
+  }
+
+  /**
+   * @returns SemicolonToken | EqualToken | DecimalLiteralToken | VariableToken
+   * | RightBraceToken
+   */
+  public function getErrorx(): EditableToken {
+    return $this->getError();
   }
 }

--- a/codegen/syntax/ErrorSyntax.php
+++ b/codegen/syntax/ErrorSyntax.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5fc5fd90e1eac1079e9423423b547b94>>
+ * @generated SignedSource<<e79882ce91eeeab40b1004e7f73cd680>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -71,9 +71,8 @@ final class ErrorSyntax extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken | EqualToken | DecimalLiteralToken | NameToken |
-   * SingleQuotedStringLiteralToken | VariableToken | LeftBraceToken |
-   * RightBraceToken
+   * @returns SemicolonToken | EqualToken | DecimalLiteralToken | VariableToken
+   * | RightBraceToken
    */
   public function getError(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_error);

--- a/codegen/syntax/EvalExpression.php
+++ b/codegen/syntax/EvalExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<63906a1a8df833b0e77e65f4c9c97415>>
+ * @generated SignedSource<<7ab111bb07cd23882503065a30b70382>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class EvalExpression extends EditableNode {
     return TypeAssert\instance_of(EvalToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns EvalToken
+   */
+  public function getKeywordx(): EvalToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -150,6 +157,13 @@ final class EvalExpression extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getArgumentUNTYPED(): EditableNode {
@@ -180,6 +194,14 @@ final class EvalExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_argument);
   }
 
+  /**
+   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * VariableExpression
+   */
+  public function getArgumentx(): EditableNode {
+    return $this->getArgument();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -201,5 +223,12 @@ final class EvalExpression extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 }

--- a/codegen/syntax/ExpressionStatement.php
+++ b/codegen/syntax/ExpressionStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7695925d181eaed7c1fba5ad9187db4e>>
+ * @generated SignedSource<<d2dcebcb458a017ce8453f87bd1766dd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -104,6 +104,26 @@ final class ExpressionStatement extends EditableNode {
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
+  }
+
+  /**
+   * @returns AnonymousFunction | AsExpression | BinaryExpression |
+   * CastExpression | CollectionLiteralExpression | ConditionalExpression |
+   * DarrayIntrinsicExpression | DefineExpression | EmptyExpression |
+   * EvalExpression | FunctionCallExpression |
+   * FunctionCallWithTypeArgumentsExpression | HaltCompilerExpression |
+   * InclusionExpression | IssetExpression | LambdaExpression |
+   * LiteralExpression | MemberSelectionExpression | Missing |
+   * ObjectCreationExpression | ParenthesizedExpression |
+   * PostfixUnaryExpression | PrefixUnaryExpression | QualifiedName |
+   * SafeMemberSelectionExpression | ScopeResolutionExpression |
+   * SubscriptExpression | RightParenToken | CommaToken | ColonToken |
+   * EqualEqualEqualToken | QuestionToken | NameToken | RightBraceToken |
+   * TupleExpression | VariableExpression | VarrayIntrinsicExpression |
+   * XHPExpression | YieldExpression | YieldFromExpression
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
   }
 
   public function getSemicolonUNTYPED(): EditableNode {

--- a/codegen/syntax/ExpressionStatement.php
+++ b/codegen/syntax/ExpressionStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7ed9dbfc844219135ef0959a6e89264c>>
+ * @generated SignedSource<<7695925d181eaed7c1fba5ad9187db4e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -98,10 +98,9 @@ final class ExpressionStatement extends EditableNode {
    * PostfixUnaryExpression | PrefixUnaryExpression | QualifiedName |
    * SafeMemberSelectionExpression | ScopeResolutionExpression |
    * SubscriptExpression | RightParenToken | CommaToken | ColonToken |
-   * EqualEqualEqualToken | EqualGreaterThanToken | RightBracketToken |
-   * NameToken | RightBraceToken | TupleExpression | VariableExpression |
-   * VarrayIntrinsicExpression | XHPExpression | YieldExpression |
-   * YieldFromExpression
+   * EqualEqualEqualToken | QuestionToken | NameToken | RightBraceToken |
+   * TupleExpression | VariableExpression | VarrayIntrinsicExpression |
+   * XHPExpression | YieldExpression | YieldFromExpression
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);

--- a/codegen/syntax/FieldInitializer.php
+++ b/codegen/syntax/FieldInitializer.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<62bd9dcb730aed229312d895a03c7907>>
+ * @generated SignedSource<<8d3d6bf7a6380854daa1f53da66d52ac>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -108,6 +108,14 @@ final class FieldInitializer extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
   }
 
+  /**
+   * @returns LiteralExpression | ScopeResolutionExpression | QuestionToken |
+   * NameToken | VariableExpression
+   */
+  public function getNamex(): EditableNode {
+    return $this->getName();
+  }
+
   public function getArrowUNTYPED(): EditableNode {
     return $this->_arrow;
   }
@@ -128,6 +136,13 @@ final class FieldInitializer extends EditableNode {
    */
   public function getArrow(): EqualGreaterThanToken {
     return TypeAssert\instance_of(EqualGreaterThanToken::class, $this->_arrow);
+  }
+
+  /**
+   * @returns EqualGreaterThanToken
+   */
+  public function getArrowx(): EqualGreaterThanToken {
+    return $this->getArrow();
   }
 
   public function getValueUNTYPED(): EditableNode {
@@ -153,5 +168,15 @@ final class FieldInitializer extends EditableNode {
    */
   public function getValue(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_value);
+  }
+
+  /**
+   * @returns ArrayIntrinsicExpression | BinaryExpression | LambdaExpression |
+   * LiteralExpression | ObjectCreationExpression | ScopeResolutionExpression |
+   * SubscriptExpression | NameToken | VariableExpression |
+   * VectorIntrinsicExpression
+   */
+  public function getValuex(): EditableNode {
+    return $this->getValue();
   }
 }

--- a/codegen/syntax/FieldSpecifier.php
+++ b/codegen/syntax/FieldSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a3ea03aaa181a2d015dbe187326b1dbc>>
+ * @generated SignedSource<<20e9c12c032964dc6085ec1e21a9b40c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -152,6 +152,13 @@ final class FieldSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
   }
 
+  /**
+   * @returns LiteralExpression | ScopeResolutionExpression
+   */
+  public function getNamex(): EditableNode {
+    return $this->getName();
+  }
+
   public function getArrowUNTYPED(): EditableNode {
     return $this->_arrow;
   }
@@ -172,6 +179,13 @@ final class FieldSpecifier extends EditableNode {
    */
   public function getArrow(): EqualGreaterThanToken {
     return TypeAssert\instance_of(EqualGreaterThanToken::class, $this->_arrow);
+  }
+
+  /**
+   * @returns EqualGreaterThanToken
+   */
+  public function getArrowx(): EqualGreaterThanToken {
+    return $this->getArrow();
   }
 
   public function getTypeUNTYPED(): EditableNode {
@@ -196,5 +210,14 @@ final class FieldSpecifier extends EditableNode {
    */
   public function getType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
+  }
+
+  /**
+   * @returns ClosureTypeSpecifier | GenericTypeSpecifier |
+   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
+   * TypeConstant
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
   }
 }

--- a/codegen/syntax/FinallyClause.php
+++ b/codegen/syntax/FinallyClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6c7273f5e03a8104a83f02ada54bf787>>
+ * @generated SignedSource<<1cdab1a5365210762fadedd2153ced8a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -88,6 +88,13 @@ final class FinallyClause extends EditableNode {
     return TypeAssert\instance_of(FinallyToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns FinallyToken
+   */
+  public function getKeywordx(): FinallyToken {
+    return $this->getKeyword();
+  }
+
   public function getBodyUNTYPED(): EditableNode {
     return $this->_body;
   }
@@ -108,5 +115,12 @@ final class FinallyClause extends EditableNode {
    */
   public function getBody(): CompoundStatement {
     return TypeAssert\instance_of(CompoundStatement::class, $this->_body);
+  }
+
+  /**
+   * @returns CompoundStatement
+   */
+  public function getBodyx(): CompoundStatement {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/ForStatement.php
+++ b/codegen/syntax/ForStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e6bf487c174a4f24c0aba9e394c6b6f7>>
+ * @generated SignedSource<<983211e08d6ae99f64c5b683629cc36d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -217,6 +217,13 @@ final class ForStatement
     return TypeAssert\instance_of(ForToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ForToken
+   */
+  public function getKeywordx(): ForToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -247,6 +254,13 @@ final class ForStatement
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getInitializerUNTYPED(): EditableNode {
@@ -324,6 +338,13 @@ final class ForStatement
       TypeAssert\instance_of(SemicolonToken::class, $this->_first_semicolon);
   }
 
+  /**
+   * @returns SemicolonToken
+   */
+  public function getFirstSemicolonx(): SemicolonToken {
+    return $this->getFirstSemicolon();
+  }
+
   public function getControlUNTYPED(): EditableNode {
     return $this->_control;
   }
@@ -397,6 +418,13 @@ final class ForStatement
   public function getSecondSemicolon(): SemicolonToken {
     return
       TypeAssert\instance_of(SemicolonToken::class, $this->_second_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSecondSemicolonx(): SemicolonToken {
+    return $this->getSecondSemicolon();
   }
 
   public function getEndOfLoopUNTYPED(): EditableNode {
@@ -473,6 +501,13 @@ final class ForStatement
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
+  }
+
   public function getBodyUNTYPED(): EditableNode {
     return $this->_body;
   }
@@ -504,5 +539,13 @@ final class ForStatement
    */
   public function getBody(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_body);
+  }
+
+  /**
+   * @returns AlternateLoopStatement | CompoundStatement | EchoStatement |
+   * ExpressionStatement | ForStatement | UnsetStatement
+   */
+  public function getBodyx(): EditableNode {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/ForeachStatement.php
+++ b/codegen/syntax/ForeachStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c72d71445930f0f4041f93e893c7cc52>>
+ * @generated SignedSource<<c1892b4ad61e37a27458c37af5080231>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -297,8 +297,8 @@ final class ForeachStatement
    * ArrayIntrinsicExpression | CastExpression | CollectionLiteralExpression |
    * FunctionCallExpression | MemberSelectionExpression |
    * ObjectCreationExpression | ParenthesizedExpression | PrefixUnaryExpression
-   * | ScopeResolutionExpression | SubscriptExpression | VariableExpression |
-   * VectorIntrinsicExpression
+   * | ScopeResolutionExpression | SubscriptExpression | NameToken |
+   * VariableExpression | VectorIntrinsicExpression
    */
   public function getCollection(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_collection);
@@ -409,7 +409,8 @@ final class ForeachStatement
   /**
    * @returns FunctionCallExpression | ListExpression |
    * MemberSelectionExpression | Missing | PrefixUnaryExpression |
-   * ScopeResolutionExpression | SubscriptExpression | VariableExpression
+   * ScopeResolutionExpression | SubscriptExpression | NameToken |
+   * VariableExpression
    */
   public function getKey(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_key);
@@ -487,7 +488,8 @@ final class ForeachStatement
   /**
    * @returns ArrayCreationExpression | FunctionCallExpression | ListExpression
    * | MemberSelectionExpression | PrefixUnaryExpression |
-   * ScopeResolutionExpression | SubscriptExpression | VariableExpression
+   * ScopeResolutionExpression | SubscriptExpression | NameToken |
+   * VariableExpression
    */
   public function getValue(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_value);

--- a/codegen/syntax/ForeachStatement.php
+++ b/codegen/syntax/ForeachStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c1892b4ad61e37a27458c37af5080231>>
+ * @generated SignedSource<<ba2dd6fbfab49d4d13070ed28b887840>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -233,6 +233,13 @@ final class ForeachStatement
     return TypeAssert\instance_of(ForeachToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ForeachToken
+   */
+  public function getKeywordx(): ForeachToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -264,6 +271,13 @@ final class ForeachStatement
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getCollectionUNTYPED(): EditableNode {
@@ -302,6 +316,18 @@ final class ForeachStatement
    */
   public function getCollection(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_collection);
+  }
+
+  /**
+   * @returns AnonymousFunction | ArrayCreationExpression |
+   * ArrayIntrinsicExpression | CastExpression | CollectionLiteralExpression |
+   * FunctionCallExpression | MemberSelectionExpression |
+   * ObjectCreationExpression | ParenthesizedExpression | PrefixUnaryExpression
+   * | ScopeResolutionExpression | SubscriptExpression | NameToken |
+   * VariableExpression | VectorIntrinsicExpression
+   */
+  public function getCollectionx(): EditableNode {
+    return $this->getCollection();
   }
 
   public function getAwaitKeywordUNTYPED(): EditableNode {
@@ -380,6 +406,13 @@ final class ForeachStatement
     return TypeAssert\instance_of(AsToken::class, $this->_as);
   }
 
+  /**
+   * @returns AsToken
+   */
+  public function getAsx(): AsToken {
+    return $this->getAs();
+  }
+
   public function getKeyUNTYPED(): EditableNode {
     return $this->_key;
   }
@@ -414,6 +447,16 @@ final class ForeachStatement
    */
   public function getKey(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_key);
+  }
+
+  /**
+   * @returns FunctionCallExpression | ListExpression |
+   * MemberSelectionExpression | Missing | PrefixUnaryExpression |
+   * ScopeResolutionExpression | SubscriptExpression | NameToken |
+   * VariableExpression
+   */
+  public function getKeyx(): EditableNode {
+    return $this->getKey();
   }
 
   public function getArrowUNTYPED(): EditableNode {
@@ -495,6 +538,16 @@ final class ForeachStatement
     return TypeAssert\instance_of(EditableNode::class, $this->_value);
   }
 
+  /**
+   * @returns ArrayCreationExpression | FunctionCallExpression | ListExpression
+   * | MemberSelectionExpression | PrefixUnaryExpression |
+   * ScopeResolutionExpression | SubscriptExpression | NameToken |
+   * VariableExpression
+   */
+  public function getValuex(): EditableNode {
+    return $this->getValue();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -526,6 +579,13 @@ final class ForeachStatement
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 
   public function getBodyUNTYPED(): EditableNode {
@@ -560,5 +620,13 @@ final class ForeachStatement
    */
   public function getBody(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_body);
+  }
+
+  /**
+   * @returns AlternateLoopStatement | CompoundStatement | EchoStatement |
+   * ExpressionStatement | ForeachStatement
+   */
+  public function getBodyx(): EditableNode {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/FunctionCallExpression.php
+++ b/codegen/syntax/FunctionCallExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<be2738836b76bf8767a551c0118c9769>>
+ * @generated SignedSource<<24b569dfde14de90fa6d0d80c3164b57>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -129,6 +129,17 @@ final class FunctionCallExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_receiver);
   }
 
+  /**
+   * @returns ArrayCreationExpression | FunctionCallExpression |
+   * LiteralExpression | MemberSelectionExpression | ParenthesizedExpression |
+   * PrefixUnaryExpression | QualifiedName | SafeMemberSelectionExpression |
+   * ScopeResolutionExpression | SubscriptExpression | NameToken |
+   * VariableExpression
+   */
+  public function getReceiverx(): EditableNode {
+    return $this->getReceiver();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -154,6 +165,13 @@ final class FunctionCallExpression extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getArgumentListUNTYPED(): EditableNode {

--- a/codegen/syntax/FunctionCallWithTypeArgumentsExpression.php
+++ b/codegen/syntax/FunctionCallWithTypeArgumentsExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<18091493a288d2c05af265fae11b1e31>>
+ * @generated SignedSource<<77773aef426dfda373fbcc4f9f55b759>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -151,6 +151,13 @@ final class FunctionCallWithTypeArgumentsExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_receiver);
   }
 
+  /**
+   * @returns MemberSelectionExpression | ScopeResolutionExpression | NameToken
+   */
+  public function getReceiverx(): EditableNode {
+    return $this->getReceiver();
+  }
+
   public function getTypeArgsUNTYPED(): EditableNode {
     return $this->_type_args;
   }
@@ -177,6 +184,13 @@ final class FunctionCallWithTypeArgumentsExpression extends EditableNode {
    */
   public function getTypeArgs(): TypeArguments {
     return TypeAssert\instance_of(TypeArguments::class, $this->_type_args);
+  }
+
+  /**
+   * @returns TypeArguments
+   */
+  public function getTypeArgsx(): TypeArguments {
+    return $this->getTypeArgs();
   }
 
   public function getLeftParenUNTYPED(): EditableNode {

--- a/codegen/syntax/FunctionCallWithTypeArgumentsExpression.php
+++ b/codegen/syntax/FunctionCallWithTypeArgumentsExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9f00c01449f484be6705d5d4c2cf7741>>
+ * @generated SignedSource<<18091493a288d2c05af265fae11b1e31>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -201,9 +201,19 @@ final class FunctionCallWithTypeArgumentsExpression extends EditableNode {
   }
 
   /**
+   * @returns Missing | LeftParenToken
+   */
+  public function getLeftParen(): ?LeftParenToken {
+    if ($this->_left_paren->isMissing()) {
+      return null;
+    }
+    return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
    * @returns LeftParenToken
    */
-  public function getLeftParen(): LeftParenToken {
+  public function getLeftParenx(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
@@ -267,9 +277,19 @@ final class FunctionCallWithTypeArgumentsExpression extends EditableNode {
   }
 
   /**
+   * @returns Missing | RightParenToken
+   */
+  public function getRightParen(): ?RightParenToken {
+    if ($this->_right_paren->isMissing()) {
+      return null;
+    }
+    return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
    * @returns RightParenToken
    */
-  public function getRightParen(): RightParenToken {
+  public function getRightParenx(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 }

--- a/codegen/syntax/FunctionDeclaration.php
+++ b/codegen/syntax/FunctionDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a72aba47f0fb9e106a4020bca26a131c>>
+ * @generated SignedSource<<8ee59ad4dddb860c7026d2fcb8459ec0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -151,6 +151,13 @@ final class FunctionDeclaration
     );
   }
 
+  /**
+   * @returns FunctionDeclarationHeader
+   */
+  public function getDeclarationHeaderx(): FunctionDeclarationHeader {
+    return $this->getDeclarationHeader();
+  }
+
   public function getBodyUNTYPED(): EditableNode {
     return $this->_body;
   }
@@ -172,5 +179,12 @@ final class FunctionDeclaration
    */
   public function getBody(): CompoundStatement {
     return TypeAssert\instance_of(CompoundStatement::class, $this->_body);
+  }
+
+  /**
+   * @returns CompoundStatement
+   */
+  public function getBodyx(): CompoundStatement {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/FunctionDeclarationHeader.php
+++ b/codegen/syntax/FunctionDeclarationHeader.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ee0ea422e0dfff909e7de1b59b1c53b0>>
+ * @generated SignedSource<<18dbdd6bbfae4a1b8715c642ec82dfe3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -380,6 +380,13 @@ final class FunctionDeclarationHeader extends EditableNode {
     return TypeAssert\instance_of(EditableToken::class, $this->_name);
   }
 
+  /**
+   * @returns ConstructToken | DestructToken | NameToken
+   */
+  public function getNamex(): EditableToken {
+    return $this->getName();
+  }
+
   public function getTypeParameterListUNTYPED(): EditableNode {
     return $this->_type_parameter_list;
   }
@@ -643,6 +650,18 @@ final class FunctionDeclarationHeader extends EditableNode {
    */
   public function getType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
+  }
+
+  /**
+   * @returns ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * DarrayTypeSpecifier | DictionaryTypeSpecifier | GenericTypeSpecifier |
+   * KeysetTypeSpecifier | MapArrayTypeSpecifier | Missing |
+   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
+   * SoftTypeSpecifier | NoreturnToken | TupleTypeSpecifier | TypeConstant |
+   * VarrayTypeSpecifier | VectorArrayTypeSpecifier | VectorTypeSpecifier
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
   }
 
   public function getWhereClauseUNTYPED(): EditableNode {

--- a/codegen/syntax/FunctionStaticStatement.php
+++ b/codegen/syntax/FunctionStaticStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8a5fb84e77bd3b0dfd074ce2fc504c7b>>
+ * @generated SignedSource<<fd8d88c76e9441d2d980ec2808e7f11b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class FunctionStaticStatement extends EditableNode {
     return TypeAssert\instance_of(StaticToken::class, $this->_static_keyword);
   }
 
+  /**
+   * @returns StaticToken
+   */
+  public function getStaticKeywordx(): StaticToken {
+    return $this->getStaticKeyword();
+  }
+
   public function getDeclarationsUNTYPED(): EditableNode {
     return $this->_declarations;
   }
@@ -129,6 +136,13 @@ final class FunctionStaticStatement extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_declarations);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getDeclarationsx(): EditableList {
+    return $this->getDeclarations();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -149,5 +163,12 @@ final class FunctionStaticStatement extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/GenericTypeSpecifier.php
+++ b/codegen/syntax/GenericTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c1c3c0e416f8255538326a43ba5921cb>>
+ * @generated SignedSource<<cf7142ff4986e7e4130b7ec18bdd4e4c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -94,6 +94,13 @@ final class GenericTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_class_type);
   }
 
+  /**
+   * @returns QualifiedName | XHPClassNameToken | NameToken | StringToken
+   */
+  public function getClassTypex(): EditableNode {
+    return $this->getClassType();
+  }
+
   public function getArgumentListUNTYPED(): EditableNode {
     return $this->_argument_list;
   }
@@ -114,5 +121,12 @@ final class GenericTypeSpecifier extends EditableNode {
    */
   public function getArgumentList(): TypeArguments {
     return TypeAssert\instance_of(TypeArguments::class, $this->_argument_list);
+  }
+
+  /**
+   * @returns TypeArguments
+   */
+  public function getArgumentListx(): TypeArguments {
+    return $this->getArgumentList();
   }
 }

--- a/codegen/syntax/GlobalStatement.php
+++ b/codegen/syntax/GlobalStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c3ba45dee2aa861ea5cd1036c90abb0d>>
+ * @generated SignedSource<<728484dd63fe3215858e79caeb8882d3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class GlobalStatement extends EditableNode {
     return TypeAssert\instance_of(GlobalToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns GlobalToken
+   */
+  public function getKeywordx(): GlobalToken {
+    return $this->getKeyword();
+  }
+
   public function getVariablesUNTYPED(): EditableNode {
     return $this->_variables;
   }
@@ -129,6 +136,13 @@ final class GlobalStatement extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_variables);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getVariablesx(): EditableList {
+    return $this->getVariables();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -149,5 +163,12 @@ final class GlobalStatement extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/GotoLabel.php
+++ b/codegen/syntax/GotoLabel.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<82b080dfcbda62af9e09655d0cdec139>>
+ * @generated SignedSource<<8a0298be636102197b9fb4147f982ad6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -88,6 +88,13 @@ final class GotoLabel extends EditableNode {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
   }
 
+  /**
+   * @returns NameToken
+   */
+  public function getNamex(): NameToken {
+    return $this->getName();
+  }
+
   public function getColonUNTYPED(): EditableNode {
     return $this->_colon;
   }
@@ -108,5 +115,12 @@ final class GotoLabel extends EditableNode {
    */
   public function getColon(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
+  }
+
+  /**
+   * @returns ColonToken
+   */
+  public function getColonx(): ColonToken {
+    return $this->getColon();
   }
 }

--- a/codegen/syntax/GotoStatement.php
+++ b/codegen/syntax/GotoStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cf8cf998cc7743b7820088302d156b33>>
+ * @generated SignedSource<<86aed5631ecd41c48b6514aee44a2cc1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class GotoStatement extends EditableNode {
     return TypeAssert\instance_of(GotoToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns GotoToken
+   */
+  public function getKeywordx(): GotoToken {
+    return $this->getKeyword();
+  }
+
   public function getLabelNameUNTYPED(): EditableNode {
     return $this->_label_name;
   }
@@ -129,6 +136,13 @@ final class GotoStatement extends EditableNode {
     return TypeAssert\instance_of(NameToken::class, $this->_label_name);
   }
 
+  /**
+   * @returns NameToken
+   */
+  public function getLabelNamex(): NameToken {
+    return $this->getLabelName();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -149,5 +163,12 @@ final class GotoStatement extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/HaltCompilerExpression.php
+++ b/codegen/syntax/HaltCompilerExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<115b259ab3659abb4ea4bd3c370b25de>>
+ * @generated SignedSource<<1525892495571d1bca5958880a7ea1c6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class HaltCompilerExpression extends EditableNode {
     return TypeAssert\instance_of(HaltCompilerToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns HaltCompilerToken
+   */
+  public function getKeywordx(): HaltCompilerToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -150,6 +157,13 @@ final class HaltCompilerExpression extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getArgumentListUNTYPED(): EditableNode {
@@ -179,6 +193,13 @@ final class HaltCompilerExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_argument_list);
   }
 
+  /**
+   * @returns Missing
+   */
+  public function getArgumentListx(): EditableNode {
+    return $this->getArgumentList();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -204,5 +225,12 @@ final class HaltCompilerExpression extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 }

--- a/codegen/syntax/IfStatement.php
+++ b/codegen/syntax/IfStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f7f01179ec66cd829b14adb4fc584bd3>>
+ * @generated SignedSource<<0004a01938edd15b1d5da416524f3e60>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -183,6 +183,13 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
     return TypeAssert\instance_of(IfToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns IfToken
+   */
+  public function getKeywordx(): IfToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -211,6 +218,13 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getConditionUNTYPED(): EditableNode {
@@ -248,6 +262,18 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
     return TypeAssert\instance_of(EditableNode::class, $this->_condition);
   }
 
+  /**
+   * @returns ArrayIntrinsicExpression | AsExpression | BinaryExpression |
+   * CastExpression | EmptyExpression | FunctionCallExpression |
+   * InstanceofExpression | IsExpression | IssetExpression | LiteralExpression
+   * | MemberSelectionExpression | ParenthesizedExpression |
+   * PrefixUnaryExpression | QualifiedName | ScopeResolutionExpression |
+   * SubscriptExpression | NameToken | VariableExpression
+   */
+  public function getConditionx(): EditableNode {
+    return $this->getCondition();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -276,6 +302,13 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 
   public function getStatementUNTYPED(): EditableNode {
@@ -308,6 +341,15 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
    */
   public function getStatement(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_statement);
+  }
+
+  /**
+   * @returns BreakStatement | CompoundStatement | ContinueStatement |
+   * EchoStatement | ExpressionStatement | GlobalStatement | GotoStatement |
+   * ReturnStatement | ThrowStatement | UnsetStatement
+   */
+  public function getStatementx(): EditableNode {
+    return $this->getStatement();
   }
 
   public function getElseifClausesUNTYPED(): EditableNode {

--- a/codegen/syntax/InclusionDirective.php
+++ b/codegen/syntax/InclusionDirective.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<42881a652b8bfd4ba526aabe50e27393>>
+ * @generated SignedSource<<83a55a9df91186c9e378cc690d403865>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -94,6 +94,13 @@ final class InclusionDirective extends EditableNode {
       TypeAssert\instance_of(InclusionExpression::class, $this->_expression);
   }
 
+  /**
+   * @returns InclusionExpression
+   */
+  public function getExpressionx(): InclusionExpression {
+    return $this->getExpression();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -114,5 +121,12 @@ final class InclusionDirective extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/InclusionExpression.php
+++ b/codegen/syntax/InclusionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f40a09b997106e1975710a4b9298617e>>
+ * @generated SignedSource<<4f5556b44e4f860ef90aaca8b92bd5e2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -89,6 +89,14 @@ final class InclusionExpression extends EditableNode {
     return TypeAssert\instance_of(EditableToken::class, $this->_require);
   }
 
+  /**
+   * @returns IncludeToken | Include_onceToken | RequireToken |
+   * Require_onceToken
+   */
+  public function getRequirex(): EditableToken {
+    return $this->getRequire();
+  }
+
   public function getFilenameUNTYPED(): EditableNode {
     return $this->_filename;
   }
@@ -110,5 +118,13 @@ final class InclusionExpression extends EditableNode {
    */
   public function getFilename(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_filename);
+  }
+
+  /**
+   * @returns BinaryExpression | LiteralExpression | ParenthesizedExpression |
+   * SubscriptExpression | NameToken | VariableExpression
+   */
+  public function getFilenamex(): EditableNode {
+    return $this->getFilename();
   }
 }

--- a/codegen/syntax/InstanceofExpression.php
+++ b/codegen/syntax/InstanceofExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<224f9a8ea8b5f8ec483f25f3835be60e>>
+ * @generated SignedSource<<14519d6ab45e6ffcbeb2955184bb0c62>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -110,6 +110,16 @@ final class InstanceofExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_operand);
   }
 
+  /**
+   * @returns AnonymousFunction | CastExpression | FunctionCallExpression |
+   * LiteralExpression | MemberSelectionExpression | ObjectCreationExpression |
+   * ParenthesizedExpression | PrefixUnaryExpression |
+   * ScopeResolutionExpression | SubscriptExpression | VariableExpression
+   */
+  public function getLeftOperandx(): EditableNode {
+    return $this->getLeftOperand();
+  }
+
   public function getOperatorUNTYPED(): EditableNode {
     return $this->_operator;
   }
@@ -130,6 +140,13 @@ final class InstanceofExpression extends EditableNode {
    */
   public function getOperator(): InstanceofToken {
     return TypeAssert\instance_of(InstanceofToken::class, $this->_operator);
+  }
+
+  /**
+   * @returns InstanceofToken
+   */
+  public function getOperatorx(): InstanceofToken {
+    return $this->getOperator();
   }
 
   public function getRightOperandUNTYPED(): EditableNode {
@@ -154,5 +171,14 @@ final class InstanceofExpression extends EditableNode {
    */
   public function getRightOperand(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_operand);
+  }
+
+  /**
+   * @returns MemberSelectionExpression | ParenthesizedExpression |
+   * QualifiedName | ScopeResolutionExpression | SubscriptExpression |
+   * NameToken | VariableExpression
+   */
+  public function getRightOperandx(): EditableNode {
+    return $this->getRightOperand();
   }
 }

--- a/codegen/syntax/IsExpression.php
+++ b/codegen/syntax/IsExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<31d074f0c3cc765af95d5460e00588c7>>
+ * @generated SignedSource<<e7521504eac9c931bb6f1bd965e934dd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -146,8 +146,10 @@ final class IsExpression extends EditableNode {
   }
 
   /**
-   * @returns GenericTypeSpecifier | NullableTypeSpecifier | ShapeTypeSpecifier
-   * | SimpleTypeSpecifier | TupleTypeSpecifier | TypeConstant
+   * @returns ClosureTypeSpecifier | DictionaryTypeSpecifier |
+   * GenericTypeSpecifier | KeysetTypeSpecifier | NullableTypeSpecifier |
+   * ShapeTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier |
+   * TupleTypeSpecifier | TypeConstant | VectorTypeSpecifier
    */
   public function getRightOperand(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_operand);

--- a/codegen/syntax/IsExpression.php
+++ b/codegen/syntax/IsExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e7521504eac9c931bb6f1bd965e934dd>>
+ * @generated SignedSource<<49e3e8f62c77d7f32d6309e656bf8dc7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -108,6 +108,13 @@ final class IsExpression extends EditableNode {
       TypeAssert\instance_of(VariableExpression::class, $this->_left_operand);
   }
 
+  /**
+   * @returns VariableExpression
+   */
+  public function getLeftOperandx(): VariableExpression {
+    return $this->getLeftOperand();
+  }
+
   public function getOperatorUNTYPED(): EditableNode {
     return $this->_operator;
   }
@@ -128,6 +135,13 @@ final class IsExpression extends EditableNode {
    */
   public function getOperator(): IsToken {
     return TypeAssert\instance_of(IsToken::class, $this->_operator);
+  }
+
+  /**
+   * @returns IsToken
+   */
+  public function getOperatorx(): IsToken {
+    return $this->getOperator();
   }
 
   public function getRightOperandUNTYPED(): EditableNode {
@@ -153,5 +167,15 @@ final class IsExpression extends EditableNode {
    */
   public function getRightOperand(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_operand);
+  }
+
+  /**
+   * @returns ClosureTypeSpecifier | DictionaryTypeSpecifier |
+   * GenericTypeSpecifier | KeysetTypeSpecifier | NullableTypeSpecifier |
+   * ShapeTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier |
+   * TupleTypeSpecifier | TypeConstant | VectorTypeSpecifier
+   */
+  public function getRightOperandx(): EditableNode {
+    return $this->getRightOperand();
   }
 }

--- a/codegen/syntax/IssetExpression.php
+++ b/codegen/syntax/IssetExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f179ee3f868cf2ea95be7e559e8c5e7f>>
+ * @generated SignedSource<<705c4da21dcdeeb53485987a504225fc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class IssetExpression extends EditableNode {
     return TypeAssert\instance_of(IssetToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns IssetToken
+   */
+  public function getKeywordx(): IssetToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -150,6 +157,13 @@ final class IssetExpression extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getArgumentListUNTYPED(): EditableNode {
@@ -179,6 +193,13 @@ final class IssetExpression extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_argument_list);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getArgumentListx(): EditableList {
+    return $this->getArgumentList();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -204,5 +225,12 @@ final class IssetExpression extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 }

--- a/codegen/syntax/KeysetIntrinsicExpression.php
+++ b/codegen/syntax/KeysetIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<aee097ab3282be95e677ea8f518869e1>>
+ * @generated SignedSource<<f2f62e9e7c267ffd9e5d9e523a838174>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -151,6 +151,13 @@ final class KeysetIntrinsicExpression extends EditableNode {
     return TypeAssert\instance_of(KeysetToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns KeysetToken
+   */
+  public function getKeywordx(): KeysetToken {
+    return $this->getKeyword();
+  }
+
   public function getExplicitTypeUNTYPED(): EditableNode {
     return $this->_explicit_type;
   }
@@ -177,6 +184,13 @@ final class KeysetIntrinsicExpression extends EditableNode {
    */
   public function getExplicitType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_explicit_type);
+  }
+
+  /**
+   * @returns Missing
+   */
+  public function getExplicitTypex(): EditableNode {
+    return $this->getExplicitType();
   }
 
   public function getLeftBracketUNTYPED(): EditableNode {
@@ -206,6 +220,13 @@ final class KeysetIntrinsicExpression extends EditableNode {
   public function getLeftBracket(): LeftBracketToken {
     return
       TypeAssert\instance_of(LeftBracketToken::class, $this->_left_bracket);
+  }
+
+  /**
+   * @returns LeftBracketToken
+   */
+  public function getLeftBracketx(): LeftBracketToken {
+    return $this->getLeftBracket();
   }
 
   public function getMembersUNTYPED(): EditableNode {
@@ -273,5 +294,12 @@ final class KeysetIntrinsicExpression extends EditableNode {
   public function getRightBracket(): RightBracketToken {
     return
       TypeAssert\instance_of(RightBracketToken::class, $this->_right_bracket);
+  }
+
+  /**
+   * @returns RightBracketToken
+   */
+  public function getRightBracketx(): RightBracketToken {
+    return $this->getRightBracket();
   }
 }

--- a/codegen/syntax/KeysetTypeSpecifier.php
+++ b/codegen/syntax/KeysetTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<397aa5d66bb2bef50c3d87ac79f5eb89>>
+ * @generated SignedSource<<3455e609922ceee72ca44c6dbfc4cc46>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -141,6 +141,13 @@ final class KeysetTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(KeysetToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns KeysetToken
+   */
+  public function getKeywordx(): KeysetToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftAngleUNTYPED(): EditableNode {
     return $this->_left_angle;
   }
@@ -167,6 +174,13 @@ final class KeysetTypeSpecifier extends EditableNode {
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
+  }
+
+  /**
+   * @returns LessThanToken
+   */
+  public function getLeftAnglex(): LessThanToken {
+    return $this->getLeftAngle();
   }
 
   public function getTypeUNTYPED(): EditableNode {
@@ -197,6 +211,13 @@ final class KeysetTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_type);
   }
 
+  /**
+   * @returns SimpleTypeSpecifier
+   */
+  public function getTypex(): SimpleTypeSpecifier {
+    return $this->getType();
+  }
+
   public function getTrailingCommaUNTYPED(): EditableNode {
     return $this->_trailing_comma;
   }
@@ -225,6 +246,13 @@ final class KeysetTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_trailing_comma);
   }
 
+  /**
+   * @returns Missing
+   */
+  public function getTrailingCommax(): EditableNode {
+    return $this->getTrailingComma();
+  }
+
   public function getRightAngleUNTYPED(): EditableNode {
     return $this->_right_angle;
   }
@@ -251,5 +279,12 @@ final class KeysetTypeSpecifier extends EditableNode {
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
+  }
+
+  /**
+   * @returns GreaterThanToken
+   */
+  public function getRightAnglex(): GreaterThanToken {
+    return $this->getRightAngle();
   }
 }

--- a/codegen/syntax/LambdaExpression.php
+++ b/codegen/syntax/LambdaExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bcdb28e7353f5051957e9a9d362dc7f8>>
+ * @generated SignedSource<<3dd938b2493cfe48c2ae03973879ef85>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -161,10 +161,26 @@ final class LambdaExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @returns AttributeSpecification | Missing
    */
-  public function getAttributeSpec(): EditableNode {
-    return TypeAssert\instance_of(EditableNode::class, $this->_attribute_spec);
+  public function getAttributeSpec(): ?AttributeSpecification {
+    if ($this->_attribute_spec->isMissing()) {
+      return null;
+    }
+    return TypeAssert\instance_of(
+      AttributeSpecification::class,
+      $this->_attribute_spec,
+    );
+  }
+
+  /**
+   * @returns AttributeSpecification
+   */
+  public function getAttributeSpecx(): AttributeSpecification {
+    return TypeAssert\instance_of(
+      AttributeSpecification::class,
+      $this->_attribute_spec,
+    );
   }
 
   public function getAsyncUNTYPED(): EditableNode {

--- a/codegen/syntax/LambdaExpression.php
+++ b/codegen/syntax/LambdaExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3dd938b2493cfe48c2ae03973879ef85>>
+ * @generated SignedSource<<948770ddde2618e0d8218a85cd0d3823>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -290,6 +290,13 @@ final class LambdaExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_signature);
   }
 
+  /**
+   * @returns LambdaSignature | VariableToken
+   */
+  public function getSignaturex(): EditableNode {
+    return $this->getSignature();
+  }
+
   public function getArrowUNTYPED(): EditableNode {
     return $this->_arrow;
   }
@@ -318,6 +325,13 @@ final class LambdaExpression extends EditableNode {
   public function getArrow(): EqualEqualGreaterThanToken {
     return
       TypeAssert\instance_of(EqualEqualGreaterThanToken::class, $this->_arrow);
+  }
+
+  /**
+   * @returns EqualEqualGreaterThanToken
+   */
+  public function getArrowx(): EqualEqualGreaterThanToken {
+    return $this->getArrow();
   }
 
   public function getBodyUNTYPED(): EditableNode {
@@ -351,5 +365,16 @@ final class LambdaExpression extends EditableNode {
    */
   public function getBody(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_body);
+  }
+
+  /**
+   * @returns ArrayIntrinsicExpression | BinaryExpression | CastExpression |
+   * CompoundStatement | ConditionalExpression | FunctionCallExpression |
+   * LambdaExpression | LiteralExpression | MemberSelectionExpression |
+   * ObjectCreationExpression | ParenthesizedExpression | PrefixUnaryExpression
+   * | SubscriptExpression | VariableExpression
+   */
+  public function getBodyx(): EditableNode {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/LambdaSignature.php
+++ b/codegen/syntax/LambdaSignature.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bea62a5da6241e38fae5c1c9551290df>>
+ * @generated SignedSource<<6c2ecceaf4ed51f31e2917d6eeee9891>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -139,6 +139,13 @@ final class LambdaSignature extends EditableNode {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
+  }
+
   public function getParametersUNTYPED(): EditableNode {
     return $this->_parameters;
   }
@@ -203,6 +210,13 @@ final class LambdaSignature extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 
   public function getColonUNTYPED(): EditableNode {
@@ -270,5 +284,13 @@ final class LambdaSignature extends EditableNode {
    */
   public function getType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
+  }
+
+  /**
+   * @returns ClosureTypeSpecifier | GenericTypeSpecifier | Missing |
+   * SimpleTypeSpecifier
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
   }
 }

--- a/codegen/syntax/LetStatement.php
+++ b/codegen/syntax/LetStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0390f7068762e785babf7e0c275a43bb>>
+ * @generated SignedSource<<a9f39eda6f444c45fb83193ec611ea9f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -153,6 +153,13 @@ final class LetStatement extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_keyword);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getKeywordx(): EditableNode {
+    return $this->getKeyword();
+  }
+
   public function getNameUNTYPED(): EditableNode {
     return $this->_name;
   }
@@ -180,6 +187,13 @@ final class LetStatement extends EditableNode {
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getNamex(): EditableNode {
+    return $this->getName();
   }
 
   public function getColonUNTYPED(): EditableNode {
@@ -211,6 +225,13 @@ final class LetStatement extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_colon);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getColonx(): EditableNode {
+    return $this->getColon();
+  }
+
   public function getTypeUNTYPED(): EditableNode {
     return $this->_type;
   }
@@ -238,6 +259,13 @@ final class LetStatement extends EditableNode {
    */
   public function getType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
   }
 
   public function getInitializerUNTYPED(): EditableNode {
@@ -269,6 +297,13 @@ final class LetStatement extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_initializer);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getInitializerx(): EditableNode {
+    return $this->getInitializer();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -296,5 +331,12 @@ final class LetStatement extends EditableNode {
    */
   public function getSemicolon(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getSemicolonx(): EditableNode {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/ListExpression.php
+++ b/codegen/syntax/ListExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6e130fa7ad23084b91281b17039b999e>>
+ * @generated SignedSource<<45e1295365b85ac1b193326ac86af9fb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class ListExpression extends EditableNode {
     return TypeAssert\instance_of(ListToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ListToken
+   */
+  public function getKeywordx(): ListToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -146,6 +153,13 @@ final class ListExpression extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getMembersUNTYPED(): EditableNode {
@@ -206,5 +220,12 @@ final class ListExpression extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 }

--- a/codegen/syntax/ListItem.php
+++ b/codegen/syntax/ListItem.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<af9ec02bd2fa412b0939868b408ecbaf>>
+ * @generated SignedSource<<7788e6c50b20ea0113ac56796802778f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -110,6 +110,37 @@ final class ListItem extends EditableNode {
    */
   public function getItem(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_item);
+  }
+
+  /**
+   * @returns AnonymousFunction | ArrayCreationExpression |
+   * ArrayIntrinsicExpression | Attribute | AwaitableCreationExpression |
+   * BinaryExpression | CastExpression | ClassnameTypeSpecifier |
+   * ClosureParameterTypeSpecifier | ClosureTypeSpecifier |
+   * CollectionLiteralExpression | ConditionalExpression | ConstantDeclarator |
+   * DarrayIntrinsicExpression | DecoratedExpression | DefineExpression |
+   * DictionaryIntrinsicExpression | DictionaryTypeSpecifier |
+   * ElementInitializer | EmptyExpression | EvalExpression | FieldInitializer |
+   * FieldSpecifier | FunctionCallExpression | GenericTypeSpecifier |
+   * InclusionExpression | InstanceofExpression | IssetExpression |
+   * KeysetIntrinsicExpression | LambdaExpression | ListExpression |
+   * LiteralExpression | MapArrayTypeSpecifier | MemberSelectionExpression |
+   * Missing | NamespaceUseClause | NullableTypeSpecifier |
+   * ObjectCreationExpression | ParameterDeclaration | ParenthesizedExpression
+   * | PipeVariableExpression | PostfixUnaryExpression | PrefixUnaryExpression
+   * | PropertyDeclarator | QualifiedName | SafeMemberSelectionExpression |
+   * ScopeResolutionExpression | ShapeExpression | ShapeTypeSpecifier |
+   * SimpleTypeSpecifier | StaticDeclarator | SubscriptExpression | EqualToken
+   * | XHPCategoryNameToken | NameToken | NoreturnToken | VariableToken |
+   * TraitUseAliasItem | TraitUsePrecedenceItem | TupleExpression |
+   * TupleTypeSpecifier | TypeConstant | TypeParameter | VariableExpression |
+   * VariadicParameter | VarrayIntrinsicExpression | VarrayTypeSpecifier |
+   * VectorArrayTypeSpecifier | VectorIntrinsicExpression | VectorTypeSpecifier
+   * | WhereConstraint | XHPClassAttribute | XHPExpression |
+   * XHPSimpleClassAttribute
+   */
+  public function getItemx(): EditableNode {
+    return $this->getItem();
   }
 
   public function getSeparatorUNTYPED(): EditableNode {

--- a/codegen/syntax/ListItem.php
+++ b/codegen/syntax/ListItem.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<de7f2a8a77604f802e1465be8ebb0555>>
+ * @generated SignedSource<<af9ec02bd2fa412b0939868b408ecbaf>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -99,14 +99,14 @@ final class ListItem extends EditableNode {
    * | PipeVariableExpression | PostfixUnaryExpression | PrefixUnaryExpression
    * | PropertyDeclarator | QualifiedName | SafeMemberSelectionExpression |
    * ScopeResolutionExpression | ShapeExpression | ShapeTypeSpecifier |
-   * SimpleTypeSpecifier | StaticDeclarator | SubscriptExpression |
-   * PercentToken | XHPCategoryNameToken | NameToken | NoreturnToken |
-   * VariableToken | TraitUseAliasItem | TraitUsePrecedenceItem |
-   * TupleExpression | TupleTypeSpecifier | TypeConstant | TypeParameter |
-   * VariableExpression | VariadicParameter | VarrayIntrinsicExpression |
-   * VarrayTypeSpecifier | VectorArrayTypeSpecifier | VectorIntrinsicExpression
-   * | VectorTypeSpecifier | WhereConstraint | XHPClassAttribute |
-   * XHPExpression | XHPSimpleClassAttribute
+   * SimpleTypeSpecifier | StaticDeclarator | SubscriptExpression | EqualToken
+   * | XHPCategoryNameToken | NameToken | NoreturnToken | VariableToken |
+   * TraitUseAliasItem | TraitUsePrecedenceItem | TupleExpression |
+   * TupleTypeSpecifier | TypeConstant | TypeParameter | VariableExpression |
+   * VariadicParameter | VarrayIntrinsicExpression | VarrayTypeSpecifier |
+   * VectorArrayTypeSpecifier | VectorIntrinsicExpression | VectorTypeSpecifier
+   * | WhereConstraint | XHPClassAttribute | XHPExpression |
+   * XHPSimpleClassAttribute
    */
   public function getItem(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_item);

--- a/codegen/syntax/LiteralExpression.php
+++ b/codegen/syntax/LiteralExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<84bb45615452159b6561107033f9bef3>>
+ * @generated SignedSource<<5196b52bffd06ea799ab56d3e8da9dda>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,5 +75,12 @@ final class LiteralExpression extends EditableNode {
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
   }
 }

--- a/codegen/syntax/MapArrayTypeSpecifier.php
+++ b/codegen/syntax/MapArrayTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b82943b6ef603c23d1d0d2e19527d4cb>>
+ * @generated SignedSource<<2aa77f5b4efdcf3ed70fb2acc4dc8ad5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -155,6 +155,13 @@ final class MapArrayTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(ArrayToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ArrayToken
+   */
+  public function getKeywordx(): ArrayToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftAngleUNTYPED(): EditableNode {
     return $this->_left_angle;
   }
@@ -182,6 +189,13 @@ final class MapArrayTypeSpecifier extends EditableNode {
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
+  }
+
+  /**
+   * @returns LessThanToken
+   */
+  public function getLeftAnglex(): LessThanToken {
+    return $this->getLeftAngle();
   }
 
   public function getKeyUNTYPED(): EditableNode {
@@ -213,6 +227,13 @@ final class MapArrayTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_key);
   }
 
+  /**
+   * @returns SimpleTypeSpecifier
+   */
+  public function getKeyx(): SimpleTypeSpecifier {
+    return $this->getKey();
+  }
+
   public function getCommaUNTYPED(): EditableNode {
     return $this->_comma;
   }
@@ -240,6 +261,13 @@ final class MapArrayTypeSpecifier extends EditableNode {
    */
   public function getComma(): CommaToken {
     return TypeAssert\instance_of(CommaToken::class, $this->_comma);
+  }
+
+  /**
+   * @returns CommaToken
+   */
+  public function getCommax(): CommaToken {
+    return $this->getComma();
   }
 
   public function getValueUNTYPED(): EditableNode {
@@ -272,6 +300,14 @@ final class MapArrayTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_value);
   }
 
+  /**
+   * @returns GenericTypeSpecifier | Missing | NullableTypeSpecifier |
+   * ShapeTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier
+   */
+  public function getValuex(): EditableNode {
+    return $this->getValue();
+  }
+
   public function getRightAngleUNTYPED(): EditableNode {
     return $this->_right_angle;
   }
@@ -299,5 +335,12 @@ final class MapArrayTypeSpecifier extends EditableNode {
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
+  }
+
+  /**
+   * @returns GreaterThanToken
+   */
+  public function getRightAnglex(): GreaterThanToken {
+    return $this->getRightAngle();
   }
 }

--- a/codegen/syntax/MarkupSuffix.php
+++ b/codegen/syntax/MarkupSuffix.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<877f4e9dc28711aab216c13563ccf30d>>
+ * @generated SignedSource<<70a95be935fffb99a17ecac91202623f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -96,6 +96,13 @@ final class MarkupSuffix extends EditableNode {
       LessThanQuestionToken::class,
       $this->_less_than_question,
     );
+  }
+
+  /**
+   * @returns LessThanQuestionToken
+   */
+  public function getLessThanQuestionx(): LessThanQuestionToken {
+    return $this->getLessThanQuestion();
   }
 
   public function getNameUNTYPED(): EditableNode {

--- a/codegen/syntax/MemberSelectionExpression.php
+++ b/codegen/syntax/MemberSelectionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e8e5c8f66ce9359b9ce659aeb038dec3>>
+ * @generated SignedSource<<5a6c476747e53aa6029517e67f867095>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -103,7 +103,8 @@ final class MemberSelectionExpression extends EditableNode {
   /**
    * @returns FunctionCallExpression | MemberSelectionExpression |
    * ParenthesizedExpression | PipeVariableExpression | PrefixUnaryExpression |
-   * ScopeResolutionExpression | SubscriptExpression | VariableExpression
+   * ScopeResolutionExpression | SubscriptExpression | NameToken |
+   * VariableExpression
    */
   public function getObject(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_object);

--- a/codegen/syntax/MemberSelectionExpression.php
+++ b/codegen/syntax/MemberSelectionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5a6c476747e53aa6029517e67f867095>>
+ * @generated SignedSource<<1363b16fa13611f1c95ad8dc42ffad2d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -110,6 +110,16 @@ final class MemberSelectionExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_object);
   }
 
+  /**
+   * @returns FunctionCallExpression | MemberSelectionExpression |
+   * ParenthesizedExpression | PipeVariableExpression | PrefixUnaryExpression |
+   * ScopeResolutionExpression | SubscriptExpression | NameToken |
+   * VariableExpression
+   */
+  public function getObjectx(): EditableNode {
+    return $this->getObject();
+  }
+
   public function getOperatorUNTYPED(): EditableNode {
     return $this->_operator;
   }
@@ -133,6 +143,13 @@ final class MemberSelectionExpression extends EditableNode {
       TypeAssert\instance_of(MinusGreaterThanToken::class, $this->_operator);
   }
 
+  /**
+   * @returns MinusGreaterThanToken
+   */
+  public function getOperatorx(): MinusGreaterThanToken {
+    return $this->getOperator();
+  }
+
   public function getNameUNTYPED(): EditableNode {
     return $this->_name;
   }
@@ -154,5 +171,13 @@ final class MemberSelectionExpression extends EditableNode {
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
+  }
+
+  /**
+   * @returns BracedExpression | PrefixUnaryExpression | XHPClassNameToken |
+   * NameToken | VariableToken
+   */
+  public function getNamex(): EditableNode {
+    return $this->getName();
   }
 }

--- a/codegen/syntax/MethodishDeclaration.php
+++ b/codegen/syntax/MethodishDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7ea235e8fa20e7ec06fa2f5dff219062>>
+ * @generated SignedSource<<418c7267e38ea8be641ee84ddadbe40e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -170,6 +170,13 @@ final class MethodishDeclaration
       FunctionDeclarationHeader::class,
       $this->_function_decl_header,
     );
+  }
+
+  /**
+   * @returns FunctionDeclarationHeader
+   */
+  public function getFunctionDeclHeaderx(): FunctionDeclarationHeader {
+    return $this->getFunctionDeclHeader();
   }
 
   public function getFunctionBodyUNTYPED(): EditableNode {

--- a/codegen/syntax/NamespaceBody.php
+++ b/codegen/syntax/NamespaceBody.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6e4a7c2b28ab74c8a1d62b632fd00d1e>>
+ * @generated SignedSource<<b15d886e5423bf1a1619038335ff142b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -105,6 +105,13 @@ final class NamespaceBody extends EditableNode {
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
+  }
+
+  /**
+   * @returns LeftBraceToken
+   */
+  public function getLeftBracex(): LeftBraceToken {
+    return $this->getLeftBrace();
   }
 
   public function getDeclarationsUNTYPED(): EditableNode {

--- a/codegen/syntax/NamespaceDeclaration.php
+++ b/codegen/syntax/NamespaceDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d67c8dadac4e523e4b178607fb59c152>>
+ * @generated SignedSource<<8dee547979fd23ab2b78cc441499be03>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ abstract class NamespaceDeclarationGeneratedBase extends EditableNode {
     return TypeAssert\instance_of(NamespaceToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns NamespaceToken
+   */
+  public function getKeywordx(): NamespaceToken {
+    return $this->getKeyword();
+  }
+
   public function getNameUNTYPED(): EditableNode {
     return $this->_name;
   }
@@ -129,6 +136,13 @@ abstract class NamespaceDeclarationGeneratedBase extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
   }
 
+  /**
+   * @returns Missing | QualifiedName | NameToken
+   */
+  public function getNamex(): EditableNode {
+    return $this->getName();
+  }
+
   public function getBodyUNTYPED(): EditableNode {
     return $this->_body;
   }
@@ -149,5 +163,12 @@ abstract class NamespaceDeclarationGeneratedBase extends EditableNode {
    */
   public function getBody(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_body);
+  }
+
+  /**
+   * @returns NamespaceBody | NamespaceEmptyBody
+   */
+  public function getBodyx(): EditableNode {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/NamespaceEmptyBody.php
+++ b/codegen/syntax/NamespaceEmptyBody.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c9691930ca231abc033110e0dfaf2d92>>
+ * @generated SignedSource<<6b33a77733d3a1470a6a0777ae2462fb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,5 +75,12 @@ final class NamespaceEmptyBody extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/NamespaceGroupUseDeclaration.php
+++ b/codegen/syntax/NamespaceGroupUseDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f191f43b4db387b48c4c062e92b0a7aa>>
+ * @generated SignedSource<<d39e2c9b65ea478bc7b449b793c931e5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -183,6 +183,13 @@ final class NamespaceGroupUseDeclaration extends EditableNode {
     return TypeAssert\instance_of(UseToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns UseToken
+   */
+  public function getKeywordx(): UseToken {
+    return $this->getKeyword();
+  }
+
   public function getKindUNTYPED(): EditableNode {
     return $this->_kind;
   }
@@ -253,6 +260,13 @@ final class NamespaceGroupUseDeclaration extends EditableNode {
     return TypeAssert\instance_of(QualifiedName::class, $this->_prefix);
   }
 
+  /**
+   * @returns QualifiedName
+   */
+  public function getPrefixx(): QualifiedName {
+    return $this->getPrefix();
+  }
+
   public function getLeftBraceUNTYPED(): EditableNode {
     return $this->_left_brace;
   }
@@ -283,6 +297,13 @@ final class NamespaceGroupUseDeclaration extends EditableNode {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
+  /**
+   * @returns LeftBraceToken
+   */
+  public function getLeftBracex(): LeftBraceToken {
+    return $this->getLeftBrace();
+  }
+
   public function getClausesUNTYPED(): EditableNode {
     return $this->_clauses;
   }
@@ -311,6 +332,13 @@ final class NamespaceGroupUseDeclaration extends EditableNode {
    */
   public function getClauses(): EditableList {
     return TypeAssert\instance_of(EditableList::class, $this->_clauses);
+  }
+
+  /**
+   * @returns EditableList
+   */
+  public function getClausesx(): EditableList {
+    return $this->getClauses();
   }
 
   public function getRightBraceUNTYPED(): EditableNode {

--- a/codegen/syntax/NamespaceUseClause.php
+++ b/codegen/syntax/NamespaceUseClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e7edd72012c4b86c09628506dde5d80b>>
+ * @generated SignedSource<<5892b70cbe60b77e5419604b0a5650b4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -150,6 +150,13 @@ final class NamespaceUseClause extends EditableNode {
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
+  }
+
+  /**
+   * @returns QualifiedName | NameToken
+   */
+  public function getNamex(): EditableNode {
+    return $this->getName();
   }
 
   public function getAsUNTYPED(): EditableNode {

--- a/codegen/syntax/NamespaceUseDeclaration.php
+++ b/codegen/syntax/NamespaceUseDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b3d9a795c36e4e6be99b571c6bba191b>>
+ * @generated SignedSource<<1647a6893adba75981f857be8875695a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -120,6 +120,13 @@ final class NamespaceUseDeclaration extends EditableNode {
     return TypeAssert\instance_of(UseToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns UseToken
+   */
+  public function getKeywordx(): UseToken {
+    return $this->getKeyword();
+  }
+
   public function getKindUNTYPED(): EditableNode {
     return $this->_kind;
   }
@@ -175,6 +182,13 @@ final class NamespaceUseDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_clauses);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getClausesx(): EditableList {
+    return $this->getClauses();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -195,5 +209,12 @@ final class NamespaceUseDeclaration extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/NullableAsExpression.php
+++ b/codegen/syntax/NullableAsExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9210ebb606f6fdacd5cc3618e8f30145>>
+ * @generated SignedSource<<48ec0d24670e04a1057a0ba96f14f4ab>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -108,6 +108,13 @@ final class NullableAsExpression extends EditableNode {
       TypeAssert\instance_of(VariableExpression::class, $this->_left_operand);
   }
 
+  /**
+   * @returns VariableExpression
+   */
+  public function getLeftOperandx(): VariableExpression {
+    return $this->getLeftOperand();
+  }
+
   public function getOperatorUNTYPED(): EditableNode {
     return $this->_operator;
   }
@@ -128,6 +135,13 @@ final class NullableAsExpression extends EditableNode {
    */
   public function getOperator(): QuestionAsToken {
     return TypeAssert\instance_of(QuestionAsToken::class, $this->_operator);
+  }
+
+  /**
+   * @returns QuestionAsToken
+   */
+  public function getOperatorx(): QuestionAsToken {
+    return $this->getOperator();
   }
 
   public function getRightOperandUNTYPED(): EditableNode {
@@ -151,5 +165,12 @@ final class NullableAsExpression extends EditableNode {
   public function getRightOperand(): SimpleTypeSpecifier {
     return
       TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_right_operand);
+  }
+
+  /**
+   * @returns SimpleTypeSpecifier
+   */
+  public function getRightOperandx(): SimpleTypeSpecifier {
+    return $this->getRightOperand();
   }
 }

--- a/codegen/syntax/NullableTypeSpecifier.php
+++ b/codegen/syntax/NullableTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a880ad5a0e8c19b6b741a9489fc0bab5>>
+ * @generated SignedSource<<41f6f6540745c65e0937bfcac34f93a9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -88,6 +88,13 @@ final class NullableTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(QuestionToken::class, $this->_question);
   }
 
+  /**
+   * @returns QuestionToken
+   */
+  public function getQuestionx(): QuestionToken {
+    return $this->getQuestion();
+  }
+
   public function getTypeUNTYPED(): EditableNode {
     return $this->_type;
   }
@@ -111,5 +118,15 @@ final class NullableTypeSpecifier extends EditableNode {
    */
   public function getType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
+  }
+
+  /**
+   * @returns ClosureTypeSpecifier | DictionaryTypeSpecifier |
+   * GenericTypeSpecifier | KeysetTypeSpecifier | MapArrayTypeSpecifier |
+   * ShapeTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier |
+   * TypeConstant | VectorArrayTypeSpecifier | VectorTypeSpecifier
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
   }
 }

--- a/codegen/syntax/ObjectCreationExpression.php
+++ b/codegen/syntax/ObjectCreationExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3992ae79a8c2eb592454ddec8f0697d6>>
+ * @generated SignedSource<<94cc30b608da445aeffb85add1f4a392>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -88,6 +88,13 @@ final class ObjectCreationExpression extends EditableNode {
     return TypeAssert\instance_of(NewToken::class, $this->_new_keyword);
   }
 
+  /**
+   * @returns NewToken
+   */
+  public function getNewKeywordx(): NewToken {
+    return $this->getNewKeyword();
+  }
+
   public function getObjectUNTYPED(): EditableNode {
     return $this->_object;
   }
@@ -108,5 +115,12 @@ final class ObjectCreationExpression extends EditableNode {
    */
   public function getObject(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_object);
+  }
+
+  /**
+   * @returns AnonymousClass | ConstructorCall
+   */
+  public function getObjectx(): EditableNode {
+    return $this->getObject();
   }
 }

--- a/codegen/syntax/ParameterDeclaration.php
+++ b/codegen/syntax/ParameterDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bdbf1bae2779e4d7f79fa74ad81efc43>>
+ * @generated SignedSource<<4946b33f2818976e469050bc361bcca9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -291,6 +291,18 @@ final class ParameterDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
   }
 
+  /**
+   * @returns ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * DarrayTypeSpecifier | DictionaryTypeSpecifier | GenericTypeSpecifier |
+   * KeysetTypeSpecifier | MapArrayTypeSpecifier | Missing |
+   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
+   * SoftTypeSpecifier | TupleTypeSpecifier | TypeConstant |
+   * VarrayTypeSpecifier | VectorArrayTypeSpecifier | VectorTypeSpecifier
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
+  }
+
   public function getNameUNTYPED(): EditableNode {
     return $this->_name;
   }
@@ -318,6 +330,13 @@ final class ParameterDeclaration extends EditableNode {
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
+  }
+
+  /**
+   * @returns DecoratedExpression | Missing | VariableToken
+   */
+  public function getNamex(): EditableNode {
+    return $this->getName();
   }
 
   public function getDefaultValueUNTYPED(): EditableNode {

--- a/codegen/syntax/ParenthesizedExpression.php
+++ b/codegen/syntax/ParenthesizedExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fa360d267b22e714d5363d5fa0e562cb>>
+ * @generated SignedSource<<48af887f6e4d66acdc224c416a49fee4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class ParenthesizedExpression extends EditableNode {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
+  }
+
   public function getExpressionUNTYPED(): EditableNode {
     return $this->_expression;
   }
@@ -135,6 +142,21 @@ final class ParenthesizedExpression extends EditableNode {
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
+  }
+
+  /**
+   * @returns AnonymousFunction | ArrayIntrinsicExpression | BinaryExpression |
+   * CastExpression | CollectionLiteralExpression | ConditionalExpression |
+   * EmptyExpression | FunctionCallExpression | InclusionExpression |
+   * InstanceofExpression | IssetExpression | LambdaExpression |
+   * LiteralExpression | MemberSelectionExpression | ObjectCreationExpression |
+   * ParenthesizedExpression | PostfixUnaryExpression | PrefixUnaryExpression |
+   * QualifiedName | ScopeResolutionExpression | SubscriptExpression |
+   * QuestionToken | NameToken | VariableExpression | XHPExpression |
+   * YieldExpression
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
   }
 
   public function getRightParenUNTYPED(): EditableNode {

--- a/codegen/syntax/Php7AnonymousFunction.php
+++ b/codegen/syntax/Php7AnonymousFunction.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<715f96e183cf45bda0188dcaecb8420e>>
+ * @generated SignedSource<<ac06e021b5e036e5c50b0c68f9842c51>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -280,6 +280,13 @@ final class Php7AnonymousFunction extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_attribute_spec);
   }
 
+  /**
+   * @returns Missing
+   */
+  public function getAttributeSpecx(): EditableNode {
+    return $this->getAttributeSpec();
+  }
+
   public function getStaticKeywordUNTYPED(): EditableNode {
     return $this->_static_keyword;
   }
@@ -316,6 +323,13 @@ final class Php7AnonymousFunction extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_static_keyword);
   }
 
+  /**
+   * @returns Missing
+   */
+  public function getStaticKeywordx(): EditableNode {
+    return $this->getStaticKeyword();
+  }
+
   public function getAsyncKeywordUNTYPED(): EditableNode {
     return $this->_async_keyword;
   }
@@ -350,6 +364,13 @@ final class Php7AnonymousFunction extends EditableNode {
    */
   public function getAsyncKeyword(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_async_keyword);
+  }
+
+  /**
+   * @returns Missing
+   */
+  public function getAsyncKeywordx(): EditableNode {
+    return $this->getAsyncKeyword();
   }
 
   public function getCoroutineKeywordUNTYPED(): EditableNode {
@@ -389,6 +410,13 @@ final class Php7AnonymousFunction extends EditableNode {
       TypeAssert\instance_of(EditableNode::class, $this->_coroutine_keyword);
   }
 
+  /**
+   * @returns Missing
+   */
+  public function getCoroutineKeywordx(): EditableNode {
+    return $this->getCoroutineKeyword();
+  }
+
   public function getFunctionKeywordUNTYPED(): EditableNode {
     return $this->_function_keyword;
   }
@@ -424,6 +452,13 @@ final class Php7AnonymousFunction extends EditableNode {
   public function getFunctionKeyword(): FunctionToken {
     return
       TypeAssert\instance_of(FunctionToken::class, $this->_function_keyword);
+  }
+
+  /**
+   * @returns FunctionToken
+   */
+  public function getFunctionKeywordx(): FunctionToken {
+    return $this->getFunctionKeyword();
   }
 
   public function getAmpersandUNTYPED(): EditableNode {
@@ -462,6 +497,13 @@ final class Php7AnonymousFunction extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_ampersand);
   }
 
+  /**
+   * @returns Missing
+   */
+  public function getAmpersandx(): EditableNode {
+    return $this->getAmpersand();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -496,6 +538,13 @@ final class Php7AnonymousFunction extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getParametersUNTYPED(): EditableNode {
@@ -534,6 +583,13 @@ final class Php7AnonymousFunction extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_parameters);
   }
 
+  /**
+   * @returns Missing
+   */
+  public function getParametersx(): EditableNode {
+    return $this->getParameters();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -568,6 +624,13 @@ final class Php7AnonymousFunction extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 
   public function getUseUNTYPED(): EditableNode {
@@ -607,6 +670,13 @@ final class Php7AnonymousFunction extends EditableNode {
       TypeAssert\instance_of(AnonymousFunctionUseClause::class, $this->_use);
   }
 
+  /**
+   * @returns AnonymousFunctionUseClause
+   */
+  public function getUsex(): AnonymousFunctionUseClause {
+    return $this->getUse();
+  }
+
   public function getColonUNTYPED(): EditableNode {
     return $this->_colon;
   }
@@ -641,6 +711,13 @@ final class Php7AnonymousFunction extends EditableNode {
    */
   public function getColon(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
+  }
+
+  /**
+   * @returns ColonToken
+   */
+  public function getColonx(): ColonToken {
+    return $this->getColon();
   }
 
   public function getTypeUNTYPED(): EditableNode {
@@ -679,6 +756,13 @@ final class Php7AnonymousFunction extends EditableNode {
     return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_type);
   }
 
+  /**
+   * @returns SimpleTypeSpecifier
+   */
+  public function getTypex(): SimpleTypeSpecifier {
+    return $this->getType();
+  }
+
   public function getBodyUNTYPED(): EditableNode {
     return $this->_body;
   }
@@ -713,5 +797,12 @@ final class Php7AnonymousFunction extends EditableNode {
    */
   public function getBody(): CompoundStatement {
     return TypeAssert\instance_of(CompoundStatement::class, $this->_body);
+  }
+
+  /**
+   * @returns CompoundStatement
+   */
+  public function getBodyx(): CompoundStatement {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/PipeVariableExpression.php
+++ b/codegen/syntax/PipeVariableExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7bdd0e98304d97f8188796c0646386ab>>
+ * @generated SignedSource<<954899c7bb0796e80afe72c6330afc77>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,5 +75,12 @@ final class PipeVariableExpression extends EditableNode {
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
   }
 }

--- a/codegen/syntax/PostfixUnaryExpression.php
+++ b/codegen/syntax/PostfixUnaryExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<48dd922cad87d153dfed84da46bc720d>>
+ * @generated SignedSource<<61ed792f78c4e0eefa5ac63afd9baaab>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -89,6 +89,14 @@ final class PostfixUnaryExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_operand);
   }
 
+  /**
+   * @returns MemberSelectionExpression | PrefixUnaryExpression |
+   * ScopeResolutionExpression | SubscriptExpression | VariableExpression
+   */
+  public function getOperandx(): EditableNode {
+    return $this->getOperand();
+  }
+
   public function getOperatorUNTYPED(): EditableNode {
     return $this->_operator;
   }
@@ -109,5 +117,12 @@ final class PostfixUnaryExpression extends EditableNode {
    */
   public function getOperator(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_operator);
+  }
+
+  /**
+   * @returns PlusPlusToken | MinusMinusToken
+   */
+  public function getOperatorx(): EditableToken {
+    return $this->getOperator();
   }
 }

--- a/codegen/syntax/PrefixUnaryExpression.php
+++ b/codegen/syntax/PrefixUnaryExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<67be1f22e11eee8a524a188a04803055>>
+ * @generated SignedSource<<4c5ee5d255dadc9a5dddfbf145c890dd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -90,6 +90,15 @@ final class PrefixUnaryExpression extends EditableNode {
     return TypeAssert\instance_of(EditableToken::class, $this->_operator);
   }
 
+  /**
+   * @returns ExclamationToken | DollarToken | AmpersandToken | PlusToken |
+   * PlusPlusToken | MinusToken | MinusMinusToken | AtToken | AwaitToken |
+   * CloneToken | PrintToken | SuspendToken | TildeToken
+   */
+  public function getOperatorx(): EditableToken {
+    return $this->getOperator();
+  }
+
   public function getOperandUNTYPED(): EditableNode {
     return $this->_operand;
   }
@@ -119,5 +128,21 @@ final class PrefixUnaryExpression extends EditableNode {
    */
   public function getOperand(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_operand);
+  }
+
+  /**
+   * @returns AnonymousFunction | ArrayIntrinsicExpression | BinaryExpression |
+   * BracedExpression | CastExpression | ConditionalExpression |
+   * DefineExpression | EmptyExpression | EvalExpression |
+   * FunctionCallExpression | InclusionExpression | InstanceofExpression |
+   * IssetExpression | LiteralExpression | MemberSelectionExpression |
+   * ObjectCreationExpression | ParenthesizedExpression |
+   * PipeVariableExpression | PostfixUnaryExpression | PrefixUnaryExpression |
+   * SafeMemberSelectionExpression | ScopeResolutionExpression |
+   * SubscriptExpression | EndOfFileToken | NameToken | VariableToken |
+   * VariableExpression
+   */
+  public function getOperandx(): EditableNode {
+    return $this->getOperand();
   }
 }

--- a/codegen/syntax/PropertyDeclaration.php
+++ b/codegen/syntax/PropertyDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7cdcb8f0da7e32c7504bb8831f455154>>
+ * @generated SignedSource<<1886935a32663590649883b9b977d8d0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -185,6 +185,13 @@ final class PropertyDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_modifiers);
   }
 
+  /**
+   * @returns EditableList | VarToken
+   */
+  public function getModifiersx(): EditableNode {
+    return $this->getModifiers();
+  }
+
   public function getTypeUNTYPED(): EditableNode {
     return $this->_type;
   }
@@ -217,6 +224,17 @@ final class PropertyDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
   }
 
+  /**
+   * @returns ClosureTypeSpecifier | DarrayTypeSpecifier |
+   * DictionaryTypeSpecifier | GenericTypeSpecifier | MapArrayTypeSpecifier |
+   * Missing | NullableTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier
+   * | TupleTypeSpecifier | TypeConstant | VarrayTypeSpecifier |
+   * VectorArrayTypeSpecifier | VectorTypeSpecifier
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
+  }
+
   public function getDeclaratorsUNTYPED(): EditableNode {
     return $this->_declarators;
   }
@@ -245,6 +263,13 @@ final class PropertyDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_declarators);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getDeclaratorsx(): EditableList {
+    return $this->getDeclarators();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -271,5 +296,12 @@ final class PropertyDeclaration extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/PropertyDeclarator.php
+++ b/codegen/syntax/PropertyDeclarator.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4f2d57ea56b00e46f8dbeb1e1a64fedb>>
+ * @generated SignedSource<<e480de5445c3981abda3e4c19a1f53c9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -86,6 +86,13 @@ final class PropertyDeclarator extends EditableNode {
    */
   public function getName(): VariableToken {
     return TypeAssert\instance_of(VariableToken::class, $this->_name);
+  }
+
+  /**
+   * @returns VariableToken
+   */
+  public function getNamex(): VariableToken {
+    return $this->getName();
   }
 
   public function getInitializerUNTYPED(): EditableNode {

--- a/codegen/syntax/QualifiedName.php
+++ b/codegen/syntax/QualifiedName.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b82a27d114c503b3b28798b523426088>>
+ * @generated SignedSource<<30aa856519b4d82b56e1c5b5ace22cc8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,5 +75,12 @@ final class QualifiedName extends EditableNode {
    */
   public function getParts(): EditableList {
     return TypeAssert\instance_of(EditableList::class, $this->_parts);
+  }
+
+  /**
+   * @returns EditableList
+   */
+  public function getPartsx(): EditableList {
+    return $this->getParts();
   }
 }

--- a/codegen/syntax/RequireClause.php
+++ b/codegen/syntax/RequireClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2f9e3de2b166299cefbc827c57432fae>>
+ * @generated SignedSource<<8f85b4ea79f10c3d9924c9ce5d9cfcfb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -120,6 +120,13 @@ final class RequireClause extends EditableNode {
     return TypeAssert\instance_of(RequireToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns RequireToken
+   */
+  public function getKeywordx(): RequireToken {
+    return $this->getKeyword();
+  }
+
   public function getKindUNTYPED(): EditableNode {
     return $this->_kind;
   }
@@ -140,6 +147,13 @@ final class RequireClause extends EditableNode {
    */
   public function getKind(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_kind);
+  }
+
+  /**
+   * @returns ExtendsToken | ImplementsToken
+   */
+  public function getKindx(): EditableToken {
+    return $this->getKind();
   }
 
   public function getNameUNTYPED(): EditableNode {
@@ -164,6 +178,13 @@ final class RequireClause extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
   }
 
+  /**
+   * @returns GenericTypeSpecifier | SimpleTypeSpecifier
+   */
+  public function getNamex(): EditableNode {
+    return $this->getName();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -184,5 +205,12 @@ final class RequireClause extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/ReturnStatement.php
+++ b/codegen/syntax/ReturnStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<300ab70f478d1d1b83ec2833869529fb>>
+ * @generated SignedSource<<72caba01628f62e7a2e769d369c3cc9c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class ReturnStatement extends EditableNode {
     return TypeAssert\instance_of(ReturnToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ReturnToken
+   */
+  public function getKeywordx(): ReturnToken {
+    return $this->getKeyword();
+  }
+
   public function getExpressionUNTYPED(): EditableNode {
     return $this->_expression;
   }
@@ -141,6 +148,25 @@ final class ReturnStatement extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
+  /**
+   * @returns AnonymousFunction | ArrayCreationExpression |
+   * ArrayIntrinsicExpression | AwaitableCreationExpression | BinaryExpression
+   * | CastExpression | CollectionLiteralExpression | ConditionalExpression |
+   * DarrayIntrinsicExpression | DictionaryIntrinsicExpression | EvalExpression
+   * | FunctionCallExpression | FunctionCallWithTypeArgumentsExpression |
+   * InstanceofExpression | IssetExpression | KeysetIntrinsicExpression |
+   * LambdaExpression | LiteralExpression | MemberSelectionExpression | Missing
+   * | ObjectCreationExpression | ParenthesizedExpression |
+   * PostfixUnaryExpression | PrefixUnaryExpression | QualifiedName |
+   * SafeMemberSelectionExpression | ScopeResolutionExpression |
+   * ShapeExpression | SubscriptExpression | NameToken | TupleExpression |
+   * VariableExpression | VarrayIntrinsicExpression | VectorIntrinsicExpression
+   * | XHPExpression | YieldFromExpression
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -161,5 +187,12 @@ final class ReturnStatement extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/SafeMemberSelectionExpression.php
+++ b/codegen/syntax/SafeMemberSelectionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9b6fc3ab96c9f7ef800c11461c42e22c>>
+ * @generated SignedSource<<f5c5be209252300ac03c604491d6cd3d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -109,6 +109,15 @@ final class SafeMemberSelectionExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_object);
   }
 
+  /**
+   * @returns FunctionCallExpression | MemberSelectionExpression |
+   * PrefixUnaryExpression | SafeMemberSelectionExpression |
+   * ScopeResolutionExpression | VariableExpression
+   */
+  public function getObjectx(): EditableNode {
+    return $this->getObject();
+  }
+
   public function getOperatorUNTYPED(): EditableNode {
     return $this->_operator;
   }
@@ -134,6 +143,13 @@ final class SafeMemberSelectionExpression extends EditableNode {
     );
   }
 
+  /**
+   * @returns QuestionMinusGreaterThanToken
+   */
+  public function getOperatorx(): QuestionMinusGreaterThanToken {
+    return $this->getOperator();
+  }
+
   public function getNameUNTYPED(): EditableNode {
     return $this->_name;
   }
@@ -154,5 +170,12 @@ final class SafeMemberSelectionExpression extends EditableNode {
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
+  }
+
+  /**
+   * @returns PrefixUnaryExpression | XHPClassNameToken | NameToken
+   */
+  public function getNamex(): EditableNode {
+    return $this->getName();
   }
 }

--- a/codegen/syntax/ScopeResolutionExpression.php
+++ b/codegen/syntax/ScopeResolutionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bb2231c3ea96a8a14fee45d28f77c69e>>
+ * @generated SignedSource<<a4d26ce02300bc32a1759e2797559c86>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -111,6 +111,17 @@ final class ScopeResolutionExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_qualifier);
   }
 
+  /**
+   * @returns FunctionCallExpression | GenericTypeSpecifier | LiteralExpression
+   * | ParenthesizedExpression | PipeVariableExpression | PrefixUnaryExpression
+   * | QualifiedName | ScopeResolutionExpression | SimpleTypeSpecifier |
+   * XHPClassNameToken | NameToken | ParentToken | SelfToken | StaticToken |
+   * VariableExpression
+   */
+  public function getQualifierx(): EditableNode {
+    return $this->getQualifier();
+  }
+
   public function getOperatorUNTYPED(): EditableNode {
     return $this->_operator;
   }
@@ -131,6 +142,13 @@ final class ScopeResolutionExpression extends EditableNode {
    */
   public function getOperator(): ColonColonToken {
     return TypeAssert\instance_of(ColonColonToken::class, $this->_operator);
+  }
+
+  /**
+   * @returns ColonColonToken
+   */
+  public function getOperatorx(): ColonColonToken {
+    return $this->getOperator();
   }
 
   public function getNameUNTYPED(): EditableNode {
@@ -154,5 +172,13 @@ final class ScopeResolutionExpression extends EditableNode {
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
+  }
+
+  /**
+   * @returns BracedExpression | PrefixUnaryExpression | ClassToken | NameToken
+   * | VariableToken
+   */
+  public function getNamex(): EditableNode {
+    return $this->getName();
   }
 }

--- a/codegen/syntax/Script.php
+++ b/codegen/syntax/Script.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<50947d9fe78f89f39e73f6752c2a2385>>
+ * @generated SignedSource<<ef7fc7ab2f1a7eb5a7e1ec0f675bdcbc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,5 +75,12 @@ final class Script extends EditableNode {
    */
   public function getDeclarations(): EditableList {
     return TypeAssert\instance_of(EditableList::class, $this->_declarations);
+  }
+
+  /**
+   * @returns EditableList
+   */
+  public function getDeclarationsx(): EditableList {
+    return $this->getDeclarations();
   }
 }

--- a/codegen/syntax/ShapeExpression.php
+++ b/codegen/syntax/ShapeExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<26455431123fb612d04ec75c4d22865a>>
+ * @generated SignedSource<<640193cc16a11a5aa229952fceae70c3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class ShapeExpression extends EditableNode {
     return TypeAssert\instance_of(ShapeToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ShapeToken
+   */
+  public function getKeywordx(): ShapeToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -146,6 +153,13 @@ final class ShapeExpression extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getFieldsUNTYPED(): EditableNode {
@@ -206,5 +220,12 @@ final class ShapeExpression extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 }

--- a/codegen/syntax/ShapeTypeSpecifier.php
+++ b/codegen/syntax/ShapeTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b587877583ea3862cf9484cf44fea00e>>
+ * @generated SignedSource<<d7053483cff0f0fe3c31c747bd66aea4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -139,6 +139,13 @@ final class ShapeTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(ShapeToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ShapeToken
+   */
+  public function getKeywordx(): ShapeToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -165,6 +172,13 @@ final class ShapeTypeSpecifier extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getFieldsUNTYPED(): EditableNode {
@@ -269,5 +283,12 @@ final class ShapeTypeSpecifier extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 }

--- a/codegen/syntax/SimpleInitializer.php
+++ b/codegen/syntax/SimpleInitializer.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<db95b5a57d0f205153581174bcd9aa17>>
+ * @generated SignedSource<<a8fc62f4fc9b12e2070c3e52835d77ff>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -88,6 +88,13 @@ final class SimpleInitializer extends EditableNode {
     return TypeAssert\instance_of(EqualToken::class, $this->_equal);
   }
 
+  /**
+   * @returns EqualToken
+   */
+  public function getEqualx(): EqualToken {
+    return $this->getEqual();
+  }
+
   public function getValueUNTYPED(): EditableNode {
     return $this->_value;
   }
@@ -115,5 +122,19 @@ final class SimpleInitializer extends EditableNode {
    */
   public function getValue(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_value);
+  }
+
+  /**
+   * @returns ArrayCreationExpression | ArrayIntrinsicExpression |
+   * BinaryExpression | CollectionLiteralExpression | ConditionalExpression |
+   * DarrayIntrinsicExpression | DictionaryIntrinsicExpression |
+   * FunctionCallExpression | KeysetIntrinsicExpression | LiteralExpression |
+   * ParenthesizedExpression | PrefixUnaryExpression | QualifiedName |
+   * ScopeResolutionExpression | ShapeExpression | SubscriptExpression |
+   * NameToken | TupleExpression | VariableExpression |
+   * VarrayIntrinsicExpression | VectorIntrinsicExpression | XHPExpression
+   */
+  public function getValuex(): EditableNode {
+    return $this->getValue();
   }
 }

--- a/codegen/syntax/SimpleInitializer.php
+++ b/codegen/syntax/SimpleInitializer.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1ee20a34304754c62392dff075d12f45>>
+ * @generated SignedSource<<db95b5a57d0f205153581174bcd9aa17>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -110,8 +110,8 @@ final class SimpleInitializer extends EditableNode {
    * FunctionCallExpression | KeysetIntrinsicExpression | LiteralExpression |
    * ParenthesizedExpression | PrefixUnaryExpression | QualifiedName |
    * ScopeResolutionExpression | ShapeExpression | SubscriptExpression |
-   * NameToken | TupleExpression | VarrayIntrinsicExpression |
-   * VectorIntrinsicExpression | XHPExpression
+   * NameToken | TupleExpression | VariableExpression |
+   * VarrayIntrinsicExpression | VectorIntrinsicExpression | XHPExpression
    */
   public function getValue(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_value);

--- a/codegen/syntax/SimpleTypeSpecifier.php
+++ b/codegen/syntax/SimpleTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1ab7c1d8eeea0961707058c98911b441>>
+ * @generated SignedSource<<17c9cd27ccd934dfba04bd7db1c09d1d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -80,5 +80,17 @@ final class SimpleTypeSpecifier extends EditableNode {
    */
   public function getSpecifier(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_specifier);
+  }
+
+  /**
+   * @returns QualifiedName | XHPClassNameToken | ConstructToken | ArrayToken |
+   * ArraykeyToken | BoolToken | BooleanToken | DarrayToken | DictToken |
+   * DoubleToken | FloatToken | IntToken | IntegerToken | KeysetToken |
+   * MixedToken | NameToken | NoreturnToken | NumToken | ObjectToken |
+   * ParentToken | RealToken | ResourceToken | SelfToken | StringToken |
+   * ThisToken | VarToken | VarrayToken | VecToken | VoidToken
+   */
+  public function getSpecifierx(): EditableNode {
+    return $this->getSpecifier();
   }
 }

--- a/codegen/syntax/SoftTypeSpecifier.php
+++ b/codegen/syntax/SoftTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<88b6ed5f2d0a5b2cfb2b4b5486b08ef4>>
+ * @generated SignedSource<<46946695a433feb860a6573dba18cea1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -88,6 +88,13 @@ final class SoftTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(AtToken::class, $this->_at);
   }
 
+  /**
+   * @returns AtToken
+   */
+  public function getAtx(): AtToken {
+    return $this->getAt();
+  }
+
   public function getTypeUNTYPED(): EditableNode {
     return $this->_type;
   }
@@ -110,5 +117,14 @@ final class SoftTypeSpecifier extends EditableNode {
    */
   public function getType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
+  }
+
+  /**
+   * @returns ClosureTypeSpecifier | GenericTypeSpecifier |
+   * MapArrayTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier |
+   * TupleTypeSpecifier
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
   }
 }

--- a/codegen/syntax/StaticDeclarator.php
+++ b/codegen/syntax/StaticDeclarator.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ba2c73488cd0ffdcbeb531d42e434cac>>
+ * @generated SignedSource<<e71beb716e6e854c61f4a7280c81a3f3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -86,6 +86,13 @@ final class StaticDeclarator extends EditableNode {
    */
   public function getName(): VariableToken {
     return TypeAssert\instance_of(VariableToken::class, $this->_name);
+  }
+
+  /**
+   * @returns VariableToken
+   */
+  public function getNamex(): VariableToken {
+    return $this->getName();
   }
 
   public function getInitializerUNTYPED(): EditableNode {

--- a/codegen/syntax/SubscriptExpression.php
+++ b/codegen/syntax/SubscriptExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<705d9bc158d4dc309a247f2ba9830f7c>>
+ * @generated SignedSource<<d9ea0084224cc3554a5a40678b8e495b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -129,6 +129,17 @@ final class SubscriptExpression extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_receiver);
   }
 
+  /**
+   * @returns ArrayCreationExpression | ArrayIntrinsicExpression |
+   * FunctionCallExpression | LiteralExpression | MemberSelectionExpression |
+   * ParenthesizedExpression | PrefixUnaryExpression |
+   * SafeMemberSelectionExpression | ScopeResolutionExpression |
+   * SubscriptExpression | RightParenToken | NameToken | VariableExpression
+   */
+  public function getReceiverx(): EditableNode {
+    return $this->getReceiver();
+  }
+
   public function getLeftBracketUNTYPED(): EditableNode {
     return $this->_left_bracket;
   }
@@ -154,6 +165,13 @@ final class SubscriptExpression extends EditableNode {
    */
   public function getLeftBracket(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_left_bracket);
+  }
+
+  /**
+   * @returns LeftBracketToken | LeftBraceToken
+   */
+  public function getLeftBracketx(): EditableToken {
+    return $this->getLeftBracket();
   }
 
   public function getIndexUNTYPED(): EditableNode {
@@ -186,6 +204,18 @@ final class SubscriptExpression extends EditableNode {
    */
   public function getIndex(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_index);
+  }
+
+  /**
+   * @returns AnonymousFunction | ArrayIntrinsicExpression | BinaryExpression |
+   * CastExpression | FunctionCallExpression | LiteralExpression |
+   * MemberSelectionExpression | Missing | ObjectCreationExpression |
+   * ParenthesizedExpression | PostfixUnaryExpression | PrefixUnaryExpression |
+   * SafeMemberSelectionExpression | ScopeResolutionExpression |
+   * SubscriptExpression | NameToken | VariableExpression
+   */
+  public function getIndexx(): EditableNode {
+    return $this->getIndex();
   }
 
   public function getRightBracketUNTYPED(): EditableNode {

--- a/codegen/syntax/SwitchFallthrough.php
+++ b/codegen/syntax/SwitchFallthrough.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<06130d4c0346af3755ad5aaaa5ef54f6>>
+ * @generated SignedSource<<a31437ad27d05fd2c1d62a53c76c9ea0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -88,6 +88,13 @@ final class SwitchFallthrough extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_keyword);
   }
 
+  /**
+   * @returns Missing
+   */
+  public function getKeywordx(): EditableNode {
+    return $this->getKeyword();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -108,5 +115,12 @@ final class SwitchFallthrough extends EditableNode {
    */
   public function getSemicolon(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns Missing
+   */
+  public function getSemicolonx(): EditableNode {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/SwitchSection.php
+++ b/codegen/syntax/SwitchSection.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ada3fc3567412e4f82db421227a50cd1>>
+ * @generated SignedSource<<4b9154f77f31df3472da6b377572d431>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -105,6 +105,13 @@ final class SwitchSection extends EditableNode {
    */
   public function getLabels(): EditableList {
     return TypeAssert\instance_of(EditableList::class, $this->_labels);
+  }
+
+  /**
+   * @returns EditableList
+   */
+  public function getLabelsx(): EditableList {
+    return $this->getLabels();
   }
 
   public function getStatementsUNTYPED(): EditableNode {

--- a/codegen/syntax/SwitchStatement.php
+++ b/codegen/syntax/SwitchStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<884081fd63ecdd64f9b9d2be169205fe>>
+ * @generated SignedSource<<b00b1c3afa100ea8dff2075562a5776b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -185,6 +185,13 @@ final class SwitchStatement
     return TypeAssert\instance_of(SwitchToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns SwitchToken
+   */
+  public function getKeywordx(): SwitchToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -213,6 +220,13 @@ final class SwitchStatement
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getExpressionUNTYPED(): EditableNode {
@@ -247,6 +261,15 @@ final class SwitchStatement
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
+  /**
+   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * MemberSelectionExpression | ObjectCreationExpression |
+   * PrefixUnaryExpression | SubscriptExpression | VariableExpression
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -277,6 +300,13 @@ final class SwitchStatement
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
+  }
+
   public function getLeftBraceUNTYPED(): EditableNode {
     return $this->_left_brace;
   }
@@ -305,6 +335,13 @@ final class SwitchStatement
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
+  }
+
+  /**
+   * @returns LeftBraceToken
+   */
+  public function getLeftBracex(): LeftBraceToken {
+    return $this->getLeftBrace();
   }
 
   public function getSectionsUNTYPED(): EditableNode {
@@ -375,5 +412,12 @@ final class SwitchStatement
    */
   public function getRightBrace(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
+  }
+
+  /**
+   * @returns RightBraceToken
+   */
+  public function getRightBracex(): RightBraceToken {
+    return $this->getRightBrace();
   }
 }

--- a/codegen/syntax/ThrowStatement.php
+++ b/codegen/syntax/ThrowStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<81c1097edf8bc01336684a6ba8dcba70>>
+ * @generated SignedSource<<63726dc422ed3f0419daf22b756cc256>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class ThrowStatement extends EditableNode {
     return TypeAssert\instance_of(ThrowToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ThrowToken
+   */
+  public function getKeywordx(): ThrowToken {
+    return $this->getKeyword();
+  }
+
   public function getExpressionUNTYPED(): EditableNode {
     return $this->_expression;
   }
@@ -130,6 +137,14 @@ final class ThrowStatement extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
+  /**
+   * @returns FunctionCallExpression | LiteralExpression |
+   * ObjectCreationExpression | ParenthesizedExpression | VariableExpression
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -150,5 +165,12 @@ final class ThrowStatement extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/TraitUse.php
+++ b/codegen/syntax/TraitUse.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e825fa4873659a08a881d4aa47020dbc>>
+ * @generated SignedSource<<c30efe0a924ea6a5bd8bf979955d818d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class TraitUse extends EditableNode {
     return TypeAssert\instance_of(UseToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns UseToken
+   */
+  public function getKeywordx(): UseToken {
+    return $this->getKeyword();
+  }
+
   public function getNamesUNTYPED(): EditableNode {
     return $this->_names;
   }
@@ -129,6 +136,13 @@ final class TraitUse extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_names);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getNamesx(): EditableList {
+    return $this->getNames();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -149,5 +163,12 @@ final class TraitUse extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/TraitUseAliasItem.php
+++ b/codegen/syntax/TraitUseAliasItem.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<78544545602a0c9e365802c9f12e9d0d>>
+ * @generated SignedSource<<2bfd8195f2a90798bdf5fa7b34dc73a6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class TraitUseAliasItem extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_aliasing_name);
   }
 
+  /**
+   * @returns ScopeResolutionExpression | SimpleTypeSpecifier
+   */
+  public function getAliasingNamex(): EditableNode {
+    return $this->getAliasingName();
+  }
+
   public function getKeywordUNTYPED(): EditableNode {
     return $this->_keyword;
   }
@@ -150,6 +157,13 @@ final class TraitUseAliasItem extends EditableNode {
    */
   public function getKeyword(): AsToken {
     return TypeAssert\instance_of(AsToken::class, $this->_keyword);
+  }
+
+  /**
+   * @returns AsToken
+   */
+  public function getKeywordx(): AsToken {
+    return $this->getKeyword();
   }
 
   public function getModifiersUNTYPED(): EditableNode {

--- a/codegen/syntax/TraitUseConflictResolution.php
+++ b/codegen/syntax/TraitUseConflictResolution.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f5eb829034b0c17e7f896fdce83e7399>>
+ * @generated SignedSource<<2b40ab78643381ab492a4bb0ed179bc9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -139,6 +139,13 @@ final class TraitUseConflictResolution extends EditableNode {
     return TypeAssert\instance_of(UseToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns UseToken
+   */
+  public function getKeywordx(): UseToken {
+    return $this->getKeyword();
+  }
+
   public function getNamesUNTYPED(): EditableNode {
     return $this->_names;
   }
@@ -167,6 +174,13 @@ final class TraitUseConflictResolution extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_names);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getNamesx(): EditableList {
+    return $this->getNames();
+  }
+
   public function getLeftBraceUNTYPED(): EditableNode {
     return $this->_left_brace;
   }
@@ -193,6 +207,13 @@ final class TraitUseConflictResolution extends EditableNode {
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
+  }
+
+  /**
+   * @returns LeftBraceToken
+   */
+  public function getLeftBracex(): LeftBraceToken {
+    return $this->getLeftBrace();
   }
 
   public function getClausesUNTYPED(): EditableNode {
@@ -259,5 +280,12 @@ final class TraitUseConflictResolution extends EditableNode {
    */
   public function getRightBrace(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
+  }
+
+  /**
+   * @returns RightBraceToken
+   */
+  public function getRightBracex(): RightBraceToken {
+    return $this->getRightBrace();
   }
 }

--- a/codegen/syntax/TraitUsePrecedenceItem.php
+++ b/codegen/syntax/TraitUsePrecedenceItem.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d16df461ab3e8d396f87442bd8bdbdfb>>
+ * @generated SignedSource<<429c175d47437d3207893365b8a06465>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -108,6 +108,13 @@ final class TraitUsePrecedenceItem extends EditableNode {
       TypeAssert\instance_of(ScopeResolutionExpression::class, $this->_name);
   }
 
+  /**
+   * @returns ScopeResolutionExpression
+   */
+  public function getNamex(): ScopeResolutionExpression {
+    return $this->getName();
+  }
+
   public function getKeywordUNTYPED(): EditableNode {
     return $this->_keyword;
   }
@@ -130,6 +137,13 @@ final class TraitUsePrecedenceItem extends EditableNode {
     return TypeAssert\instance_of(InsteadofToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns InsteadofToken
+   */
+  public function getKeywordx(): InsteadofToken {
+    return $this->getKeyword();
+  }
+
   public function getRemovedNamesUNTYPED(): EditableNode {
     return $this->_removed_names;
   }
@@ -150,5 +164,12 @@ final class TraitUsePrecedenceItem extends EditableNode {
    */
   public function getRemovedNames(): EditableList {
     return TypeAssert\instance_of(EditableList::class, $this->_removed_names);
+  }
+
+  /**
+   * @returns EditableList
+   */
+  public function getRemovedNamesx(): EditableList {
+    return $this->getRemovedNames();
   }
 }

--- a/codegen/syntax/TryStatement.php
+++ b/codegen/syntax/TryStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7b20dda4450d4719eede4fe9dc2754c1>>
+ * @generated SignedSource<<cc980af08d452c38c939da0e4ef0e398>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -136,6 +136,13 @@ final class TryStatement extends EditableNode {
     return TypeAssert\instance_of(TryToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns TryToken
+   */
+  public function getKeywordx(): TryToken {
+    return $this->getKeyword();
+  }
+
   public function getCompoundStatementUNTYPED(): EditableNode {
     return $this->_compound_statement;
   }
@@ -164,6 +171,13 @@ final class TryStatement extends EditableNode {
       CompoundStatement::class,
       $this->_compound_statement,
     );
+  }
+
+  /**
+   * @returns CompoundStatement
+   */
+  public function getCompoundStatementx(): CompoundStatement {
+    return $this->getCompoundStatement();
   }
 
   public function getCatchClausesUNTYPED(): EditableNode {

--- a/codegen/syntax/TupleExpression.php
+++ b/codegen/syntax/TupleExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d425e4554cdb1a34873a708491a5fd5f>>
+ * @generated SignedSource<<5a0ff74be979f5032b1ae511c819f153>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class TupleExpression extends EditableNode {
     return TypeAssert\instance_of(TupleToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns TupleToken
+   */
+  public function getKeywordx(): TupleToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -146,6 +153,13 @@ final class TupleExpression extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getItemsUNTYPED(): EditableNode {
@@ -206,5 +220,12 @@ final class TupleExpression extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 }

--- a/codegen/syntax/TupleTypeExplicitSpecifier.php
+++ b/codegen/syntax/TupleTypeExplicitSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6a64cdae0cf8c3fe64daa94ec6bc417c>>
+ * @generated SignedSource<<31ac9fb78f456234d592a59cf0694755>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class TupleTypeExplicitSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_keyword);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getKeywordx(): EditableNode {
+    return $this->getKeyword();
+  }
+
   public function getLeftAngleUNTYPED(): EditableNode {
     return $this->_left_angle;
   }
@@ -146,6 +153,13 @@ final class TupleTypeExplicitSpecifier extends EditableNode {
    */
   public function getLeftAngle(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_angle);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getLeftAnglex(): EditableNode {
+    return $this->getLeftAngle();
   }
 
   public function getTypesUNTYPED(): EditableNode {
@@ -175,6 +189,13 @@ final class TupleTypeExplicitSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_types);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getTypesx(): EditableNode {
+    return $this->getTypes();
+  }
+
   public function getRightAngleUNTYPED(): EditableNode {
     return $this->_right_angle;
   }
@@ -196,5 +217,12 @@ final class TupleTypeExplicitSpecifier extends EditableNode {
    */
   public function getRightAngle(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_angle);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getRightAnglex(): EditableNode {
+    return $this->getRightAngle();
   }
 }

--- a/codegen/syntax/TupleTypeSpecifier.php
+++ b/codegen/syntax/TupleTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<40d4f3ff5e4a920c00d40f747c9f6563>>
+ * @generated SignedSource<<95010db8cc47a782bd3056ce98445329>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class TupleTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
+  }
+
   public function getTypesUNTYPED(): EditableNode {
     return $this->_types;
   }
@@ -129,6 +136,13 @@ final class TupleTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_types);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getTypesx(): EditableList {
+    return $this->getTypes();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -149,5 +163,12 @@ final class TupleTypeSpecifier extends EditableNode {
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 }

--- a/codegen/syntax/TypeArguments.php
+++ b/codegen/syntax/TypeArguments.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<730877383d50d6282cb07609c27e0597>>
+ * @generated SignedSource<<0308590539e1b0fad7723b55d59a6626>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class TypeArguments extends EditableNode {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
   }
 
+  /**
+   * @returns LessThanToken
+   */
+  public function getLeftAnglex(): LessThanToken {
+    return $this->getLeftAngle();
+  }
+
   public function getTypesUNTYPED(): EditableNode {
     return $this->_types;
   }
@@ -127,6 +134,13 @@ final class TypeArguments extends EditableNode {
    */
   public function getTypes(): EditableList {
     return TypeAssert\instance_of(EditableList::class, $this->_types);
+  }
+
+  /**
+   * @returns EditableList
+   */
+  public function getTypesx(): EditableList {
+    return $this->getTypes();
   }
 
   public function getRightAngleUNTYPED(): EditableNode {

--- a/codegen/syntax/TypeConstDeclaration.php
+++ b/codegen/syntax/TypeConstDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1a2ea2e37ed0bd1eda6ae66945e54e21>>
+ * @generated SignedSource<<ea2a0b865996c78c3db97d3f646dfeea>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -257,6 +257,13 @@ final class TypeConstDeclaration extends EditableNode {
     return TypeAssert\instance_of(ConstToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ConstToken
+   */
+  public function getKeywordx(): ConstToken {
+    return $this->getKeyword();
+  }
+
   public function getTypeKeywordUNTYPED(): EditableNode {
     return $this->_type_keyword;
   }
@@ -287,6 +294,13 @@ final class TypeConstDeclaration extends EditableNode {
    */
   public function getTypeKeyword(): TypeToken {
     return TypeAssert\instance_of(TypeToken::class, $this->_type_keyword);
+  }
+
+  /**
+   * @returns TypeToken
+   */
+  public function getTypeKeywordx(): TypeToken {
+    return $this->getTypeKeyword();
   }
 
   public function getNameUNTYPED(): EditableNode {
@@ -321,6 +335,13 @@ final class TypeConstDeclaration extends EditableNode {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
   }
 
+  /**
+   * @returns NameToken
+   */
+  public function getNamex(): NameToken {
+    return $this->getName();
+  }
+
   public function getTypeParametersUNTYPED(): EditableNode {
     return $this->_type_parameters;
   }
@@ -351,6 +372,13 @@ final class TypeConstDeclaration extends EditableNode {
    */
   public function getTypeParameters(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type_parameters);
+  }
+
+  /**
+   * @returns Missing
+   */
+  public function getTypeParametersx(): EditableNode {
+    return $this->getTypeParameters();
   }
 
   public function getTypeConstraintUNTYPED(): EditableNode {
@@ -474,6 +502,16 @@ final class TypeConstDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type_specifier);
   }
 
+  /**
+   * @returns ClosureTypeSpecifier | DictionaryTypeSpecifier |
+   * GenericTypeSpecifier | KeysetTypeSpecifier | Missing |
+   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
+   * TupleTypeSpecifier | TypeConstant | VectorTypeSpecifier
+   */
+  public function getTypeSpecifierx(): EditableNode {
+    return $this->getTypeSpecifier();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -504,5 +542,12 @@ final class TypeConstDeclaration extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/TypeConstant.php
+++ b/codegen/syntax/TypeConstant.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f7476d23d9d286c4a89e1f5a9f2cf703>>
+ * @generated SignedSource<<4d6e2db00b0b43187a1e2d66fd84ef7e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class TypeConstant extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_type);
   }
 
+  /**
+   * @returns NameToken | ParentToken | SelfToken | ThisToken | TypeConstant
+   */
+  public function getLeftTypex(): EditableNode {
+    return $this->getLeftType();
+  }
+
   public function getSeparatorUNTYPED(): EditableNode {
     return $this->_separator;
   }
@@ -129,6 +136,13 @@ final class TypeConstant extends EditableNode {
     return TypeAssert\instance_of(ColonColonToken::class, $this->_separator);
   }
 
+  /**
+   * @returns ColonColonToken
+   */
+  public function getSeparatorx(): ColonColonToken {
+    return $this->getSeparator();
+  }
+
   public function getRightTypeUNTYPED(): EditableNode {
     return $this->_right_type;
   }
@@ -149,5 +163,12 @@ final class TypeConstant extends EditableNode {
    */
   public function getRightType(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_right_type);
+  }
+
+  /**
+   * @returns NameToken
+   */
+  public function getRightTypex(): NameToken {
+    return $this->getRightType();
   }
 }

--- a/codegen/syntax/TypeConstraint.php
+++ b/codegen/syntax/TypeConstraint.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2365942ea97fca8f65f1a0e7bbd8515b>>
+ * @generated SignedSource<<be07a11b8263035b4e9fc14828b36f40>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -88,6 +88,13 @@ final class TypeConstraint extends EditableNode {
     return TypeAssert\instance_of(EditableToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns AsToken | SuperToken
+   */
+  public function getKeywordx(): EditableToken {
+    return $this->getKeyword();
+  }
+
   public function getTypeUNTYPED(): EditableNode {
     return $this->_type;
   }
@@ -111,5 +118,15 @@ final class TypeConstraint extends EditableNode {
    */
   public function getType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
+  }
+
+  /**
+   * @returns ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * DictionaryTypeSpecifier | GenericTypeSpecifier | KeysetTypeSpecifier |
+   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
+   * TypeConstant | VectorArrayTypeSpecifier
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
   }
 }

--- a/codegen/syntax/TypeParameter.php
+++ b/codegen/syntax/TypeParameter.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<15fcc7617b837cf719c299ecf0e17a23>>
+ * @generated SignedSource<<19d8d1170a4f48fc8f027e66b33c9572>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -137,6 +137,13 @@ final class TypeParameter extends EditableNode {
    */
   public function getName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
+  }
+
+  /**
+   * @returns NameToken
+   */
+  public function getNamex(): NameToken {
+    return $this->getName();
   }
 
   public function getConstraintsUNTYPED(): EditableNode {

--- a/codegen/syntax/TypeParameters.php
+++ b/codegen/syntax/TypeParameters.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a11ffce86c5637a9a67ccabfd44f9d04>>
+ * @generated SignedSource<<441264d9609d52dd73a23fd38258ecb5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class TypeParameters extends EditableNode {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
   }
 
+  /**
+   * @returns LessThanToken
+   */
+  public function getLeftAnglex(): LessThanToken {
+    return $this->getLeftAngle();
+  }
+
   public function getParametersUNTYPED(): EditableNode {
     return $this->_parameters;
   }
@@ -129,6 +136,13 @@ final class TypeParameters extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_parameters);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getParametersx(): EditableList {
+    return $this->getParameters();
+  }
+
   public function getRightAngleUNTYPED(): EditableNode {
     return $this->_right_angle;
   }
@@ -149,5 +163,12 @@ final class TypeParameters extends EditableNode {
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
+  }
+
+  /**
+   * @returns GreaterThanToken
+   */
+  public function getRightAnglex(): GreaterThanToken {
+    return $this->getRightAngle();
   }
 }

--- a/codegen/syntax/TypeParameters.php
+++ b/codegen/syntax/TypeParameters.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b1826e68d71a7d2957178b941611a8e6>>
+ * @generated SignedSource<<a11ffce86c5637a9a67ccabfd44f9d04>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -145,19 +145,9 @@ final class TypeParameters extends EditableNode {
   }
 
   /**
-   * @returns Missing | GreaterThanToken
-   */
-  public function getRightAngle(): ?GreaterThanToken {
-    if ($this->_right_angle->isMissing()) {
-      return null;
-    }
-    return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
-  }
-
-  /**
    * @returns GreaterThanToken
    */
-  public function getRightAnglex(): GreaterThanToken {
+  public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
   }
 }

--- a/codegen/syntax/UnsetStatement.php
+++ b/codegen/syntax/UnsetStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a043654819d113f7c87c5cc5c67ce464>>
+ * @generated SignedSource<<4e7aebdd577355ea3d680788e1652b71>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -141,6 +141,13 @@ final class UnsetStatement extends EditableNode {
     return TypeAssert\instance_of(UnsetToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns UnsetToken
+   */
+  public function getKeywordx(): UnsetToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -167,6 +174,13 @@ final class UnsetStatement extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getVariablesUNTYPED(): EditableNode {
@@ -197,6 +211,13 @@ final class UnsetStatement extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_variables);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getVariablesx(): EditableList {
+    return $this->getVariables();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -225,6 +246,13 @@ final class UnsetStatement extends EditableNode {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -251,5 +279,12 @@ final class UnsetStatement extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/UsingStatementBlockScoped.php
+++ b/codegen/syntax/UsingStatementBlockScoped.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5907935e52a7281584f5b379686d3cf6>>
+ * @generated SignedSource<<3791d7cead6921e7356f4a3bd5763a2d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -206,6 +206,13 @@ final class UsingStatementBlockScoped extends EditableNode {
     return TypeAssert\instance_of(UsingToken::class, $this->_using_keyword);
   }
 
+  /**
+   * @returns UsingToken
+   */
+  public function getUsingKeywordx(): UsingToken {
+    return $this->getUsingKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -233,6 +240,13 @@ final class UsingStatementBlockScoped extends EditableNode {
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getExpressionsUNTYPED(): EditableNode {
@@ -264,6 +278,13 @@ final class UsingStatementBlockScoped extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_expressions);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getExpressionsx(): EditableList {
+    return $this->getExpressions();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -293,6 +314,13 @@ final class UsingStatementBlockScoped extends EditableNode {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
+  }
+
   public function getBodyUNTYPED(): EditableNode {
     return $this->_body;
   }
@@ -320,5 +348,12 @@ final class UsingStatementBlockScoped extends EditableNode {
    */
   public function getBody(): CompoundStatement {
     return TypeAssert\instance_of(CompoundStatement::class, $this->_body);
+  }
+
+  /**
+   * @returns CompoundStatement
+   */
+  public function getBodyx(): CompoundStatement {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/UsingStatementFunctionScoped.php
+++ b/codegen/syntax/UsingStatementFunctionScoped.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a29408c5def76b704b8484c0c4b36d54>>
+ * @generated SignedSource<<162b4a5d19b01f9e8fe2459720bab0d3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -162,6 +162,13 @@ final class UsingStatementFunctionScoped extends EditableNode {
     return TypeAssert\instance_of(UsingToken::class, $this->_using_keyword);
   }
 
+  /**
+   * @returns UsingToken
+   */
+  public function getUsingKeywordx(): UsingToken {
+    return $this->getUsingKeyword();
+  }
+
   public function getExpressionUNTYPED(): EditableNode {
     return $this->_expression;
   }
@@ -190,6 +197,14 @@ final class UsingStatementFunctionScoped extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
+  /**
+   * @returns BinaryExpression | LambdaExpression | ObjectCreationExpression |
+   * ParenthesizedExpression | PrefixUnaryExpression | VariableExpression
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -215,5 +230,12 @@ final class UsingStatementFunctionScoped extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/VariableExpression.php
+++ b/codegen/syntax/VariableExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<932d560b1a3bfe27271aff03318876ce>>
+ * @generated SignedSource<<284cabdc4efe7a17057edc1b97771e1a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,5 +75,12 @@ final class VariableExpression extends EditableNode {
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
   }
 }

--- a/codegen/syntax/VariadicParameter.php
+++ b/codegen/syntax/VariadicParameter.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<63ca3eb889597fd2f6c629df43488f0c>>
+ * @generated SignedSource<<a1ac50e2e6ec7768c841e17a541c2dde>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class VariadicParameter extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_call_convention);
   }
 
+  /**
+   * @returns Missing
+   */
+  public function getCallConventionx(): EditableNode {
+    return $this->getCallConvention();
+  }
+
   public function getTypeUNTYPED(): EditableNode {
     return $this->_type;
   }
@@ -130,6 +137,14 @@ final class VariadicParameter extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
   }
 
+  /**
+   * @returns ClosureTypeSpecifier | Missing | SimpleTypeSpecifier |
+   * TupleTypeSpecifier
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
+  }
+
   public function getEllipsisUNTYPED(): EditableNode {
     return $this->_ellipsis;
   }
@@ -150,5 +165,12 @@ final class VariadicParameter extends EditableNode {
    */
   public function getEllipsis(): DotDotDotToken {
     return TypeAssert\instance_of(DotDotDotToken::class, $this->_ellipsis);
+  }
+
+  /**
+   * @returns DotDotDotToken
+   */
+  public function getEllipsisx(): DotDotDotToken {
+    return $this->getEllipsis();
   }
 }

--- a/codegen/syntax/VarrayIntrinsicExpression.php
+++ b/codegen/syntax/VarrayIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c2bdc07b5813ca7112f5df549c7ea1e4>>
+ * @generated SignedSource<<e2ac7ae8ec5337ada30d15eb8dd9ebbb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -151,6 +151,13 @@ final class VarrayIntrinsicExpression extends EditableNode {
     return TypeAssert\instance_of(VarrayToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns VarrayToken
+   */
+  public function getKeywordx(): VarrayToken {
+    return $this->getKeyword();
+  }
+
   public function getExplicitTypeUNTYPED(): EditableNode {
     return $this->_explicit_type;
   }
@@ -177,6 +184,13 @@ final class VarrayIntrinsicExpression extends EditableNode {
    */
   public function getExplicitType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_explicit_type);
+  }
+
+  /**
+   * @returns Missing
+   */
+  public function getExplicitTypex(): EditableNode {
+    return $this->getExplicitType();
   }
 
   public function getLeftBracketUNTYPED(): EditableNode {
@@ -206,6 +220,13 @@ final class VarrayIntrinsicExpression extends EditableNode {
   public function getLeftBracket(): LeftBracketToken {
     return
       TypeAssert\instance_of(LeftBracketToken::class, $this->_left_bracket);
+  }
+
+  /**
+   * @returns LeftBracketToken
+   */
+  public function getLeftBracketx(): LeftBracketToken {
+    return $this->getLeftBracket();
   }
 
   public function getMembersUNTYPED(): EditableNode {
@@ -273,5 +294,12 @@ final class VarrayIntrinsicExpression extends EditableNode {
   public function getRightBracket(): RightBracketToken {
     return
       TypeAssert\instance_of(RightBracketToken::class, $this->_right_bracket);
+  }
+
+  /**
+   * @returns RightBracketToken
+   */
+  public function getRightBracketx(): RightBracketToken {
+    return $this->getRightBracket();
   }
 }

--- a/codegen/syntax/VarrayTypeSpecifier.php
+++ b/codegen/syntax/VarrayTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<dae5e59b9dcabd874a554518b97e5773>>
+ * @generated SignedSource<<ff6d213893fb8aded1a7615f8861e5b5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -141,6 +141,13 @@ final class VarrayTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(VarrayToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns VarrayToken
+   */
+  public function getKeywordx(): VarrayToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftAngleUNTYPED(): EditableNode {
     return $this->_left_angle;
   }
@@ -167,6 +174,13 @@ final class VarrayTypeSpecifier extends EditableNode {
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
+  }
+
+  /**
+   * @returns LessThanToken
+   */
+  public function getLeftAnglex(): LessThanToken {
+    return $this->getLeftAngle();
   }
 
   public function getTypeUNTYPED(): EditableNode {
@@ -198,6 +212,14 @@ final class VarrayTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
   }
 
+  /**
+   * @returns DarrayTypeSpecifier | SimpleTypeSpecifier | VarrayTypeSpecifier |
+   * VectorArrayTypeSpecifier
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
+  }
+
   public function getTrailingCommaUNTYPED(): EditableNode {
     return $this->_trailing_comma;
   }
@@ -226,6 +248,13 @@ final class VarrayTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_trailing_comma);
   }
 
+  /**
+   * @returns Missing
+   */
+  public function getTrailingCommax(): EditableNode {
+    return $this->getTrailingComma();
+  }
+
   public function getRightAngleUNTYPED(): EditableNode {
     return $this->_right_angle;
   }
@@ -252,5 +281,12 @@ final class VarrayTypeSpecifier extends EditableNode {
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
+  }
+
+  /**
+   * @returns GreaterThanToken
+   */
+  public function getRightAnglex(): GreaterThanToken {
+    return $this->getRightAngle();
   }
 }

--- a/codegen/syntax/VectorArrayTypeSpecifier.php
+++ b/codegen/syntax/VectorArrayTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<257dca78d26d19a67cc9eb542abb0ba7>>
+ * @generated SignedSource<<a1cc74550b618468b76dcf5942aae1e0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -121,6 +121,13 @@ final class VectorArrayTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(ArrayToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns ArrayToken
+   */
+  public function getKeywordx(): ArrayToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftAngleUNTYPED(): EditableNode {
     return $this->_left_angle;
   }
@@ -142,6 +149,13 @@ final class VectorArrayTypeSpecifier extends EditableNode {
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
+  }
+
+  /**
+   * @returns LessThanToken
+   */
+  public function getLeftAnglex(): LessThanToken {
+    return $this->getLeftAngle();
   }
 
   public function getTypeUNTYPED(): EditableNode {
@@ -173,6 +187,15 @@ final class VectorArrayTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
   }
 
+  /**
+   * @returns DarrayTypeSpecifier | GenericTypeSpecifier |
+   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
+   * TupleTypeSpecifier | VarrayTypeSpecifier | VectorArrayTypeSpecifier
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
+  }
+
   public function getRightAngleUNTYPED(): EditableNode {
     return $this->_right_angle;
   }
@@ -194,5 +217,12 @@ final class VectorArrayTypeSpecifier extends EditableNode {
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
+  }
+
+  /**
+   * @returns GreaterThanToken
+   */
+  public function getRightAnglex(): GreaterThanToken {
+    return $this->getRightAngle();
   }
 }

--- a/codegen/syntax/VectorIntrinsicExpression.php
+++ b/codegen/syntax/VectorIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<923204578abd073a5a060aeb17767db1>>
+ * @generated SignedSource<<77f3f16cb5c24cfdeefbe9a4194c86f2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -151,6 +151,13 @@ final class VectorIntrinsicExpression extends EditableNode {
     return TypeAssert\instance_of(VecToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns VecToken
+   */
+  public function getKeywordx(): VecToken {
+    return $this->getKeyword();
+  }
+
   public function getExplicitTypeUNTYPED(): EditableNode {
     return $this->_explicit_type;
   }
@@ -177,6 +184,13 @@ final class VectorIntrinsicExpression extends EditableNode {
    */
   public function getExplicitType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_explicit_type);
+  }
+
+  /**
+   * @returns Missing
+   */
+  public function getExplicitTypex(): EditableNode {
+    return $this->getExplicitType();
   }
 
   public function getLeftBracketUNTYPED(): EditableNode {
@@ -206,6 +220,13 @@ final class VectorIntrinsicExpression extends EditableNode {
   public function getLeftBracket(): LeftBracketToken {
     return
       TypeAssert\instance_of(LeftBracketToken::class, $this->_left_bracket);
+  }
+
+  /**
+   * @returns LeftBracketToken
+   */
+  public function getLeftBracketx(): LeftBracketToken {
+    return $this->getLeftBracket();
   }
 
   public function getMembersUNTYPED(): EditableNode {
@@ -273,5 +294,12 @@ final class VectorIntrinsicExpression extends EditableNode {
   public function getRightBracket(): RightBracketToken {
     return
       TypeAssert\instance_of(RightBracketToken::class, $this->_right_bracket);
+  }
+
+  /**
+   * @returns RightBracketToken
+   */
+  public function getRightBracketx(): RightBracketToken {
+    return $this->getRightBracket();
   }
 }

--- a/codegen/syntax/VectorTypeSpecifier.php
+++ b/codegen/syntax/VectorTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f2dfd0fec789fea07f0290d3c32485ab>>
+ * @generated SignedSource<<cd41884207b33982999a429e242696e0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -141,6 +141,13 @@ final class VectorTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(VecToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns VecToken
+   */
+  public function getKeywordx(): VecToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftAngleUNTYPED(): EditableNode {
     return $this->_left_angle;
   }
@@ -167,6 +174,13 @@ final class VectorTypeSpecifier extends EditableNode {
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
+  }
+
+  /**
+   * @returns LessThanToken
+   */
+  public function getLeftAnglex(): LessThanToken {
+    return $this->getLeftAngle();
   }
 
   public function getTypeUNTYPED(): EditableNode {
@@ -198,6 +212,14 @@ final class VectorTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
   }
 
+  /**
+   * @returns ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * NullableTypeSpecifier | SimpleTypeSpecifier | VectorTypeSpecifier
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
+  }
+
   public function getTrailingCommaUNTYPED(): EditableNode {
     return $this->_trailing_comma;
   }
@@ -226,6 +248,13 @@ final class VectorTypeSpecifier extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_trailing_comma);
   }
 
+  /**
+   * @returns Missing
+   */
+  public function getTrailingCommax(): EditableNode {
+    return $this->getTrailingComma();
+  }
+
   public function getRightAngleUNTYPED(): EditableNode {
     return $this->_right_angle;
   }
@@ -252,5 +281,12 @@ final class VectorTypeSpecifier extends EditableNode {
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
+  }
+
+  /**
+   * @returns GreaterThanToken
+   */
+  public function getRightAnglex(): GreaterThanToken {
+    return $this->getRightAngle();
   }
 }

--- a/codegen/syntax/WhereClause.php
+++ b/codegen/syntax/WhereClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<04389f7addfb0d19da4697987103b3c3>>
+ * @generated SignedSource<<4cf7a8af61700941b0b140bd61a4ce5f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -91,6 +91,13 @@ final class WhereClause extends EditableNode {
     return TypeAssert\instance_of(WhereToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns WhereToken
+   */
+  public function getKeywordx(): WhereToken {
+    return $this->getKeyword();
+  }
+
   public function getConstraintsUNTYPED(): EditableNode {
     return $this->_constraints;
   }
@@ -111,5 +118,12 @@ final class WhereClause extends EditableNode {
    */
   public function getConstraints(): EditableList {
     return TypeAssert\instance_of(EditableList::class, $this->_constraints);
+  }
+
+  /**
+   * @returns EditableList
+   */
+  public function getConstraintsx(): EditableList {
+    return $this->getConstraints();
   }
 }

--- a/codegen/syntax/WhereConstraint.php
+++ b/codegen/syntax/WhereConstraint.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4edf0875c0f6e962d03f29861b5ea2c4>>
+ * @generated SignedSource<<7469ccdcf64e78ed5486571e486f3f63>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class WhereConstraint extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_type);
   }
 
+  /**
+   * @returns GenericTypeSpecifier | SimpleTypeSpecifier | TypeConstant
+   */
+  public function getLeftTypex(): EditableNode {
+    return $this->getLeftType();
+  }
+
   public function getOperatorUNTYPED(): EditableNode {
     return $this->_operator;
   }
@@ -127,6 +134,13 @@ final class WhereConstraint extends EditableNode {
    */
   public function getOperator(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_operator);
+  }
+
+  /**
+   * @returns EqualToken | AsToken | SuperToken
+   */
+  public function getOperatorx(): EditableToken {
+    return $this->getOperator();
   }
 
   public function getRightTypeUNTYPED(): EditableNode {
@@ -150,5 +164,13 @@ final class WhereConstraint extends EditableNode {
    */
   public function getRightType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_type);
+  }
+
+  /**
+   * @returns GenericTypeSpecifier | NullableTypeSpecifier |
+   * SimpleTypeSpecifier | TypeConstant
+   */
+  public function getRightTypex(): EditableNode {
+    return $this->getRightType();
   }
 }

--- a/codegen/syntax/WhileStatement.php
+++ b/codegen/syntax/WhileStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3834b14291e9014424d31764b6795b8d>>
+ * @generated SignedSource<<4b954ac328fe4102935e42506bf35f7d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -141,6 +141,13 @@ final class WhileStatement
     return TypeAssert\instance_of(WhileToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns WhileToken
+   */
+  public function getKeywordx(): WhileToken {
+    return $this->getKeyword();
+  }
+
   public function getLeftParenUNTYPED(): EditableNode {
     return $this->_left_paren;
   }
@@ -167,6 +174,13 @@ final class WhileStatement
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
+  }
+
+  /**
+   * @returns LeftParenToken
+   */
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getConditionUNTYPED(): EditableNode {
@@ -199,6 +213,15 @@ final class WhileStatement
     return TypeAssert\instance_of(EditableNode::class, $this->_condition);
   }
 
+  /**
+   * @returns BinaryExpression | FunctionCallExpression | InstanceofExpression
+   * | IssetExpression | LiteralExpression | ParenthesizedExpression |
+   * PostfixUnaryExpression | PrefixUnaryExpression | VariableExpression
+   */
+  public function getConditionx(): EditableNode {
+    return $this->getCondition();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -225,6 +248,13 @@ final class WhileStatement
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns RightParenToken
+   */
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 
   public function getBodyUNTYPED(): EditableNode {
@@ -254,5 +284,13 @@ final class WhileStatement
    */
   public function getBody(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_body);
+  }
+
+  /**
+   * @returns AlternateLoopStatement | CompoundStatement | ContinueStatement |
+   * EchoStatement | ExpressionStatement
+   */
+  public function getBodyx(): EditableNode {
+    return $this->getBody();
   }
 }

--- a/codegen/syntax/XHPCategoryDeclaration.php
+++ b/codegen/syntax/XHPCategoryDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<48fb3d76c9d03b041f128e589f7e2e0b>>
+ * @generated SignedSource<<7ba1ed264d141e187a4290dfe66f503f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class XHPCategoryDeclaration extends EditableNode {
     return TypeAssert\instance_of(CategoryToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns CategoryToken
+   */
+  public function getKeywordx(): CategoryToken {
+    return $this->getKeyword();
+  }
+
   public function getCategoriesUNTYPED(): EditableNode {
     return $this->_categories;
   }
@@ -129,6 +136,13 @@ final class XHPCategoryDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_categories);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getCategoriesx(): EditableList {
+    return $this->getCategories();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -149,5 +163,12 @@ final class XHPCategoryDeclaration extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/XHPChildrenDeclaration.php
+++ b/codegen/syntax/XHPChildrenDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<aa917778fd33a86aa7511b688f5cc199>>
+ * @generated SignedSource<<5e277fd59db12925c65364b45d2f5ea2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class XHPChildrenDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_keyword);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getKeywordx(): EditableNode {
+    return $this->getKeyword();
+  }
+
   public function getExpressionUNTYPED(): EditableNode {
     return $this->_expression;
   }
@@ -129,6 +136,13 @@ final class XHPChildrenDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -149,5 +163,12 @@ final class XHPChildrenDeclaration extends EditableNode {
    */
   public function getSemicolon(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getSemicolonx(): EditableNode {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/XHPChildrenParenthesizedList.php
+++ b/codegen/syntax/XHPChildrenParenthesizedList.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<980f068fea51388f7cd1c2d2a6f67f0a>>
+ * @generated SignedSource<<45205ee6dbb85aa08d61a64d3de85dfc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class XHPChildrenParenthesizedList extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_paren);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getLeftParenx(): EditableNode {
+    return $this->getLeftParen();
+  }
+
   public function getXhpChildrenUNTYPED(): EditableNode {
     return $this->_xhp_children;
   }
@@ -129,6 +136,13 @@ final class XHPChildrenParenthesizedList extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_xhp_children);
   }
 
+  /**
+   * @returns unknown
+   */
+  public function getXhpChildrenx(): EditableNode {
+    return $this->getXhpChildren();
+  }
+
   public function getRightParenUNTYPED(): EditableNode {
     return $this->_right_paren;
   }
@@ -149,5 +163,12 @@ final class XHPChildrenParenthesizedList extends EditableNode {
    */
   public function getRightParen(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_paren);
+  }
+
+  /**
+   * @returns unknown
+   */
+  public function getRightParenx(): EditableNode {
+    return $this->getRightParen();
   }
 }

--- a/codegen/syntax/XHPClassAttribute.php
+++ b/codegen/syntax/XHPClassAttribute.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<214241e0feb4ab4e7bb42bda1e6a04d6>>
+ * @generated SignedSource<<b98e2989c1ed07e53f3e08e0cbace69a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -123,6 +123,15 @@ final class XHPClassAttribute extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
   }
 
+  /**
+   * @returns GenericTypeSpecifier | MapArrayTypeSpecifier |
+   * NullableTypeSpecifier | SimpleTypeSpecifier | VectorArrayTypeSpecifier |
+   * XHPEnumType
+   */
+  public function getTypex(): EditableNode {
+    return $this->getType();
+  }
+
   public function getNameUNTYPED(): EditableNode {
     return $this->_name;
   }
@@ -144,6 +153,13 @@ final class XHPClassAttribute extends EditableNode {
    */
   public function getName(): XHPElementNameToken {
     return TypeAssert\instance_of(XHPElementNameToken::class, $this->_name);
+  }
+
+  /**
+   * @returns XHPElementNameToken
+   */
+  public function getNamex(): XHPElementNameToken {
+    return $this->getName();
   }
 
   public function getInitializerUNTYPED(): EditableNode {

--- a/codegen/syntax/XHPClassAttributeDeclaration.php
+++ b/codegen/syntax/XHPClassAttributeDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b62b7d1b6035eecbb3a9fa8695fc861b>>
+ * @generated SignedSource<<f51b86f90ece56079c33d415d2893eed>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class XHPClassAttributeDeclaration extends EditableNode {
     return TypeAssert\instance_of(AttributeToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns AttributeToken
+   */
+  public function getKeywordx(): AttributeToken {
+    return $this->getKeyword();
+  }
+
   public function getAttributesUNTYPED(): EditableNode {
     return $this->_attributes;
   }
@@ -129,6 +136,13 @@ final class XHPClassAttributeDeclaration extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_attributes);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getAttributesx(): EditableList {
+    return $this->getAttributes();
+  }
+
   public function getSemicolonUNTYPED(): EditableNode {
     return $this->_semicolon;
   }
@@ -149,5 +163,12 @@ final class XHPClassAttributeDeclaration extends EditableNode {
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
+  }
+
+  /**
+   * @returns SemicolonToken
+   */
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/XHPClose.php
+++ b/codegen/syntax/XHPClose.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<69a9fb619a415d33904b309dcb46ce41>>
+ * @generated SignedSource<<ab3fd0be46d2f289b38f1c51e7bdb591>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -105,6 +105,13 @@ final class XHPClose extends EditableNode {
    */
   public function getLeftAngle(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_left_angle);
+  }
+
+  /**
+   * @returns LessThanSlashToken | EndOfFileToken
+   */
+  public function getLeftAnglex(): EditableToken {
+    return $this->getLeftAngle();
   }
 
   public function getNameUNTYPED(): EditableNode {

--- a/codegen/syntax/XHPEnumType.php
+++ b/codegen/syntax/XHPEnumType.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<42f1d8c6ee0b3694cc45ead1972f9bf1>>
+ * @generated SignedSource<<3d7f6ef37ae4ecf67358844afe22c6ae>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -139,6 +139,13 @@ final class XHPEnumType extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_optional);
   }
 
+  /**
+   * @returns Missing
+   */
+  public function getOptionalx(): EditableNode {
+    return $this->getOptional();
+  }
+
   public function getKeywordUNTYPED(): EditableNode {
     return $this->_keyword;
   }
@@ -165,6 +172,13 @@ final class XHPEnumType extends EditableNode {
    */
   public function getKeyword(): EnumToken {
     return TypeAssert\instance_of(EnumToken::class, $this->_keyword);
+  }
+
+  /**
+   * @returns EnumToken
+   */
+  public function getKeywordx(): EnumToken {
+    return $this->getKeyword();
   }
 
   public function getLeftBraceUNTYPED(): EditableNode {
@@ -195,6 +209,13 @@ final class XHPEnumType extends EditableNode {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
+  /**
+   * @returns LeftBraceToken
+   */
+  public function getLeftBracex(): LeftBraceToken {
+    return $this->getLeftBrace();
+  }
+
   public function getValuesUNTYPED(): EditableNode {
     return $this->_values;
   }
@@ -223,6 +244,13 @@ final class XHPEnumType extends EditableNode {
     return TypeAssert\instance_of(EditableList::class, $this->_values);
   }
 
+  /**
+   * @returns EditableList
+   */
+  public function getValuesx(): EditableList {
+    return $this->getValues();
+  }
+
   public function getRightBraceUNTYPED(): EditableNode {
     return $this->_right_brace;
   }
@@ -249,5 +277,12 @@ final class XHPEnumType extends EditableNode {
    */
   public function getRightBrace(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
+  }
+
+  /**
+   * @returns RightBraceToken
+   */
+  public function getRightBracex(): RightBraceToken {
+    return $this->getRightBrace();
   }
 }

--- a/codegen/syntax/XHPExpression.php
+++ b/codegen/syntax/XHPExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7dffcbac6f7cfdb147850e00f3b8a0dc>>
+ * @generated SignedSource<<68e9e915083ccb44c808427ff5bedc40>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -105,6 +105,13 @@ final class XHPExpression extends EditableNode {
    */
   public function getOpen(): XHPOpen {
     return TypeAssert\instance_of(XHPOpen::class, $this->_open);
+  }
+
+  /**
+   * @returns XHPOpen
+   */
+  public function getOpenx(): XHPOpen {
+    return $this->getOpen();
   }
 
   public function getBodyUNTYPED(): EditableNode {

--- a/codegen/syntax/XHPOpen.php
+++ b/codegen/syntax/XHPOpen.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a767aa9ca32c9d07eec74f7967c3be27>>
+ * @generated SignedSource<<7e89480b541c0ca5ad7eef3c72b5c5d9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -121,6 +121,13 @@ final class XHPOpen extends EditableNode {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
   }
 
+  /**
+   * @returns LessThanToken
+   */
+  public function getLeftAnglex(): LessThanToken {
+    return $this->getLeftAngle();
+  }
+
   public function getNameUNTYPED(): EditableNode {
     return $this->_name;
   }
@@ -146,6 +153,13 @@ final class XHPOpen extends EditableNode {
    */
   public function getName(): XHPElementNameToken {
     return TypeAssert\instance_of(XHPElementNameToken::class, $this->_name);
+  }
+
+  /**
+   * @returns XHPElementNameToken
+   */
+  public function getNamex(): XHPElementNameToken {
+    return $this->getName();
   }
 
   public function getAttributesUNTYPED(): EditableNode {

--- a/codegen/syntax/XHPRequired.php
+++ b/codegen/syntax/XHPRequired.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d775ff0d4cd36b94e4658373703f4a02>>
+ * @generated SignedSource<<ad9bc060af97cef9f55ad959bef34ab8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -88,6 +88,13 @@ final class XHPRequired extends EditableNode {
     return TypeAssert\instance_of(AtToken::class, $this->_at);
   }
 
+  /**
+   * @returns AtToken
+   */
+  public function getAtx(): AtToken {
+    return $this->getAt();
+  }
+
   public function getKeywordUNTYPED(): EditableNode {
     return $this->_keyword;
   }
@@ -108,5 +115,12 @@ final class XHPRequired extends EditableNode {
    */
   public function getKeyword(): RequiredToken {
     return TypeAssert\instance_of(RequiredToken::class, $this->_keyword);
+  }
+
+  /**
+   * @returns RequiredToken
+   */
+  public function getKeywordx(): RequiredToken {
+    return $this->getKeyword();
   }
 }

--- a/codegen/syntax/XHPSimpleAttribute.php
+++ b/codegen/syntax/XHPSimpleAttribute.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8db78d6d62585d56dfbefa32b2efd35d>>
+ * @generated SignedSource<<44bf35f6a4e060c8e778f6029be67c1a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class XHPSimpleAttribute extends EditableNode {
     return TypeAssert\instance_of(XHPElementNameToken::class, $this->_name);
   }
 
+  /**
+   * @returns XHPElementNameToken
+   */
+  public function getNamex(): XHPElementNameToken {
+    return $this->getName();
+  }
+
   public function getEqualUNTYPED(): EditableNode {
     return $this->_equal;
   }
@@ -129,6 +136,13 @@ final class XHPSimpleAttribute extends EditableNode {
     return TypeAssert\instance_of(EqualToken::class, $this->_equal);
   }
 
+  /**
+   * @returns EqualToken
+   */
+  public function getEqualx(): EqualToken {
+    return $this->getEqual();
+  }
+
   public function getExpressionUNTYPED(): EditableNode {
     return $this->_expression;
   }
@@ -149,5 +163,12 @@ final class XHPSimpleAttribute extends EditableNode {
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
+  }
+
+  /**
+   * @returns BracedExpression | XHPStringLiteralToken
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
   }
 }

--- a/codegen/syntax/XHPSimpleClassAttribute.php
+++ b/codegen/syntax/XHPSimpleClassAttribute.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<458ba4bc9ab83aa40da3855e8f3767b6>>
+ * @generated SignedSource<<4b017b0d98ac3e88116d3f133dcf6940>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,5 +75,12 @@ final class XHPSimpleClassAttribute extends EditableNode {
    */
   public function getType(): SimpleTypeSpecifier {
     return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_type);
+  }
+
+  /**
+   * @returns SimpleTypeSpecifier
+   */
+  public function getTypex(): SimpleTypeSpecifier {
+    return $this->getType();
   }
 }

--- a/codegen/syntax/XHPSpreadAttribute.php
+++ b/codegen/syntax/XHPSpreadAttribute.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<44781dcf553c4cdff5e3cce2b8c3f35d>>
+ * @generated SignedSource<<32a406ddb605e6d4e369f6ff14f90774>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -125,6 +125,13 @@ final class XHPSpreadAttribute extends EditableNode {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
+  /**
+   * @returns LeftBraceToken
+   */
+  public function getLeftBracex(): LeftBraceToken {
+    return $this->getLeftBrace();
+  }
+
   public function getSpreadOperatorUNTYPED(): EditableNode {
     return $this->_spread_operator;
   }
@@ -151,6 +158,13 @@ final class XHPSpreadAttribute extends EditableNode {
   public function getSpreadOperator(): DotDotDotToken {
     return
       TypeAssert\instance_of(DotDotDotToken::class, $this->_spread_operator);
+  }
+
+  /**
+   * @returns DotDotDotToken
+   */
+  public function getSpreadOperatorx(): DotDotDotToken {
+    return $this->getSpreadOperator();
   }
 
   public function getExpressionUNTYPED(): EditableNode {
@@ -180,6 +194,13 @@ final class XHPSpreadAttribute extends EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
+  /**
+   * @returns VariableExpression | XHPExpression
+   */
+  public function getExpressionx(): EditableNode {
+    return $this->getExpression();
+  }
+
   public function getRightBraceUNTYPED(): EditableNode {
     return $this->_right_brace;
   }
@@ -205,5 +226,12 @@ final class XHPSpreadAttribute extends EditableNode {
    */
   public function getRightBrace(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
+  }
+
+  /**
+   * @returns RightBraceToken
+   */
+  public function getRightBracex(): RightBraceToken {
+    return $this->getRightBrace();
   }
 }

--- a/codegen/syntax/YieldExpression.php
+++ b/codegen/syntax/YieldExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c19149534fff452c26ad0d9c046f1d11>>
+ * @generated SignedSource<<c52ecff9344562f59c31e1423a7b06d8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -88,6 +88,13 @@ final class YieldExpression extends EditableNode {
     return TypeAssert\instance_of(YieldToken::class, $this->_keyword);
   }
 
+  /**
+   * @returns YieldToken
+   */
+  public function getKeywordx(): YieldToken {
+    return $this->getKeyword();
+  }
+
   public function getOperandUNTYPED(): EditableNode {
     return $this->_operand;
   }
@@ -113,5 +120,17 @@ final class YieldExpression extends EditableNode {
    */
   public function getOperand(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_operand);
+  }
+
+  /**
+   * @returns AnonymousFunction | BinaryExpression | ElementInitializer |
+   * FunctionCallExpression | LambdaExpression | LiteralExpression |
+   * MemberSelectionExpression | Missing | ObjectCreationExpression |
+   * ParenthesizedExpression | PostfixUnaryExpression | PrefixUnaryExpression |
+   * SubscriptExpression | BreakToken | NameToken | TupleExpression |
+   * VariableExpression
+   */
+  public function getOperandx(): EditableNode {
+    return $this->getOperand();
   }
 }

--- a/codegen/syntax/YieldFromExpression.php
+++ b/codegen/syntax/YieldFromExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<52d5faa5842c14958576df3d2a936a3d>>
+ * @generated SignedSource<<00647d20bf77b9010554b131680a31a1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -107,6 +107,13 @@ final class YieldFromExpression extends EditableNode {
     return TypeAssert\instance_of(YieldToken::class, $this->_yield_keyword);
   }
 
+  /**
+   * @returns YieldToken
+   */
+  public function getYieldKeywordx(): YieldToken {
+    return $this->getYieldKeyword();
+  }
+
   public function getFromKeywordUNTYPED(): EditableNode {
     return $this->_from_keyword;
   }
@@ -127,6 +134,13 @@ final class YieldFromExpression extends EditableNode {
    */
   public function getFromKeyword(): FromToken {
     return TypeAssert\instance_of(FromToken::class, $this->_from_keyword);
+  }
+
+  /**
+   * @returns FromToken
+   */
+  public function getFromKeywordx(): FromToken {
+    return $this->getFromKeyword();
   }
 
   public function getOperandUNTYPED(): EditableNode {
@@ -150,5 +164,13 @@ final class YieldFromExpression extends EditableNode {
    */
   public function getOperand(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_operand);
+  }
+
+  /**
+   * @returns ArrayCreationExpression | FunctionCallExpression |
+   * LiteralExpression | ParenthesizedExpression | VariableExpression
+   */
+  public function getOperandx(): EditableNode {
+    return $this->getOperand();
   }
 }

--- a/src/__Private/codegen/CodegenSyntax.php
+++ b/src/__Private/codegen/CodegenSyntax.php
@@ -143,7 +143,14 @@ final class CodegenSyntax extends CodegenBase {
           $type,
           $underscored,
         );
-      return;
+      // For backwards compatibility: always offer getFoox, in case it was
+      // nullable in a previous version
+      yield $cg
+        ->codegenMethodf('get%sx', $upper_camel)
+        ->setDocBlock('@returns '.\implode(' | ', $types))
+        ->setReturnType($type)
+        ->setBodyf('return $this->get%s();', $upper_camel);
+     return;
     }
 
     yield $cg


### PR DESCRIPTION
This means that if an AST field changes from optional to non-optional, it's not an API BC break.

Depends on #55