### PR TITLE
LSP interface definitions, POC in LinterCLI

### DIFF
--- a/src/__Private/LSP/ApplyWorkspaceEditParams.php
+++ b/src/__Private/LSP/ApplyWorkspaceEditParams.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ApplyWorkspaceEditParams = shape(
+  ?'label' => string,
+  'edit' => WorkspaceEdit,
+);

--- a/src/__Private/LSP/ApplyWorkspaceEditResponse.php
+++ b/src/__Private/LSP/ApplyWorkspaceEditResponse.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ApplyWorkspaceEditResponse = shape(
+  'applied' => bool,
+);

--- a/src/__Private/LSP/CancelParams.php
+++ b/src/__Private/LSP/CancelParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CancelParams = shape(
+  'id' => arraykey,
+);

--- a/src/__Private/LSP/ClientCapabilities.php
+++ b/src/__Private/LSP/ClientCapabilities.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ClientCapabilities = shape(
+  ?'workspace' => WorkspaceClientCapabilities,
+  ?'textDocument' => TextDocumentClientCapabilities,
+  ?'experimental' => mixed,
+);

--- a/src/__Private/LSP/CodeAction.php
+++ b/src/__Private/LSP/CodeAction.php
@@ -1,0 +1,19 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CodeAction = shape(
+  'title' => string,
+  ?'kind' => CodeActionKind,
+  ?'diagnostics' => vec<Diagnostic>,
+  ?'edit' => WorkspaceEdit,
+  ?'command' => Command,
+);

--- a/src/__Private/LSP/CodeActionContext.php
+++ b/src/__Private/LSP/CodeActionContext.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CodeActionContext = shape(
+  'diagnostics' => vec<Diagnostic>,
+  ?'only' => vec<CodeActionKind>,
+);

--- a/src/__Private/LSP/CodeActionKind.php
+++ b/src/__Private/LSP/CodeActionKind.php
@@ -1,0 +1,21 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum CodeActionKind: string {
+  QUICK_FIX = 'quickfix';
+  REFACTOR = 'refactor';
+  REFACTOR_EXTRACT = 'refactor.extract';
+  REFACTOR_INLINE = 'refactor.inline';
+  REFACTOR_REWRITE = 'refactor.rewrite';
+  SOURCE = 'source';
+  SOURCE_ORGANIZE_IMPORTS = 'source.organizeImports';
+}

--- a/src/__Private/LSP/CodeActionParams.php
+++ b/src/__Private/LSP/CodeActionParams.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CodeActionParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+  'range' => Range,
+  'context' => CodeActionContext,
+);

--- a/src/__Private/LSP/CodeLens.php
+++ b/src/__Private/LSP/CodeLens.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CodeLens = shape(
+  'range' => Range,
+  ?'command' => Command,
+  ?'data' => mixed,
+);

--- a/src/__Private/LSP/CodeLensOptions.php
+++ b/src/__Private/LSP/CodeLensOptions.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CodeLensOptions = shape(
+  ?'resolveProvider' => bool,
+);

--- a/src/__Private/LSP/CodeLensParams.php
+++ b/src/__Private/LSP/CodeLensParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CodeLensParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+);

--- a/src/__Private/LSP/CodeLensRegistrationOptions.php
+++ b/src/__Private/LSP/CodeLensRegistrationOptions.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CodeLensRegistrationOptions = shape(
+  ?'resolveProvider' => bool,
+  /* TextDocumentRegistrationOptions */
+  'documentSelector' => ?DocumentSelector,
+);

--- a/src/__Private/LSP/Color.php
+++ b/src/__Private/LSP/Color.php
@@ -1,0 +1,19 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+
+type Color = shape(
+  'red' => float,
+  'green' => float,
+  'blue' => float,
+  'alpha' => float,
+);

--- a/src/__Private/LSP/ColorInformation.php
+++ b/src/__Private/LSP/ColorInformation.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+
+type ColorInformation = shape(
+  'range' => Range,
+  'color' => Color,
+);

--- a/src/__Private/LSP/ColorPresentation.php
+++ b/src/__Private/LSP/ColorPresentation.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ColorPresentation = shape(
+  'label' => string,
+  ?'textEdit' => TextEdit,
+  ?'additionalTextEdits' => vec<TextEdit>,
+);

--- a/src/__Private/LSP/ColorPresentationParams.php
+++ b/src/__Private/LSP/ColorPresentationParams.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ColorPresentationParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+  'color' => Color,
+  'range' => Range,
+);

--- a/src/__Private/LSP/ColorProviderOptions.php
+++ b/src/__Private/LSP/ColorProviderOptions.php
@@ -1,0 +1,14 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ColorProviderOptions = shape(
+);

--- a/src/__Private/LSP/Command.php
+++ b/src/__Private/LSP/Command.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type Command = shape(
+  'title' => string,
+  'command' => string,
+  ?'arguments' => vec<mixed>,
+);

--- a/src/__Private/LSP/CompletionContext.php
+++ b/src/__Private/LSP/CompletionContext.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CompletionContext = shape(
+  'triggerKind' => CompletionTriggerKind,
+  ?'triggerCharacter' => string,
+);

--- a/src/__Private/LSP/CompletionItem.php
+++ b/src/__Private/LSP/CompletionItem.php
@@ -1,0 +1,29 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CompletionItem = shape(
+  'label' => string,
+  ?'kind' => CompletionItemKind,
+  ?'detail' => string,
+  /* string | MarkupContent */
+  ?'documentation' => mixed,
+  ?'deprecated' => bool,
+  ?'sortText' => string,
+  ?'filterText' => string,
+  ?'insertText' => string,
+  ?'insertTextFormat' => InsertTextFormat,
+  ?'textEdit' => TextEdit,
+  ?'additionalTextEdits' => vec<TextEdit>,
+  ?'commitCharacters' => vec<string>,
+  ?'command' => Command,
+  ?'data' => mixed,
+);

--- a/src/__Private/LSP/CompletionItemKind.php
+++ b/src/__Private/LSP/CompletionItemKind.php
@@ -1,0 +1,40 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum CompletionItemKind: int {
+  // K prefix because of reserved words
+  K_TEXT = 1;
+  K_METHOD = 2;
+  K_FUNCTION = 3;
+  K_CONSTRUCTOR = 4;
+  K_FIELD = 5;
+  K_VARIABLE = 6;
+  K_CLASS = 7;
+  K_INTERFACE = 8;
+  K_MODULE = 9;
+  K_PROPERTY = 10;
+  K_UNIT = 11;
+  K_VALUE = 12;
+  K_ENUM = 13;
+  K_KEYWORD = 14;
+  K_SNIPPET = 15;
+  K_COLOR = 16;
+  K_FILE = 17;
+  K_REFERENCE = 18;
+  K_FOLDER = 19;
+  K_ENUM_MEMBER = 20;
+  K_CONSTANT = 21;
+  K_STRUCT = 22;
+  K_EVENT = 23;
+  K_OPERATOR = 24;
+  K_TYPE_PARAMETER = 25;
+}

--- a/src/__Private/LSP/CompletionList.php
+++ b/src/__Private/LSP/CompletionList.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CompletionList = shape(
+  'isIncomplete' => bool,
+  'items' => vec<CompletionItem>,
+);

--- a/src/__Private/LSP/CompletionOptions.php
+++ b/src/__Private/LSP/CompletionOptions.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CompletionOptions = shape(
+  ?'resolveProvider' => bool,
+  ?'triggerCharacters' => vec<string>,
+);

--- a/src/__Private/LSP/CompletionParams.php
+++ b/src/__Private/LSP/CompletionParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CompletionParams = shape(
+  ?'context' => CompletionContext,
+);

--- a/src/__Private/LSP/CompletionRegistrationOptions.php
+++ b/src/__Private/LSP/CompletionRegistrationOptions.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type CompletionRegistrationOptions = shape(
+  ?'resolveProvider' => bool,
+  ?'triggerCharacters' => vec<string>,
+  /* TextDocumentRegistrationOptions */
+  'documentSelector' => ?DocumentSelector,
+);

--- a/src/__Private/LSP/CompletionTriggerKind.php
+++ b/src/__Private/LSP/CompletionTriggerKind.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum CompletionTriggerKind: int {
+  INVOKED = 1;
+  TRIGGER_CHARACTER = 2;
+  TRIGGER_FOR_INCOMPLETE_COMPLETIONS = 3;
+}

--- a/src/__Private/LSP/ConfigurationItem.php
+++ b/src/__Private/LSP/ConfigurationItem.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ConfigurationItem = shape(
+  ?'scopeUri' => string,
+  ?'section' => string,
+);

--- a/src/__Private/LSP/ConfigurationParams.php
+++ b/src/__Private/LSP/ConfigurationParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ConfigurationParams = shape(
+  'items' => vec<ConfigurationItem>,
+);

--- a/src/__Private/LSP/Diagnostic.php
+++ b/src/__Private/LSP/Diagnostic.php
@@ -1,0 +1,20 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type Diagnostic = shape(
+  'range' => Range,
+  ?'severity' => DiagnosticSeverity,
+  ?'code' => arraykey,
+  ?'source' => string,
+  'message' => string,
+  ?'relatedInformation' => vec<DiagnosticRelatedInformation>,
+);

--- a/src/__Private/LSP/DiagnosticRelatedInformation.php
+++ b/src/__Private/LSP/DiagnosticRelatedInformation.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DiagnosticRelatedInformation = shape(
+  'location' => Location,
+  'message' => string,
+);

--- a/src/__Private/LSP/DiagnosticSeverity.php
+++ b/src/__Private/LSP/DiagnosticSeverity.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum DiagnosticSeverity: int {
+  ERROR = 1;
+  WARNING = 2;
+  INFORMATION = 3;
+  HINT = 4;
+}

--- a/src/__Private/LSP/DidChangeConfigurationParams.php
+++ b/src/__Private/LSP/DidChangeConfigurationParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DidChangeConfigurationParams = shape(
+  'settings' => mixed,
+);

--- a/src/__Private/LSP/DidChangeTextDocumentParams.php
+++ b/src/__Private/LSP/DidChangeTextDocumentParams.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DidChangeTextDocumentParams = shape(
+  'textDocument' => VersionedTextDocumentIdentifier,
+  'contentChanges' => vec<TextDocumentContentChangeEvent>,
+);

--- a/src/__Private/LSP/DidChangeWatchedFilesParams.php
+++ b/src/__Private/LSP/DidChangeWatchedFilesParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DidChangeWatchedFilesParams = shape(
+  'changes' => vec<FileEvent>,
+);

--- a/src/__Private/LSP/DidChangeWatchedFilesRegistrationOptions.php
+++ b/src/__Private/LSP/DidChangeWatchedFilesRegistrationOptions.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DidChangeWatchedFilesRegistrationOptions = shape(
+  'watchers' => vec<FileSystemWatcher>,
+);

--- a/src/__Private/LSP/DidChangeWorkspaceFoldersParams.php
+++ b/src/__Private/LSP/DidChangeWorkspaceFoldersParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DidChangeWorkspaceFoldersParams = shape(
+  'event' => WorkspaceFoldersChangeEvent,
+);

--- a/src/__Private/LSP/DidCloseTextDocumentParams.php
+++ b/src/__Private/LSP/DidCloseTextDocumentParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DidCloseTextDocumentParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+);

--- a/src/__Private/LSP/DidOpenTextDocumentParams.php
+++ b/src/__Private/LSP/DidOpenTextDocumentParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DidOpenTextDocumentParams = shape(
+  'textDocument' => TextDocumentItem,
+);

--- a/src/__Private/LSP/DidSaveTextDocumentParams.php
+++ b/src/__Private/LSP/DidSaveTextDocumentParams.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DidSaveTextDocumentParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+  ?'text' => string,
+);

--- a/src/__Private/LSP/DocumentColorParams.php
+++ b/src/__Private/LSP/DocumentColorParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentColorParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+);

--- a/src/__Private/LSP/DocumentFilter.php
+++ b/src/__Private/LSP/DocumentFilter.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentFilter = shape(
+  ?'language' => string,
+  ?'scheme' => string,
+  ?'pattern' => string,
+);

--- a/src/__Private/LSP/DocumentFormattingParams.php
+++ b/src/__Private/LSP/DocumentFormattingParams.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentFormattingParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+  'options' => FormattingOptions,
+);

--- a/src/__Private/LSP/DocumentHighlight.php
+++ b/src/__Private/LSP/DocumentHighlight.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentHighlight = shape(
+  'range' => Range,
+  ?'kind' => DocumentHighlightKind,
+);

--- a/src/__Private/LSP/DocumentHighlightKind.php
+++ b/src/__Private/LSP/DocumentHighlightKind.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum DocumentHighlightKind: int {
+  TEXT = 1;
+  READ = 2;
+  WRITE = 3;
+}

--- a/src/__Private/LSP/DocumentLink.php
+++ b/src/__Private/LSP/DocumentLink.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentLink = shape(
+  'range' => Range,
+  ?'target' => DocumentUri,
+  ?'data' => mixed,
+);

--- a/src/__Private/LSP/DocumentLinkOptions.php
+++ b/src/__Private/LSP/DocumentLinkOptions.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentLinkOptions = shape(
+  ?'resolveProvider' => bool,
+);

--- a/src/__Private/LSP/DocumentLinkParams.php
+++ b/src/__Private/LSP/DocumentLinkParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentLinkParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+);

--- a/src/__Private/LSP/DocumentLinkRegistrationOptions.php
+++ b/src/__Private/LSP/DocumentLinkRegistrationOptions.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentLinkRegistrationOptions = shape(
+  ?'resolveProvider' => bool,
+  /* TextDocumentRegistrationOptions */
+  'documentSelector' => ?DocumentSelector,
+);

--- a/src/__Private/LSP/DocumentOnTypeFormattingOptions.php
+++ b/src/__Private/LSP/DocumentOnTypeFormattingOptions.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentOnTypeFormattingOptions = shape(
+  'firstTriggerCharacter' => string,
+  ?'moreTriggerCharacters' => vec<string>,
+);

--- a/src/__Private/LSP/DocumentOnTypeFormattingParams.php
+++ b/src/__Private/LSP/DocumentOnTypeFormattingParams.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentOnTypeFormattingParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+  'position' => Position,
+  'ch' => string,
+  'options' => FormattingOptions,
+);

--- a/src/__Private/LSP/DocumentRangeFormattingParams.php
+++ b/src/__Private/LSP/DocumentRangeFormattingParams.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentRangeFormattingParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+  'range' => Range,
+  'options' => FormattingOptions,
+);

--- a/src/__Private/LSP/DocumentSelector.php
+++ b/src/__Private/LSP/DocumentSelector.php
@@ -1,0 +1,13 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentSelector = vec<DocumentFilter>;

--- a/src/__Private/LSP/DocumentSymbolParams.php
+++ b/src/__Private/LSP/DocumentSymbolParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentSymbolParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+);

--- a/src/__Private/LSP/DocumentUri.php
+++ b/src/__Private/LSP/DocumentUri.php
@@ -1,0 +1,13 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type DocumentUri = string;

--- a/src/__Private/LSP/ErrorCode.php
+++ b/src/__Private/LSP/ErrorCode.php
@@ -1,0 +1,26 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum ErrorCode: int as int {
+  // JSON RPC
+  PARSE_ERROR = -32700;
+  INVALID_REQUEST = -32600;
+  METHOD_NOT_FOUND = -32601;
+  INVALID_PARAMS = -32602;
+  INTERNAL_ERROR = -32603;
+  SERVER_ERROR_START = -32099;
+  SERVER_ERROR_END = -32000;
+  SERVER_NOT_INITIALIZED = -32002;
+  UNKNOWN_ERROR_CODE = -32001;
+  // LSP
+  REQUEST_CANCELLED = -32800;
+}

--- a/src/__Private/LSP/ExecuteCommandOptions.php
+++ b/src/__Private/LSP/ExecuteCommandOptions.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ExecuteCommandOptions = shape(
+  'commands' => vec<string>,
+);

--- a/src/__Private/LSP/ExecuteCommandParams.php
+++ b/src/__Private/LSP/ExecuteCommandParams.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ExecuteCommandParams = shape(
+  'command' => string,
+  ?'arguments' => vec<mixed>,
+);

--- a/src/__Private/LSP/ExecuteCommandRegistrationOptions.php
+++ b/src/__Private/LSP/ExecuteCommandRegistrationOptions.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ExecuteCommandRegistrationOptions = shape(
+  'commands' => vec<string>,
+);

--- a/src/__Private/LSP/FileChangeType.php
+++ b/src/__Private/LSP/FileChangeType.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum FileChangeType: int {
+  CREATED = 1;
+  CHANGED = 2;
+  DELETED = 3;
+}

--- a/src/__Private/LSP/FileEvent.php
+++ b/src/__Private/LSP/FileEvent.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type FileEvent = shape(
+  'uri' => DocumentUri,
+  'type' => FileChangeType,
+);

--- a/src/__Private/LSP/FileSystemWatcher.php
+++ b/src/__Private/LSP/FileSystemWatcher.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type FileSystemWatcher = shape(
+  'globPattern' => string,
+  ?'kind' => WatchKind,
+);

--- a/src/__Private/LSP/FormattingOptions.php
+++ b/src/__Private/LSP/FormattingOptions.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type FormattingOptions = shape(
+  'tabSize' => int,
+  'insertSpaces' => bool,
+  ...
+);

--- a/src/__Private/LSP/Hover.php
+++ b/src/__Private/LSP/Hover.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type Hover = shape(
+  /* MarkedString | vec<MarkedString> | MarkupContent */
+  'contents' => mixed,
+  ?'range' => Range,
+);

--- a/src/__Private/LSP/InitializeError.php
+++ b/src/__Private/LSP/InitializeError.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type InitializeError = shape(
+  'retry' => bool,
+);

--- a/src/__Private/LSP/InitializeErrorCode.php
+++ b/src/__Private/LSP/InitializeErrorCode.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum InitializeErrorCode: int as int {
+  UNKNOWN_PROTOCOL_VERSION = 1;
+}

--- a/src/__Private/LSP/InitializeParams.php
+++ b/src/__Private/LSP/InitializeParams.php
@@ -1,0 +1,21 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type InitializeParams = shape(
+  'processId' => ?int,
+  ?'rootPath' => ?string,
+  'rootUri' => ?DocumentUri,
+  ?'initializationOptions' => mixed,
+  'capabilities' => ClientCapabilities,
+  ?'trace' => TraceLevel,
+  ?'workspaceFolders' => ?vec<WorkspaceFolder>,
+);

--- a/src/__Private/LSP/InitializeResult.php
+++ b/src/__Private/LSP/InitializeResult.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type InitializeResult = shape(
+  'capabilities' => ServerCapabilities,
+);

--- a/src/__Private/LSP/InitializedParams.php
+++ b/src/__Private/LSP/InitializedParams.php
@@ -1,0 +1,14 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type InitializedParams = shape(
+);

--- a/src/__Private/LSP/InsertTextFormat.php
+++ b/src/__Private/LSP/InsertTextFormat.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum InsertTextFormat: int {
+  PLAIN_TEXT = 1;
+  SNIPPET = 2;
+}

--- a/src/__Private/LSP/Location.php
+++ b/src/__Private/LSP/Location.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type Location = shape(
+  'uri' => DocumentUri,
+  'range' => Range,
+);

--- a/src/__Private/LSP/LogMessageParams.php
+++ b/src/__Private/LSP/LogMessageParams.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type LogMessageParams = shape(
+  'type' => MessageType,
+  'message' => string,
+);

--- a/src/__Private/LSP/MarkedString.php
+++ b/src/__Private/LSP/MarkedString.php
@@ -1,0 +1,14 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+/** string | shape( 'language' => string, 'value' => string) */
+type MarkedString = mixed;

--- a/src/__Private/LSP/MarkupContent.php
+++ b/src/__Private/LSP/MarkupContent.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type MarkupContent = shape(
+  'kind' => MarkupKind,
+  'value' => string,
+);

--- a/src/__Private/LSP/MarkupKind.php
+++ b/src/__Private/LSP/MarkupKind.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum MarkupKind: string {
+  PLAIN_TEXT = 'plaintext';
+  MARKDOWN = 'markdown';
+}

--- a/src/__Private/LSP/Message.php
+++ b/src/__Private/LSP/Message.php
@@ -12,4 +12,5 @@ namespace Facebook\HHAST\__Private\LSP;
 
 type Message = shape(
   'jsonrpc' => string,
+  ...
 );

--- a/src/__Private/LSP/Message.php
+++ b/src/__Private/LSP/Message.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type Message = shape(
+  'jsonrpc' => string,
+);

--- a/src/__Private/LSP/MessageActionItem.php
+++ b/src/__Private/LSP/MessageActionItem.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type MessageActionItem = shape(
+  'title' => string,
+);

--- a/src/__Private/LSP/MessageType.php
+++ b/src/__Private/LSP/MessageType.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum MessageType: int {
+  ERROR = 1;
+  WARNING = 2;
+  INFO = 3;
+  LOG = 4;
+}

--- a/src/__Private/LSP/NotificationMessage.php
+++ b/src/__Private/LSP/NotificationMessage.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type NotificationMessage /* extends Message */ = shape(
+  'method' => string,
+  ?'params' => mixed,
+  /* Message */
+  'jsonrpc' => string,
+);

--- a/src/__Private/LSP/ParameterInformation.php
+++ b/src/__Private/LSP/ParameterInformation.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ParameterInformation = shape(
+  'label' => string,
+  /** string | MarkupContent */
+  ?'documentation' => mixed,
+);

--- a/src/__Private/LSP/Position.php
+++ b/src/__Private/LSP/Position.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type Position = shape(
+  'line' => int,
+  'character' => int,
+);

--- a/src/__Private/LSP/PublishDiagnosticsParams.php
+++ b/src/__Private/LSP/PublishDiagnosticsParams.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type PublishDiagnosticsParams = shape(
+  'uri' => DocumentUri,
+  'diagnostics' => vec<Diagnostic>,
+);

--- a/src/__Private/LSP/Range.php
+++ b/src/__Private/LSP/Range.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type Range = shape(
+  'start' => Position,
+  'end' => Position,
+);

--- a/src/__Private/LSP/ReferenceContext.php
+++ b/src/__Private/LSP/ReferenceContext.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ReferenceContext = shape(
+  'includeDeclaration' => bool,
+);

--- a/src/__Private/LSP/ReferenceParams.php
+++ b/src/__Private/LSP/ReferenceParams.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ReferenceParams = shape(
+  'context' => ReferenceContext,
+  /* TextDocumentPositionParams */
+  'textDocument' => TextDocumentIdentifier,
+  'position' => Position,
+);

--- a/src/__Private/LSP/Registration.php
+++ b/src/__Private/LSP/Registration.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type Registration = shape(
+  'id' => string,
+  'method' => string,
+  ?'registerOptions' => mixed,
+);

--- a/src/__Private/LSP/RegistrationParams.php
+++ b/src/__Private/LSP/RegistrationParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type RegistrationParams = shape(
+  'registrations' => vec<Registration>,
+);

--- a/src/__Private/LSP/RenameParams.php
+++ b/src/__Private/LSP/RenameParams.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type RenameParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+  'position' => Position,
+  'newName' => string,
+);

--- a/src/__Private/LSP/RequestMessage.php
+++ b/src/__Private/LSP/RequestMessage.php
@@ -1,0 +1,19 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type RequestMessage /* extends Message */ = shape(
+  'id' => arraykey,
+  'method' => string,
+  ?'params' => mixed,
+  /* Message */
+  'jsonrpc' => string,
+);

--- a/src/__Private/LSP/ResponseError.php
+++ b/src/__Private/LSP/ResponseError.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ResponseError<T> = shape(
+  'code' => int,
+  'message' => string,
+  ?'data' => T,
+);

--- a/src/__Private/LSP/ResponseMessage.php
+++ b/src/__Private/LSP/ResponseMessage.php
@@ -1,0 +1,19 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ResponseMessage /* extends Message */ = shape(
+  'id' => arraykey,
+  ?'result' => mixed,
+  ?'error' => ResponseError<mixed>,
+  /* Message */
+  'jsonrpc' => string,
+);

--- a/src/__Private/LSP/SaveOptions.php
+++ b/src/__Private/LSP/SaveOptions.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type SaveOptions = shape(
+  ?'includeText' => bool,
+);

--- a/src/__Private/LSP/ServerCapabilities.php
+++ b/src/__Private/LSP/ServerCapabilities.php
@@ -1,0 +1,48 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ServerCapabilities = shape(
+  /** TextDocumentSyncOptions | TextDocumentSyncKind */
+  ?'textDocumentSync' => mixed,
+  ?'hoverProvider' => bool,
+  ?'completionProvider' => CompletionOptions,
+  ?'signatureHelpProvider' => SignatureHelpOptions,
+  ?'definitionProvider' => bool,
+  /** bool | (TextDocumentRegistrationOptions & StaticRegistrationOptions) */
+  ?'typeDefinitionProvider' => mixed,
+  /** bool | (TextDocumentRegistrationOptions & StaticRegistrationOptions) */
+  ?'implementationProvider' => mixed,
+  ?'referencesProvider' => bool,
+  ?'documentHighlightProvider' => bool,
+  ?'documentSymbolProvider' => bool,
+  ?'workspaceSymbolProvider' => bool,
+  ?'codeActionProvider' => bool,
+  ?'codeLensProvider' => CodeLensOptions,
+  ?'documentFormattingProvider' => bool,
+  ?'documentRangeFormattingProvider' => bool,
+  ?'documentOnTypeFormattingProvider' => DocumentOnTypeFormattingOptions,
+  ?'renameProvider' => bool,
+  ?'documentLinkProvider' => DocumentLinkOptions,
+  /** bool | ColorProviderOptions |
+   * ColorProviderOptions & TextDocumentRegistrationOptions
+   *   & StaticRegistrationOptions */
+  ?'colorProvider' => mixed,
+  ?'executeCommandProvider' => ExecuteCommandOptions,
+  ?'workspace' => shape(
+    ?'workspaceFolders' => shape(
+      ?'supported' => bool,
+      /** string | bool */
+      ?'changeNotifications' => mixed,
+    ),
+  ),
+  ?'experimental' => mixed,
+);

--- a/src/__Private/LSP/ShowMessageParams.php
+++ b/src/__Private/LSP/ShowMessageParams.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ShowMessageParams = shape(
+  'type' => MessageType,
+  'message' => string,
+);

--- a/src/__Private/LSP/ShowMessageRequestParams.php
+++ b/src/__Private/LSP/ShowMessageRequestParams.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type ShowMessageRequestParams = shape(
+  'type' => MessageType,
+  'message' => string,
+  ?'actions' => vec<MessageActionItem>,
+);

--- a/src/__Private/LSP/SignatureHelp.php
+++ b/src/__Private/LSP/SignatureHelp.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type SignatureHelp = shape(
+  'signatures' => vec<SignatureInformation>,
+  ?'activeSignature' => int,
+  ?'activeParameter' => int,
+);

--- a/src/__Private/LSP/SignatureHelpOptions.php
+++ b/src/__Private/LSP/SignatureHelpOptions.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type SignatureHelpOptions = shape(
+  ?'triggerCharacters' => vec<string>,
+);

--- a/src/__Private/LSP/SignatureHelpRegistrationOptions.php
+++ b/src/__Private/LSP/SignatureHelpRegistrationOptions.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type SignatureHelpRegistrationOptions = shape(
+  ?'triggerCharacters' => vec<string>,
+  /* TextDocumentRegistrationOptions */
+  'documentSelector' => ?DocumentSelector,
+);

--- a/src/__Private/LSP/SignatureInformation.php
+++ b/src/__Private/LSP/SignatureInformation.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type SignatureInformation = shape(
+  'label' => string,
+  /** string | MarkupContent */
+  ?'documentation' => mixed,
+  ?'parameters' => vec<ParameterInformation>,
+);

--- a/src/__Private/LSP/StaticRegistrationOptions.php
+++ b/src/__Private/LSP/StaticRegistrationOptions.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type StaticRegistrationOptions = shape(
+  ?'id' => string,
+);

--- a/src/__Private/LSP/SymbolInformation.php
+++ b/src/__Private/LSP/SymbolInformation.php
@@ -1,0 +1,19 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type SymbolInformation = shape(
+  'name' => string,
+  'kind' => SymbolKind,
+  ?'deprecated' => bool,
+  'location' => Location,
+  ?'containerName' => string,
+);

--- a/src/__Private/LSP/SymbolKind.php
+++ b/src/__Private/LSP/SymbolKind.php
@@ -1,0 +1,41 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum SymbolKind : int {
+  // K prefix because of reserved words
+  K_FILE = 1;
+  K_MODULE = 2;
+  K_NAMESPACE = 3;
+  K_PACKAGE = 4;
+  K_CLASS = 5;
+  K_METHOD = 6;
+  K_PROPERTY = 7;
+  K_FIELD = 8;
+  K_CONSTRUCTOR = 9;
+  K_ENUM = 10;
+  K_INTERFACE = 11;
+  K_FUNCTION = 12;
+  K_VARIABLE = 13;
+  K_CONSTANT = 14;
+  K_STRING = 15;
+  K_NUMBER = 16;
+  K_BOOLEAN = 17;
+  K_ARRAY = 18;
+  K_OBJECT = 19;
+  K_KEY = 20;
+  K_NULL = 21;
+  K_ENUM_MEMBER = 22;
+  K_STRUCT = 23;
+  K_EVENT = 24;
+  K_OPERATOR = 25;
+  K_TYPE_PARAMETER = 26;
+}

--- a/src/__Private/LSP/TextDocumentChangeRegistrationOptions.php
+++ b/src/__Private/LSP/TextDocumentChangeRegistrationOptions.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type TextDocumentChangeRegistrationOptions
+/* extends TextDocumentRegistrationOptions */ = shape(
+  'syncKind' => TextDocumentSyncKind,
+  /* TextDocumentRegistrationOptions */
+  'documentSelector' => ?DocumentSelector,
+);

--- a/src/__Private/LSP/TextDocumentClientCapabilities.php
+++ b/src/__Private/LSP/TextDocumentClientCapabilities.php
@@ -1,0 +1,96 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type TextDocumentClientCapabilities = shape(
+  ?'synchronization' => shape(
+    ?'dynamicRegistration' => bool,
+    ?'willSave' => bool,
+    ?'willSaveUntil' => bool,
+    ?'didSave' => bool,
+  ),
+  ?'completion' => shape(
+    ?'dynamicRegistration' => bool,
+    ?'completionItem' => shape(
+      ?'snippetSupport' => bool,
+      ?'commitCharactersSupport' => bool,
+      ?'documentationFormat' => keyset<MarkupKind>,
+      ?'deprecatedSupport' => bool,
+    ),
+    ?'completionItemKind' => shape(
+      ?'valueSet' => keyset<CompletionItemKind>,
+    ),
+    ?'contextSupport' => bool,
+  ),
+  ?'hover' => shape(
+    ?'dynamicRegistration' => bool,
+    ?'contentFormat' => vec<MarkupKind>,
+  ),
+  ?'signatureHelp' => shape(
+    ?'dynamicRegistration' => bool,
+    ?'signatureInformation' => shape(
+      ?'documentationFormat' => vec<MarkupKind>,
+    ),
+  ),
+  ?'references' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'documentHighlight' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'documentSymbol' => shape(
+    ?'dynamicRegistration' => bool,
+    ?'symbolKind' => shape(
+      ?'valueSet' => keyset<SymbolKind>,
+    ),
+  ),
+  ?'formatting' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'rangeFormatting' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'onTypeFormatting' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'definition' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'typeDefinition' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'implementation' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'codeAction' => shape(
+    ?'dynamicRegistration' => bool,
+    ?'codeActionLiteralSupport' => shape(
+      'codeActionKind' => shape(
+        'valueSet' => keyset<CodeActionKind>,
+      ),
+    ),
+  ),
+  ?'codeLens' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'documentLink' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'colorProvider' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'rename' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'publishDiagnostics' => shape(
+    ?'relatedInformation' => bool,
+  ),
+);

--- a/src/__Private/LSP/TextDocumentContentChangeEvent.php
+++ b/src/__Private/LSP/TextDocumentContentChangeEvent.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type TextDocumentContentChangeEvent = shape(
+  ?'range' => Range,
+  ?'rangeLength' => int,
+  'text' => string,
+);

--- a/src/__Private/LSP/TextDocumentEdit.php
+++ b/src/__Private/LSP/TextDocumentEdit.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type TextDocumentEdit = shape(
+  'textDocument' => VersionedTextDocumentIdentifier,
+  'edits' => vec<TextEdit>,
+);

--- a/src/__Private/LSP/TextDocumentIdentifier.php
+++ b/src/__Private/LSP/TextDocumentIdentifier.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type TextDocumentIdentifier = shape(
+  'uri' => DocumentUri,
+);

--- a/src/__Private/LSP/TextDocumentItem.php
+++ b/src/__Private/LSP/TextDocumentItem.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type TextDocumentItem = shape(
+  'uri' => DocumentUri,
+  'langaugeId' => string,
+  'version' => int,
+  'text' => string,
+);

--- a/src/__Private/LSP/TextDocumentPositionParams.php
+++ b/src/__Private/LSP/TextDocumentPositionParams.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type TextDocumentPositionParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+  'position' => Position,
+);

--- a/src/__Private/LSP/TextDocumentRegistrationOptions.php
+++ b/src/__Private/LSP/TextDocumentRegistrationOptions.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type TextDocumentRegistrationOptions = shape(
+  'documentSelector' => ?DocumentSelector,
+);

--- a/src/__Private/LSP/TextDocumentSaveReason.php
+++ b/src/__Private/LSP/TextDocumentSaveReason.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum TextDocumentSaveReason: int {
+  MANUAL = 1;
+  AFTER_DELAY = 2;
+  FOCUS_OUT = 3;
+}

--- a/src/__Private/LSP/TextDocumentSaveRegistrationOptions.php
+++ b/src/__Private/LSP/TextDocumentSaveRegistrationOptions.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type TextDocumentSaveRegistrationoptions
+/* extends TextDocumentRegistrationOptions */ = shape(
+  ?'includeText' => bool,
+  /* TextDocumentRegistrationOptions */
+  'documentSelector' => ?DocumentSelector,
+);

--- a/src/__Private/LSP/TextDocumentSyncKind.php
+++ b/src/__Private/LSP/TextDocumentSyncKind.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum TextDocumentSyncKind: int {
+  NONE = 0;
+  FULL = 1;
+  INCREMENTAL = 2;
+}

--- a/src/__Private/LSP/TextDocumentSyncOptions.php
+++ b/src/__Private/LSP/TextDocumentSyncOptions.php
@@ -12,8 +12,8 @@ namespace Facebook\HHAST\__Private\LSP;
 
 type TextDocumentSyncOptions = shape(
   ?'openClose' => bool,
-  ?'change' => int,
+  ?'change' => TextDocumentSyncKind,
   ?'willSave' => bool,
   ?'willSaveWaitUntil' => bool,
-  ?'save' => bool,
+  ?'save' => SaveOptions,
 );

--- a/src/__Private/LSP/TextDocumentSyncOptions.php
+++ b/src/__Private/LSP/TextDocumentSyncOptions.php
@@ -1,0 +1,19 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type TextDocumentSyncOptions = shape(
+  ?'openClose' => bool,
+  ?'change' => int,
+  ?'willSave' => bool,
+  ?'willSaveWaitUntil' => bool,
+  ?'save' => bool,
+);

--- a/src/__Private/LSP/TextEdit.php
+++ b/src/__Private/LSP/TextEdit.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type TextEdit = shape(
+  'range' => Range,
+  'newText' => string,
+);

--- a/src/__Private/LSP/TraceLevel.php
+++ b/src/__Private/LSP/TraceLevel.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum TraceLevel: string {
+  OFF = 'off';
+  MESSAGES = 'messages';
+  VEROSE = 'verbose';
+}

--- a/src/__Private/LSP/Unregistration.php
+++ b/src/__Private/LSP/Unregistration.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type Unregistration = shape(
+  'id' => string,
+  'method' => string,
+);

--- a/src/__Private/LSP/UnregistrationParams.php
+++ b/src/__Private/LSP/UnregistrationParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type UnregistrationParams = shape(
+  'unregistrations' => vec<Unregistration>,
+);

--- a/src/__Private/LSP/VersionedTextDocumentIdentifier.php
+++ b/src/__Private/LSP/VersionedTextDocumentIdentifier.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type VersionedTextDocumentIdentifier /* extends TextDocumentIdentifier */ = shape(
+  'version' => ?int,
+  /* TextDocumentIdentifier */
+  'uri' => DocumentUri,
+);

--- a/src/__Private/LSP/WatchKind.php
+++ b/src/__Private/LSP/WatchKind.php
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+enum WatchKind: int {
+  CREATE = 1;
+  CHANGE = 2;
+  DELETE = 4;
+}

--- a/src/__Private/LSP/WillSaveTextDocumentParams.php
+++ b/src/__Private/LSP/WillSaveTextDocumentParams.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type WillSaveTextDocumentParams = shape(
+  'textDocument' => TextDocumentIdentifier,
+  'reason' => TextDocumentSaveReason,
+);

--- a/src/__Private/LSP/WorkspaceClientCapabilities.php
+++ b/src/__Private/LSP/WorkspaceClientCapabilities.php
@@ -1,0 +1,35 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type WorkspaceClientCapabilities = shape(
+  ?'applyEdit' => bool,
+  ?'workspaceEdit' => shape(
+    ?'documentChanges' => bool,
+  ),
+  ?'didChangeConfiguration' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'didChangeWatchedFiles' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'symbol' => shape(
+    ?'dynamicRegistration' => bool,
+    ?'symbolKind' => shape(
+      ?'valueSet' => vec<SymbolKind>,
+    ),
+  ),
+  ?'executeCommand' => shape(
+    ?'dynamicRegistration' => bool,
+  ),
+  ?'workspaceFolders' => bool,
+  ?'configuration' => bool,
+);

--- a/src/__Private/LSP/WorkspaceEdit.php
+++ b/src/__Private/LSP/WorkspaceEdit.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type WorkspaceEdit = shape(
+  ?'changes' => dict<string, vec<TextEdit>>,
+  ?'documentChanges' => vec<TextDocumentEdit>,
+);

--- a/src/__Private/LSP/WorkspaceFolder.php
+++ b/src/__Private/LSP/WorkspaceFolder.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type WorkspaceFolder = shape(
+  'uri' => string,
+  'name' => string,
+);

--- a/src/__Private/LSP/WorkspaceFoldersChangeEvent.php
+++ b/src/__Private/LSP/WorkspaceFoldersChangeEvent.php
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type WorkspaceFoldersChangeEvent = shape(
+  'added' => vec<WorkspaceFolder>,
+  'removed' => vec<WorkspaceFolder>,
+);

--- a/src/__Private/LSP/WorkspaceSymbolParams.php
+++ b/src/__Private/LSP/WorkspaceSymbolParams.php
@@ -1,0 +1,15 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSP;
+
+type WorkspaceSymbolParams = shape(
+  'query' => string,
+);

--- a/src/__Private/LSPImpl/DidSaveTextDocumentNotification.php
+++ b/src/__Private/LSPImpl/DidSaveTextDocumentNotification.php
@@ -1,0 +1,58 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSPImpl;
+
+use type Facebook\HHAST\__Private\{
+  LintRun,
+  LintRunConfig,
+  LintRunLSPErrorHandler,
+};
+use type Facebook\CLILib\ITerminal;
+use namespace Facebook\HHAST\__Private\{LSP, LSPLib};
+use namespace HH\Lib\Str;
+
+final class DidSaveTextDocumentNotification
+  extends LSPLib\DidSaveTextDocumentNotification {
+
+  public function __construct(
+    private ITerminal $terminal,
+    private ?LintRunConfig $config,
+  ) {
+  }
+
+  public async function executeAsync(self::TParams $p): Awaitable<void> {
+    $uri = $p['textDocument']['uri'];
+    if (!Str\starts_with($uri, 'file://')) {
+      return;
+    }
+    $path = Str\strip_prefix($uri, 'file://');
+    $config = $this->config ?? LintRunConfig::getForPath($path);
+
+    $handler = (new LintRunLSPErrorHandler($this->terminal));
+    (new LintRun($config, $handler, vec[$path]))->run();
+    $handler->printFinalOutput();
+    if ($handler->hadErrors()) {
+      return;
+    }
+    $message = (new LSPLib\PublishDiagnosticsNotification(shape(
+      'uri' => $uri,
+      'diagnostics' => vec[],
+    )))->asMessage();
+    $json = \json_encode($message);
+    $this->terminal
+      ->getStdout()
+      ->write(Str\format(
+        "Content-Length: %d\r\n\r\n%s",
+        Str\length($json),
+        $json,
+      ));
+  }
+}

--- a/src/__Private/LSPImpl/DidSaveTextDocumentNotification.php
+++ b/src/__Private/LSPImpl/DidSaveTextDocumentNotification.php
@@ -28,6 +28,7 @@ final class DidSaveTextDocumentNotification
   ) {
   }
 
+  <<__Override>>
   public async function executeAsync(self::TParams $p): Awaitable<void> {
     $uri = $p['textDocument']['uri'];
     if (!Str\starts_with($uri, 'file://')) {

--- a/src/__Private/LSPImpl/InitializeCommand.php
+++ b/src/__Private/LSPImpl/InitializeCommand.php
@@ -13,6 +13,7 @@ namespace Facebook\HHAST\__Private\LSPImpl;
 use namespace Facebook\HHAST\__Private\{LSP, LSPLib};
 
 final class InitializeCommand extends LSPLib\InitializeCommand {
+  <<__Override>>
   public async function executeAsync(
     self::TParams $_,
   ): Awaitable<self::TExecuteResult> {

--- a/src/__Private/LSPImpl/InitializeCommand.php
+++ b/src/__Private/LSPImpl/InitializeCommand.php
@@ -18,7 +18,11 @@ final class InitializeCommand extends LSPLib\InitializeCommand {
   ): Awaitable<self::TExecuteResult> {
     return self::success(shape(
       'capabilities' => shape(
-        // Yeah, we don't do much :/
+        'textDocumentSync' => shape(
+          'save' => shape(
+            'includeText' => false,
+          ),
+        ),
       ),
     ));
   }

--- a/src/__Private/LSPImpl/InitializeCommand.php
+++ b/src/__Private/LSPImpl/InitializeCommand.php
@@ -1,0 +1,25 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSPImpl;
+
+use namespace Facebook\HHAST\__Private\{LSP, LSPLib};
+
+final class InitializeCommand extends LSPLib\InitializeCommand {
+  public async function executeAsync(
+    self::TParams $_,
+  ): Awaitable<self::TExecuteResult> {
+    return self::success(shape(
+      'capabilities' => shape(
+        // Yeah, we don't do much :/
+      ),
+    ));
+  }
+}

--- a/src/__Private/LSPLib/ClientNotification.php
+++ b/src/__Private/LSPLib/ClientNotification.php
@@ -10,9 +10,10 @@
 
 namespace Facebook\HHAST\__Private\LSPLib;
 
-use namespace Facebook\HHAST\__Private\LSP;
+<<__ConsistentConstruct>>
+abstract class ClientNotification {
+  abstract const string METHOD;
+  abstract const type TParams;
 
-final class PublishDiagnosticsNotification extends ServerNotification {
-  const string METHOD = 'textDocument/publishDiagnostics';
-  const type TParams = LSP\PublishDiagnosticsParams;
+  abstract public function executeAsync(this::TParams $in): Awaitable<void>;
 }

--- a/src/__Private/LSPLib/Command.php
+++ b/src/__Private/LSPLib/Command.php
@@ -1,0 +1,41 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSPLib;
+
+<<__ConsistentConstruct>>
+abstract class Command {
+  abstract const string COMMAND;
+  abstract const type TParams;
+  abstract const type TResponse;
+  abstract const type TErrorCode as int;
+  abstract const type TErrorData;
+
+  const type TExecuteResult =
+    SuccessOrError<this::TResponse, this::TErrorCode, this::TErrorData>;
+
+  abstract public function executeAsync(
+    this::TParams $in,
+  ): Awaitable<this::TExecuteResult>;
+
+  final protected static function success(
+    this::TResponse $in,
+  ): this::TExecuteResult {
+    return new Success($in);
+  }
+
+  final protected static function error(
+    this::TErrorCode $code,
+    string $message,
+    this::TErrorData $data,
+  ): this::TExecuteResult {
+    return new Error($code, $message, $data);
+  }
+}

--- a/src/__Private/LSPLib/Command.php
+++ b/src/__Private/LSPLib/Command.php
@@ -12,7 +12,7 @@ namespace Facebook\HHAST\__Private\LSPLib;
 
 <<__ConsistentConstruct>>
 abstract class Command {
-  abstract const string COMMAND;
+  abstract const string METHOD;
   abstract const type TParams;
   abstract const type TResponse;
   abstract const type TErrorCode as int;

--- a/src/__Private/LSPLib/Command.php
+++ b/src/__Private/LSPLib/Command.php
@@ -10,7 +10,6 @@
 
 namespace Facebook\HHAST\__Private\LSPLib;
 
-<<__ConsistentConstruct>>
 abstract class Command {
   abstract const string METHOD;
   abstract const type TParams;

--- a/src/__Private/LSPLib/DidSaveTextDocumentNotification.php
+++ b/src/__Private/LSPLib/DidSaveTextDocumentNotification.php
@@ -10,9 +10,9 @@
 
 namespace Facebook\HHAST\__Private\LSPLib;
 
-abstract class ClientNotification {
-  abstract const string METHOD;
-  abstract const type TParams;
+use namespace Facebook\HHAST\__Private\LSP;
 
-  abstract public function executeAsync(this::TParams $in): Awaitable<void>;
+abstract class DidSaveTextDocumentNotification extends ClientNotification {
+  const string METHOD = 'textDocument/didSave';
+  const type TParams = LSP\DidSaveTextDocumentParams;
 }

--- a/src/__Private/LSPLib/Error.php
+++ b/src/__Private/LSPLib/Error.php
@@ -21,14 +21,17 @@ final class Error<TResult, TErrorCode as int, TErrorData>
   ) {
   }
 
+  <<__Override>>
   public function isSuccess(): bool {
     return false;
   }
 
+  <<__Override>>
   public function getResult(): TResult {
     invariant_violation('%s should not be called on %s', __METHOD__, __CLASS__);
   }
 
+  <<__Override>>
   public function getError(): this {
     return $this;
   }

--- a/src/__Private/LSPLib/Error.php
+++ b/src/__Private/LSPLib/Error.php
@@ -1,0 +1,46 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSPLib;
+
+use namespace Facebook\HHAST\__Private\LSP;
+
+final class Error<TResult, TErrorCode as int, TErrorData>
+  extends SuccessOrError<TResult, TErrorCode, TErrorData> {
+  public function __construct(
+    private TErrorCode $code,
+    private string $message,
+    private TErrorData $data,
+  ) {
+  }
+
+  public function isSuccess(): bool {
+    return false;
+  }
+
+  public function getResult(): TResult {
+    invariant_violation('%s should not be called on %s', __METHOD__, __CLASS__);
+  }
+
+  public function getError(): this {
+    return $this;
+  }
+
+  public function asResponseError(): LSP\ResponseError<TErrorData> {
+    $s = shape(
+      'code' => $this->code,
+      'message' => $this->message
+    );
+    if ($this->data !== null) {
+      $s['data'] = $this->data;
+    }
+    return $s;
+  }
+}

--- a/src/__Private/LSPLib/InitializeCommand.php
+++ b/src/__Private/LSPLib/InitializeCommand.php
@@ -1,0 +1,21 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSPLib;
+
+use namespace Facebook\HHAST\__Private\LSP;
+
+abstract class InitializeCommand extends Command {
+  const string COMMAND = 'initialize';
+  const type TParams = LSP\InitializeParams;
+  const type TResponse = LSP\InitializeResult;
+  const type TErrorCode = LSP\InitializeErrorCode;
+  const type TErrorData = LSP\InitializeError;
+}

--- a/src/__Private/LSPLib/InitializeCommand.php
+++ b/src/__Private/LSPLib/InitializeCommand.php
@@ -13,7 +13,7 @@ namespace Facebook\HHAST\__Private\LSPLib;
 use namespace Facebook\HHAST\__Private\LSP;
 
 abstract class InitializeCommand extends Command {
-  const string COMMAND = 'initialize';
+  const string METHOD = 'initialize';
   const type TParams = LSP\InitializeParams;
   const type TResponse = LSP\InitializeResult;
   const type TErrorCode = LSP\InitializeErrorCode;

--- a/src/__Private/LSPLib/InitializedNotification.php
+++ b/src/__Private/LSPLib/InitializedNotification.php
@@ -15,6 +15,7 @@ class InitializedNotification extends ClientNotification {
   const string METHOD = 'initialized';
   const type TParams = mixed;
 
+  <<__Override>>
   public async function executeAsync(this::TParams $_in): Awaitable<void> {
   }
 }

--- a/src/__Private/LSPLib/InitializedNotification.php
+++ b/src/__Private/LSPLib/InitializedNotification.php
@@ -10,9 +10,11 @@
 
 namespace Facebook\HHAST\__Private\LSPLib;
 
-use namespace Facebook\HHAST\__Private\LSP;
+<<__ConsistentConstruct>>
+class InitializedNotification extends ClientNotification {
+  const string METHOD = 'initialized';
+  const type TParams = mixed;
 
-final class PublishDiagnosticsNotification extends ServerNotification {
-  const string METHOD = 'textDocument/publishDiagnostics';
-  const type TParams = LSP\PublishDiagnosticsParams;
+  public async function executeAsync(this::TParams $_in): Awaitable<void> {
+  }
 }

--- a/src/__Private/LSPLib/Notification.php
+++ b/src/__Private/LSPLib/Notification.php
@@ -1,0 +1,34 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSPLib;
+
+use namespace Facebook\HHAST\__Private\LSP;
+
+abstract class Notification {
+  abstract const string METHOD;
+  abstract const type TParams;
+
+  public function __construct(private this::TParams $params) {}
+
+  public function asMessage(): LSP\NotificationMessage {
+    $message = shape(
+      'jsonrpc' => '2.0',
+      'method' => static::METHOD,
+    );
+
+    $params = $this->params;
+    if ($params !== null) {
+      $message['params'] = $params;
+    }
+
+    return $message;
+  }
+}

--- a/src/__Private/LSPLib/PublishDiagnosticsNotification.php
+++ b/src/__Private/LSPLib/PublishDiagnosticsNotification.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSPLib;
+
+use namespace Facebook\HHAST\__Private\LSP;
+
+final class PublishDiagnosticsNotification extends Notification {
+  const string METHOD = 'textDocument/publishDiagnostics';
+  const type TParams = LSP\PublishDiagnosticsParams;
+}

--- a/src/__Private/LSPLib/Server.php
+++ b/src/__Private/LSPLib/Server.php
@@ -1,0 +1,85 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSPLib;
+
+use namespace Facebook\HHAST\__Private\LSP;
+use function Facebook\HHAST\__Private\type_alias_structure;
+use namespace Facebook\TypeSpec;
+use namespace HH\Lib\{Dict, Str};
+
+abstract class Server {
+  abstract const keyset<classname<Command>> COMMANDS;
+
+  private dict<string, Command> $commands;
+
+  public function __construct() {
+    $this->commands = Dict\pull(
+      static::COMMANDS,
+      $class ==> new $class(),
+      $class ==> $class::COMMAND,
+    );
+  }
+
+  final public async function handleMessageAsync(
+    string $json,
+  ): Awaitable<string> {
+    $request =
+      self::jsonDecode(type_alias_structure(LSP\RequestMessage::class), $json);
+    $command = $this->commands[$request['method']] ?? null;
+    if ($command === null) {
+      return self::encodeResponse(
+        shape(
+          'jsonrpc' => '2.0',
+          'id' => $request['id'],
+          'error' => shape(
+            'code' => LSP\ErrorCode::METHOD_NOT_FOUND,
+            'message' =>
+              Str\format("Command '%s' is not implemented", $request['method']),
+          ),
+        ),
+      );
+    }
+
+    $params = ($request['params'] ?? null)
+      |> TypeSpec\__Private\from_type_structure(
+        type_structure($command, 'TParams'),
+      )->coerceType($$);
+    $result = await $command->executeAsync($params);
+    if ($result instanceof Success) {
+      return self::encodeResponse(shape(
+        'jsonrpc' => '2.0',
+        'id' => $request['id'],
+        'result' => $result->getResult(),
+      ));
+    }
+
+    $error = $result->getError();
+    return self::encodeResponse(shape(
+      'jsonrpc' => '2.0',
+      'id' => $request['id'],
+      'error' => $result->getError()->asResponseError(),
+    ));
+  }
+
+  private static function encodeResponse(LSP\ResponseMessage $response): string {
+    return \json_encode($response);
+  }
+
+  private static function jsonDecode<T>(TypeStructure<T> $ts, string $json): T {
+    $request = \json_decode(
+      $json, /* assoc = */
+      true, /* depth = */
+      512,
+      \JSON_FB_HACK_ARRAYS,
+    );
+    return TypeSpec\__Private\from_type_structure($ts)->coerceType($request);
+  }
+}

--- a/src/__Private/LSPLib/Server.php
+++ b/src/__Private/LSPLib/Server.php
@@ -17,24 +17,27 @@ use type Facebook\TypeAssert\TypeCoercionException;
 use namespace HH\Lib\{Dict, Str};
 
 abstract class Server {
-  abstract const keyset<classname<Command>> COMMANDS;
-  const keyset<classname<ClientNotification>> NOTIFICATIONS = keyset[
-    InitializedNotification::class,
-  ];
+  protected function getSupportedCommands(): vec<Command> {
+    return vec[];
+  }
 
-  private dict<string, Command> $commands;
-  private dict<string, ClientNotification> $notifications;
+  protected function getSupportedClientNotifications(): vec<ClientNotification> {
+    return vec[new InitializedNotification()];
+  }
+
+  private dict<string, Command> $commands = dict[];
+  private dict<string, ClientNotification> $notifications = dict[];
   private bool $inited = false;
 
   public function __construct() {
     $this->commands = Dict\pull(
-      static::COMMANDS,
-      $class ==> new $class(),
+      $this->getSupportedCommands(),
+      $class ==> $class,
       $class ==> $class::METHOD,
     );
     $this->notifications = Dict\pull(
-      static::NOTIFICATIONS,
-      $class ==> new $class(),
+      $this->getSupportedClientNotifications(),
+      $class ==> $class,
       $class ==> $class::METHOD,
     );
   }

--- a/src/__Private/LSPLib/ServerNotification.php
+++ b/src/__Private/LSPLib/ServerNotification.php
@@ -12,7 +12,7 @@ namespace Facebook\HHAST\__Private\LSPLib;
 
 use namespace Facebook\HHAST\__Private\LSP;
 
-abstract class Notification {
+abstract class ServerNotification {
   abstract const string METHOD;
   abstract const type TParams;
 

--- a/src/__Private/LSPLib/Success.php
+++ b/src/__Private/LSPLib/Success.php
@@ -1,0 +1,28 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSPLib;
+
+final class Success<TResult, TErrorCode as int, TErrorData> extends SuccessOrError<TResult, TErrorCode, TErrorData> {
+  public function __construct(private TResult $result) {
+  }
+
+  public function isSuccess(): bool {
+    return true;
+  }
+
+  public function getResult(): TResult {
+    return $this->result;
+  }
+
+  public function getError(): Error<TResult, TErrorCode, TErrorData> {
+    invariant_violation('%s should not be called on %s', __METHOD__, __CLASS__);
+  }
+}

--- a/src/__Private/LSPLib/Success.php
+++ b/src/__Private/LSPLib/Success.php
@@ -14,14 +14,17 @@ final class Success<TResult, TErrorCode as int, TErrorData> extends SuccessOrErr
   public function __construct(private TResult $result) {
   }
 
+  <<__Override>>
   public function isSuccess(): bool {
     return true;
   }
 
+  <<__Override>>
   public function getResult(): TResult {
     return $this->result;
   }
 
+  <<__Override>>
   public function getError(): Error<TResult, TErrorCode, TErrorData> {
     invariant_violation('%s should not be called on %s', __METHOD__, __CLASS__);
   }

--- a/src/__Private/LSPLib/SuccessOrError.php
+++ b/src/__Private/LSPLib/SuccessOrError.php
@@ -1,0 +1,23 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\LSPLib;
+
+<<__Sealed(Success::class, Error::class)>>
+abstract class SuccessOrError<TSuccess, TErrorCode as int, TErrorData> {
+  abstract public function isSuccess(): bool;
+
+  final public function isError(): bool {
+    return !$this->isSuccess();
+  }
+
+  abstract public function getResult(): TSuccess;
+  abstract public function getError(): Error<TSuccess, TErrorCode, TErrorData>;
+}

--- a/src/__Private/LSPLib/SuccessOrError.php
+++ b/src/__Private/LSPLib/SuccessOrError.php
@@ -10,6 +10,7 @@
 
 namespace Facebook\HHAST\__Private\LSPLib;
 
+/* HH_IGNORE_ERROR[2049] __Sealed is new in 3.27 */
 <<__Sealed(Success::class, Error::class)>>
 abstract class SuccessOrError<TSuccess, TErrorCode as int, TErrorData> {
   abstract public function isSuccess(): bool;

--- a/src/__Private/LSPServer.php
+++ b/src/__Private/LSPServer.php
@@ -28,14 +28,28 @@ final class LSPServer extends LSPLib\Server {
   }
 
   public async function mainAsync(): Awaitable<int> {
-    await Tuple\from_async(
-      async {
-        await $this->mainLoopAsync();
-      },
-      async {
-        await $this->initAsync();
-      },
-    );
+    try {
+      await Tuple\from_async(
+        async {
+          await $this->mainLoopAsync();
+        },
+        async {
+          await $this->initAsync();
+        },
+      );
+    } catch (\Throwable $e) {
+      $this->terminal
+        ->getStderr()
+        ->write(
+          Str\format(
+            "Uncaught exception: %s:\n%s\n%s\n",
+            \get_class($e),
+            $e->getMessage(),
+            $e->getTraceAsString(),
+          ),
+        );
+      throw $e;
+    }
     return 0;
   }
 

--- a/src/__Private/LSPServer.php
+++ b/src/__Private/LSPServer.php
@@ -1,0 +1,84 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private;
+
+use type Facebook\CLILib\ITerminal;
+use namespace HH\Lib\{Tuple, Str};
+
+final class LSPServer extends LSPLib\Server {
+  const keyset<classname<LSPLib\Command>> COMMANDS = keyset[
+    LSPImpl\InitializeCommand::class,
+  ];
+
+  public function __construct(private ITerminal $terminal) {
+    parent::__construct();
+  }
+
+  public async function mainAsync(): Awaitable<int> {
+    await Tuple\from_async(
+      async {
+        await $this->mainLoopAsync();
+      },
+      async {
+        await $this->initAsync();
+      },
+    );
+    return 0;
+  }
+
+  private async function mainLoopAsync(): Awaitable<void> {
+    $stdin = $this->terminal->getStdin();
+    while (!$stdin->isEof()) {
+      await $this->handleOneAsync();
+    }
+  }
+
+  private async function initAsync(): Awaitable<void> {
+    $this->terminal->getStderr()->write("Waiting for init\n");
+    await $this->waitForInitAsync();
+    $this->terminal->getStderr()->write("Got Init\n");
+    // TODO: lint!
+  }
+
+  private async function handleOneAsync(): Awaitable<void> {
+    $stdin = $this->terminal->getStdin();
+    $length = null;
+
+    // read headers
+    while (true) {
+      $line = await $stdin->readLineAsync();
+      $line = Str\trim($line);
+      if ($line === '') {
+        break;
+      }
+      if (!Str\starts_with($line, 'Content-Length')) {
+        continue;
+      }
+      $length = $line
+        |> Str\strip_prefix($$, 'Content-Length:')
+        |> Str\trim($$)
+        |> Str\to_int($$);
+    }
+    invariant($length !== null, "Expected a content-length header");
+
+    // read body
+    $body = '';
+    while ($length > 0 && !$stdin->isEof()) {
+      $part = await $stdin->readAsync($length);
+      $body .= $part;
+      $length -= Str\length($part);
+      invariant($length >= 0, 'negative bytes remaining');
+    }
+
+    $response = await $this->handleMessageAsync($body);
+    $this->terminal->getStdout()->write($response);
+  }
+}

--- a/src/__Private/LSPServer.php
+++ b/src/__Private/LSPServer.php
@@ -77,13 +77,15 @@ final class LSPServer extends LSPLib\Server {
 
   private async function initAsync(): Awaitable<void> {
     await $this->waitForInitAsync();
+    $handler = new LintRunLSPErrorHandler($this->terminal);
     (
       new LintRun(
         $this->config,
-        new LintRunLSPErrorHandler($this->terminal),
+        $handler,
         $this->roots,
       )
     )->run();
+    $handler->printFinalOutput();
   }
 
   private async function handleOneAsync(): Awaitable<void> {
@@ -121,7 +123,6 @@ final class LSPServer extends LSPLib\Server {
 
   protected function sendMessage(LSP\Message $message): void {
     $json = \json_encode($message);
-    $this->terminal->getStderr()->write("Sending JSON: ".$json."\n");
     $this->terminal
       ->getStdout()
       ->write(Str\format(

--- a/src/__Private/LSPServer.php
+++ b/src/__Private/LSPServer.php
@@ -42,6 +42,7 @@ final class LSPServer extends LSPLib\Server {
     ];
   }
 
+  <<__Override>>
   protected function getSupportedClientNotifications(
   ): vec<LSPLib\ClientNotification> {
     $new = vec[
@@ -82,6 +83,7 @@ final class LSPServer extends LSPLib\Server {
   private async function mainLoopAsync(): Awaitable<void> {
     $stdin = $this->terminal->getStdin();
     while (!$stdin->isEof()) {
+      /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
       await $this->handleOneAsync();
     }
   }
@@ -99,6 +101,7 @@ final class LSPServer extends LSPLib\Server {
 
     // read headers
     while (true) {
+      /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
       $line = await $stdin->readLineAsync();
       $line = Str\trim($line);
       if ($line === '') {
@@ -117,6 +120,7 @@ final class LSPServer extends LSPLib\Server {
     // read body
     $body = '';
     while ($length > 0 && !$stdin->isEof()) {
+      /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
       $part = await $stdin->readAsync($length);
       $body .= $part;
       $length -= Str\length($part);
@@ -126,6 +130,7 @@ final class LSPServer extends LSPLib\Server {
     await $this->handleMessageAsync($body);
   }
 
+  <<__Override>>
   protected function sendMessage(LSP\Message $message): void {
     $json = \json_encode($message);
     $this->terminal

--- a/src/__Private/LintRunLSPErrorHandler.php
+++ b/src/__Private/LintRunLSPErrorHandler.php
@@ -47,7 +47,7 @@ final class LintRunLSPErrorHandler implements LintRunErrorHandler {
           $start = shape('line' => $position[0] - 1, 'character' => $position[1]);
           return shape(
             'range' => shape('start' => $start, 'end' => $start),
-            'severity' => LSP\DiagnosticSeverity::ERROR,
+            'severity' => LSP\DiagnosticSeverity::WARNING,
             'code' => \get_class($linter)
               |> Str\split($$, "\\")
               |> C\lastx($$)
@@ -68,5 +68,8 @@ final class LintRunLSPErrorHandler implements LintRunErrorHandler {
           $encoded,
         ),
       );
+  }
+
+  final public function printFinalOutput(): void {
   }
 }

--- a/src/__Private/LintRunLSPErrorHandler.php
+++ b/src/__Private/LintRunLSPErrorHandler.php
@@ -53,6 +53,7 @@ final class LintRunLSPErrorHandler implements LintRunErrorHandler {
               |> C\lastx($$)
               |> Str\strip_suffix($$, 'Linter'),
             'message' => $error->getDescription(),
+            'source' => 'HHAST',
           );
         },
       ),

--- a/src/__Private/LintRunLSPErrorHandler.php
+++ b/src/__Private/LintRunLSPErrorHandler.php
@@ -63,7 +63,7 @@ final class LintRunLSPErrorHandler implements LintRunErrorHandler {
       ->getStdout()
       ->write(
         Str\format(
-          "Content-Length: %d\r\n\r\n%s\r\n",
+          "Content-Length: %d\r\n\r\n%s",
           Str\length($encoded),
           $encoded,
         ),

--- a/src/__Private/LintRunLSPErrorHandler.php
+++ b/src/__Private/LintRunLSPErrorHandler.php
@@ -14,11 +14,15 @@ use type Facebook\CLILib\ITerminal;
 use namespace Facebook\HHAST\Linters;
 use namespace HH\Lib\{C, Dict, Str, Vec};
 
-final class LintRunLSPErrorHandler implements LintRunErrorHandler {
+final class LintRunLSPErrorHandler implements LinterCLIErrorHandler {
   public function __construct(private ITerminal $terminal) {
   }
 
   private dict<string, vec<LSP\Diagnostic>> $log = dict[];
+
+  public function hadErrors(): bool {
+    return !C\is_empty($this->log);
+  }
 
   public function processErrors(
     Linters\BaseLinter $linter,

--- a/src/__Private/LintRunLSPErrorHandler.php
+++ b/src/__Private/LintRunLSPErrorHandler.php
@@ -1,0 +1,71 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private;
+
+use type Facebook\CLILib\ITerminal;
+use namespace Facebook\HHAST\Linters;
+use namespace HH\Lib\{C, Dict, Str, Vec};
+
+final class LintRunLSPErrorHandler implements LintRunErrorHandler {
+  public function __construct(private ITerminal $terminal) {
+  }
+
+  /**
+   * Process a set of errors returned by running an individual linter on a
+   * single file
+   */
+  public function processErrors(
+    Linters\BaseLinter $linter,
+    LintRunConfig::TFileConfig $config,
+    Traversable<Linters\LintError> $errors,
+  ): void {
+    $by_files = Dict\group_by($errors, $error ==> $error->getFile());
+    foreach ($by_files as $file => $errors) {
+      $this->publishDiagnostics($linter, $file, $errors);
+    }
+  }
+
+  private function publishDiagnostics(
+    Linters\BaseLinter $linter,
+    string $file,
+    vec<Linters\LintError> $errors,
+  ): void {
+    $message = (new LSPLib\PublishDiagnosticsNotification(shape(
+      'uri' => 'file://'.\realpath($file),
+      'diagnostics' => Vec\map(
+        $errors,
+        $error ==> {
+          $position = $error->getPosition() ?? tuple(0, 0);
+          $start = shape('line' => $position[0] - 1, 'character' => $position[1]);
+          return shape(
+            'range' => shape('start' => $start, 'end' => $start),
+            'severity' => LSP\DiagnosticSeverity::ERROR,
+            'code' => \get_class($linter)
+              |> Str\split($$, "\\")
+              |> C\lastx($$)
+              |> Str\strip_suffix($$, 'Linter'),
+            'message' => $error->getDescription(),
+          );
+        },
+      ),
+    )))->asMessage();
+    $encoded = \json_encode($message);
+    $this->terminal
+      ->getStdout()
+      ->write(
+        Str\format(
+          "Content-Length: %d\r\n\r\n%s\r\n",
+          Str\length($encoded),
+          $encoded,
+        ),
+      );
+  }
+}

--- a/src/__Private/LintRunLSPErrorHandler.php
+++ b/src/__Private/LintRunLSPErrorHandler.php
@@ -40,15 +40,16 @@ final class LintRunLSPErrorHandler implements LintRunErrorHandler {
   ): LSP\Diagnostic {
     $position = $error->getPosition() ?? tuple(0, 0);
     $start = shape('line' => $position[0] - 1, 'character' => $position[1]);
+    $source = \get_class($linter)
+      |> Str\split($$, "\\")
+      |> C\lastx($$)
+      |> Str\strip_suffix($$, 'Linter');
     return shape(
       'range' => shape('start' => $start, 'end' => $start),
       'severity' => LSP\DiagnosticSeverity::WARNING,
-      'code' => \get_class($linter)
-        |> Str\split($$, "\\")
-        |> C\lastx($$)
-        |> Str\strip_suffix($$, 'Linter'),
       'message' => $error->getDescription(),
-      'source' => 'HHAST',
+      'code' => $source,
+      'source' => 'HHAST:'.$source,
     );
   }
 

--- a/src/__Private/LintRunLSPErrorHandler.php
+++ b/src/__Private/LintRunLSPErrorHandler.php
@@ -18,10 +18,8 @@ final class LintRunLSPErrorHandler implements LintRunErrorHandler {
   public function __construct(private ITerminal $terminal) {
   }
 
-  /**
-   * Process a set of errors returned by running an individual linter on a
-   * single file
-   */
+  private dict<string, vec<LSP\Diagnostic>> $log = dict[];
+
   public function processErrors(
     Linters\BaseLinter $linter,
     LintRunConfig::TFileConfig $config,
@@ -29,47 +27,54 @@ final class LintRunLSPErrorHandler implements LintRunErrorHandler {
   ): void {
     $by_files = Dict\group_by($errors, $error ==> $error->getFile());
     foreach ($by_files as $file => $errors) {
-      $this->publishDiagnostics($linter, $file, $errors);
+      $file = \realpath($file);
+      $this->log[$file] =
+        Vec\map($errors, $e ==> $this->asDiagnostic($linter, $e))
+        |> Vec\concat($this->log[$file] ?? vec[], $$);
     }
   }
 
-  private function publishDiagnostics(
+  private function asDiagnostic(
     Linters\BaseLinter $linter,
-    string $file,
-    vec<Linters\LintError> $errors,
-  ): void {
-    $message = (new LSPLib\PublishDiagnosticsNotification(shape(
-      'uri' => 'file://'.\realpath($file),
-      'diagnostics' => Vec\map(
-        $errors,
-        $error ==> {
-          $position = $error->getPosition() ?? tuple(0, 0);
-          $start = shape('line' => $position[0] - 1, 'character' => $position[1]);
-          return shape(
-            'range' => shape('start' => $start, 'end' => $start),
-            'severity' => LSP\DiagnosticSeverity::WARNING,
-            'code' => \get_class($linter)
-              |> Str\split($$, "\\")
-              |> C\lastx($$)
-              |> Str\strip_suffix($$, 'Linter'),
-            'message' => $error->getDescription(),
-            'source' => 'HHAST',
-          );
-        },
-      ),
-    )))->asMessage();
-    $encoded = \json_encode($message);
-    $this->terminal
-      ->getStdout()
-      ->write(
-        Str\format(
-          "Content-Length: %d\r\n\r\n%s",
-          Str\length($encoded),
-          $encoded,
-        ),
-      );
+    Linters\LintError $error,
+  ): LSP\Diagnostic {
+    $position = $error->getPosition() ?? tuple(0, 0);
+    $start = shape('line' => $position[0] - 1, 'character' => $position[1]);
+    return shape(
+      'range' => shape('start' => $start, 'end' => $start),
+      'severity' => LSP\DiagnosticSeverity::WARNING,
+      'code' => \get_class($linter)
+        |> Str\split($$, "\\")
+        |> C\lastx($$)
+        |> Str\strip_suffix($$, 'Linter'),
+      'message' => $error->getDescription(),
+      'source' => 'HHAST',
+    );
   }
 
-  final public function printFinalOutput(): void {
+  private function publishDiagnostics(
+    string $file,
+    vec<LSP\Diagnostic> $diagnostics,
+  ): void {
+    $message = (new LSPLib\PublishDiagnosticsNotification(shape(
+      'uri' => 'file://'.$file,
+      'diagnostics' => $diagnostics,
+    )))->asMessage();
+    $json = \json_encode($message);
+    $this->terminal->getStdout()->write(Str\format(
+      "Content-Length: %d\r\n\r\n%s",
+      Str\length($json),
+      $json,
+    ));
+  }
+
+  public function printFinalOutput(): void {
+    foreach ($this->log as $file => $diagnostics) {
+      $diagnostics = Vec\sort_by(
+        $diagnostics,
+        $d ==> $d['range']['start']['line'],
+      );
+      $this->publishDiagnostics($file, $diagnostics);
+    }
   }
 }

--- a/src/__Private/LinterCLI.php
+++ b/src/__Private/LinterCLI.php
@@ -117,7 +117,7 @@ final class LinterCLI extends CLIWithArguments {
         $error_handler = new LinterCLIErrorHandlerJSON($this->getTerminal());
         break;
       case LinterCLIMode::LSP:
-        return await (new LSPServer($this->getTerminal()))->mainAsync();
+        return await (new LSPServer($this->getTerminal(), $config, $roots))->mainAsync();
     }
 
     (new LintRun($config, $error_handler, $roots))->run();

--- a/src/__Private/LinterCLI.php
+++ b/src/__Private/LinterCLI.php
@@ -79,6 +79,7 @@ final class LinterCLI extends CLIWithArguments {
   private async function mainImplAsync(): Awaitable<int> {
     $err = $this->getStderr();
     $roots = $this->getArguments();
+
     if (C\is_empty($roots)) {
       $config = LintRunConfig::getForPath(\getcwd());
       $roots = $config->getRoots();
@@ -95,7 +96,7 @@ final class LinterCLI extends CLIWithArguments {
         if (\is_dir($path)) {
           $config_file = $path.'/hhast-lint.json';
           if (\file_exists($config_file)) {
-            $this->getStdout()->write(
+            $err->write(
               "Warning: PATH arguments contain a hhast-lint.json, ".
               "which modifies the linters used and customizes behavior. ".
               "Consider 'cd ".
@@ -115,6 +116,8 @@ final class LinterCLI extends CLIWithArguments {
       case LinterCLIMode::JSON:
         $error_handler = new LinterCLIErrorHandlerJSON($this->getTerminal());
         break;
+      case LinterCLIMode::LSP:
+        return await (new LSPServer($this->getTerminal()))->mainAsync();
     }
 
     (new LintRun($config, $error_handler, $roots))->run();

--- a/src/__Private/LinterCLIMode.php
+++ b/src/__Private/LinterCLIMode.php
@@ -13,4 +13,5 @@ namespace Facebook\HHAST\__Private;
 enum LinterCLIMode: string {
   PLAIN = 'plain';
   JSON = 'json';
+  LSP = 'lsp';
 }

--- a/src/__Private/LoggingInputTap.php
+++ b/src/__Private/LoggingInputTap.php
@@ -1,0 +1,40 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private;
+
+use type Facebook\CLILib\InputInterface;
+use namespace HH\Lib\Str;
+
+final class LoggingInputTap implements InputInterface {
+  public function __construct(
+    private InputInterface $impl,
+    private resource $logfile,
+  ) {
+  }
+
+  public function isEof(): bool {
+    return $this->impl->isEof();
+  }
+
+  public async function readAsync(?int $max_bytes = null): Awaitable<string> {
+    $result = await $this->impl->readAsync($max_bytes);
+    \fwrite($this->logfile, $result);
+    return $result;
+  }
+
+  public async function readLineAsync(
+    ?int $max_bytes = null,
+  ): Awaitable<string> {
+    $result = await $this->impl->readLineAsync($max_bytes);
+    \fwrite($this->logfile, $result);
+    return $result;
+  }
+}

--- a/src/__Private/LoggingOutputTap.php
+++ b/src/__Private/LoggingOutputTap.php
@@ -1,0 +1,32 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private;
+
+use type Facebook\CLILib\OutputInterface;
+use namespace HH\Lib\Str;
+
+final class LoggingOutputTap implements OutputInterface {
+  public function __construct(
+    private OutputInterface $impl,
+    private resource $logfile,
+  ) {
+  }
+
+  public function isEof(): bool {
+    return $this->impl->isEof();
+  }
+
+  public function write(string $buf): int {
+    $written = $this->impl->write($buf);
+    \fwrite($this->logfile, $buf, $written);
+    return $written;
+  }
+}


### PR DESCRIPTION
This builds on top of #65, and only implements the `initialize` message. It also depends on https://github.com/hhvm/hh-clilib/commit/b8ac1045c4333bca3444a454d7f0297f82c2af9f

You probably want to look at this commit-at-a-time, instead of all the changes.

It includes *all* the LSP spec interfaces, not just the ones we hope to use in HHAST.

refs #25

in vscode:

```
[Info  - 4:02:28 PM] Connection to server got closed. Server will restart.
Waiting for init
Got Init
```