### PR TITLE
Fix running function naming linters against PHP methods without modifiers

### DIFF
--- a/src/Linters/FunctionNamingLinter.php
+++ b/src/Linters/FunctionNamingLinter.php
@@ -112,9 +112,9 @@ abstract class FunctionNamingLinter extends BaseASTLinter<
       $new = $this->getSuggestedNameForFunction($old, $node);
     } else if ($node instanceof MethodishDeclaration) {
       if (
-        $node->getFunctionDeclHeader()->getModifiersx()->getDescendantsOfType(
+        $node->getFunctionDeclHeader()->getModifiers()?->getDescendantsOfType(
           StaticToken::class,
-        ) |> C\is_empty(vec($$))
+        ) |> ($$ ?? vec[]) |> C\is_empty(vec($$))
       ) {
         $what = 'Method';
         $new = $this->getSuggestedNameForInstanceMethod($old, $node);

--- a/tests/AsyncFunctionAndMethodLinterTest.php
+++ b/tests/AsyncFunctionAndMethodLinterTest.php
@@ -38,6 +38,7 @@ final class AsyncFunctionAndMethodLinterTest extends TestCase {
       ['<?hh function foo_bar_UNSAFE() {}'],
       ['<?hh function foo_bar_async_UNTYPED(): Awaitable<int> {}'],
       ['<?hh function foo_bar_DEPRECATED(): void {}'],
+      ['<?php class Foo { function defaultVisibilityIsPublic(): string {}' ],
       // functions that start with 'test':
       ['<?hh class Foo { public function testFoo() : Awaitable<string> {}'],
       ['<?hh function test_foo_async(): Awaitable<void> {}'],


### PR DESCRIPTION

for example, `class Foo { function bar() {} }` is valid PHP.