### PR TITLE
Nice handling of linters throwing exceptions

### DIFF
--- a/src/Linters/LinterException.php
+++ b/src/Linters/LinterException.php
@@ -1,0 +1,46 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\Linters;
+
+use namespace HH\Lib\{C, Str, Vec};
+
+class LinterException extends \Exception {
+  public function __construct(
+    private classname<BaseLinter> $linter,
+    private string $fileBeingLinted,
+    private string $rawMessage,
+    ?\Throwable $previous = null,
+  ) {
+    parent::__construct(
+      Str\format(
+        "While running '%s' on '%s': %s",
+        $linter,
+        $fileBeingLinted,
+        $rawMessage,
+      ),
+      /* code = */ 0,
+      /* HH_IGNORE_ERROR[4110] : Throwable is fine. facebook/hhvm#8239 */
+      $previous,
+    );
+  }
+
+  public function getLinterClass(): classname<BaseLinter> {
+    return $this->linter;
+  }
+
+  public function getFileBeingLinted(): string {
+    return $this->fileBeingLinted;
+  }
+
+  public function getRawMessage(): string {
+    return $this->rawMessage;
+  }
+}

--- a/src/Linters/LinterException.php
+++ b/src/Linters/LinterException.php
@@ -12,11 +12,12 @@ namespace Facebook\HHAST\Linters;
 
 use namespace HH\Lib\{C, Str, Vec};
 
-class LinterException extends \Exception {
+final class LinterException extends \Exception {
   public function __construct(
     private classname<BaseLinter> $linter,
     private string $fileBeingLinted,
     private string $rawMessage,
+    private ?(int, int) $position = null,
     ?\Throwable $previous = null,
   ) {
     parent::__construct(
@@ -42,5 +43,9 @@ class LinterException extends \Exception {
 
   public function getRawMessage(): string {
     return $this->rawMessage;
+  }
+
+  public function getPosition(): ?(int, int) {
+    return $this->position;
   }
 }

--- a/src/__Private/LintRun.php
+++ b/src/__Private/LintRun.php
@@ -68,7 +68,7 @@ final class LintRun {
       } catch (LinterException $e) {
         throw $e;
       } catch (\Throwable $t) {
-        throw new LinterException($class, $path, $t->getMessage(), $t);
+        throw new LinterException($class, $path, $t->getMessage(), null, $t);
       }
     }
     $this->handler->finishedFile($path, $result);

--- a/src/__Private/LintRun.php
+++ b/src/__Private/LintRun.php
@@ -10,6 +10,7 @@
 
 namespace Facebook\HHAST\__Private;
 
+use type Facebook\HHAST\Linters\{BaseLinter, LinterException};
 use type Facebook\CLILib\ExitException;
 use namespace HH\Lib\{C, Str, Vec};
 
@@ -59,30 +60,52 @@ final class LintRun {
     $result = LintRunResult::NO_ERRORS;
 
     foreach ($config['linters'] as $class) {
-      if (!$class::shouldLintFile($path)) {
-        continue;
-      }
-
-      $linter = new $class($path);
-
-      if ($linter->isLinterSuppressedForFile()) {
-        continue;
-      }
-
-      /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
-      $errors = await $linter->getLintErrorsAsync();
-      if ($errors) {
-        $result = (
-          $this->handler->linterRaisedErrors($linter, $config, $errors) ===
-            LintAutoFixResult::ALL_FIXED
-            ? LintRunResult::HAD_AUTOFIXED_ERRORS
-            : LintRunResult::HAVE_UNFIXED_ERRORS
-        )
-          |> self::worstResult($result, $$);
+      try {
+        /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
+        $this_result =
+          await $this->runLinterOnFileImplAsync($config, $class, $path);
+        $result = self::worstResult($result, $this_result);
+      } catch (LinterException $e) {
+        throw $e;
+      } catch (\Throwable $t) {
+        throw new LinterException($class, $path, $t->getMessage(), $t);
       }
     }
     $this->handler->finishedFile($path, $result);
     return $result;
+  }
+
+  private async function runLinterOnFileImplAsync(
+    LintRunConfig::TFileConfig $config,
+    classname<BaseLinter> $linter,
+    string $path,
+  ): Awaitable<LintRunResult> {
+    if (!$linter::shouldLintFile($path)) {
+      return LintRunResult::NO_ERRORS;
+    }
+
+    $linter = new $linter($path);
+
+    if ($linter->isLinterSuppressedForFile()) {
+      return LintRunResult::NO_ERRORS;
+    }
+
+    try {
+      $errors = await $linter->getLintErrorsAsync();
+    } catch (\Throwable $t) {
+      throw $t;
+    } catch (\Exception $e) {
+      throw $e;
+    }
+    if (!$errors) {
+      return LintRunResult::NO_ERRORS;
+    }
+    return (
+      $this->handler->linterRaisedErrors($linter, $config, $errors) ===
+        LintAutoFixResult::ALL_FIXED
+    )
+      ? LintRunResult::HAD_AUTOFIXED_ERRORS
+      : LintRunResult::HAVE_UNFIXED_ERRORS;
   }
 
   private async function lintDirectoryAsync(


### PR DESCRIPTION
Depends on (and includes) #76 - only the last two commits in this PR need reviewing

Example output:

```
A linter threw an exception:
  Linter: Facebook\HHAST\Linters\AsyncFunctionAndMethodLinter
  File: /Users/fred/code/definition-finder/tests/data/php_class_contents.php:13:3
    >
    > class Foo {
    >   function defaultVisibility() {}
        ^ HERE
  Exception: Facebook\TypeAssert\IncorrectTypeException
  Message: Expected type 'Facebook\HHAST\EditableList', got type 'Facebook\HHAST\Missing'
  Trace:
    #0 /Users/fred/code/hhast/vendor/hhvm/type-assert/src/IncorrectTypeException.php(54): Facebook\TypeAssert\IncorrectTypeException::withType()
    #1 /Users/fred/code/hhast/vendor/hhvm/type-assert/src/TypeSpec/__Private/InstanceOfSpec.php(29): Facebook\TypeAssert\IncorrectTypeException::withValue()
    #2 /Users/fred/code/hhast/vendor/hhvm/type-assert/src/TypeAssert.php(56): Facebook\TypeSpec\__Private\InstanceOfSpec->assertType()
    #3 /Users/fred/code/hhast/codegen/syntax/FunctionDeclarationHeader.php(258): Facebook\TypeAssert\instance_of()
    #4 /Users/fred/code/hhast/src/Linters/FunctionNamingLinter.php(115): Facebook\HHAST\FunctionDeclarationHeader->getModifiersx()
    #5 /Users/fred/code/hhast/src/Linters/BaseASTLinter.php(92): Facebook\HHAST\Linters\FunctionNamingLinter->getLintErrorForNode()
    #6 /Users/fred/code/hhast/src/__Private/LintRun.php(94): Facebook\HHAST\Linters\BaseASTLinter->getLintErrorsAsync()
    #7 /Users/fred/code/hhast/src/__Private/LintRun.php(66): Facebook\HHAST\__Private\LintRun->runLinterOnFileImplAsync()
    #8 /Users/fred/code/hhast/src/__Private/LintRun.php(129): Facebook\HHAST\__Private\LintRun->lintFileAsync()
    #9 /Users/fred/code/hhast/vendor/hhvm/hsl/src/vec/async.php(71): Closure$Facebook\HHAST\__Private\LintRun::lintDirectoryAsync()
    #10 /Users/fred/code/hhast/src/__Private/LintRun.php(130): HH\Lib\Vec\map_async()
    #11 /Users/fred/code/hhast/src/__Private/LintRun.php(142): Facebook\HHAST\__Private\LintRun->lintDirectoryAsync()
    #12 /Users/fred/code/hhast/src/__Private/LintRun.php(47): Facebook\HHAST\__Private\LintRun->lintPathAsync()
    #13 /Users/fred/code/hhast/vendor/hhvm/hsl/src/vec/async.php(71): Closure$Facebook\HHAST\__Private\LintRun::runAsync()
    #14 /Users/fred/code/hhast/src/__Private/LintRun.php(49): HH\Lib\Vec\map_async()
    #15 /Users/fred/code/hhast/src/__Private/LinterCLI.php(159): Facebook\HHAST\__Private\LintRun->runAsync()
    #16 /Users/fred/code/hhast/src/__Private/LinterCLI.php(84): Facebook\HHAST\__Private\LinterCLI->mainImplAsync()
    #17 (): Facebook\HHAST\__Private\LinterCLI->mainAsync()
    #18 /Users/fred/code/hhast/vendor/facebook/hh-clilib/src/CLIBase.hh(168): HH\Asio\join()
    #19 /Users/fred/code/hhast/bin/hhast-lint(36): Facebook\CLILib\CLIBase::main()
    #20 {main}

```