### PR TITLE
Assert to Expect migration

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,23 +1,23 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "b8981db4f6f199cc6229bc4daef10b13",
     "packages": [
         {
             "name": "facebook/hh-clilib",
-            "version": "v1.1.1",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hh-clilib.git",
-                "reference": "b8ac1045c4333bca3444a454d7f0297f82c2af9f"
+                "reference": "2772c82a8f5fc715d5a2fbe801563f36fdda9943"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/b8ac1045c4333bca3444a454d7f0297f82c2af9f",
-                "reference": "b8ac1045c4333bca3444a454d7f0297f82c2af9f",
+                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/2772c82a8f5fc715d5a2fbe801563f36fdda9943",
+                "reference": "2772c82a8f5fc715d5a2fbe801563f36fdda9943",
                 "shasum": ""
             },
             "require": {
@@ -35,7 +35,7 @@
             "license": [
                 "MIT"
             ],
-            "time": "2018-06-15T23:05:53+00:00"
+            "time": "2018-06-20T03:25:12+00:00"
         },
         {
             "name": "fredemmott/hack-error-suppressor",
@@ -126,25 +126,25 @@
         },
         {
             "name": "hhvm/hsl",
-            "version": "v3.26.0",
+            "version": "v3.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hsl.git",
-                "reference": "e046cdba90c8204d9b329ad25ce134e9845761eb"
+                "reference": "f43f027681402f0a6807325400a761106fa10274"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hsl/zipball/e046cdba90c8204d9b329ad25ce134e9845761eb",
-                "reference": "e046cdba90c8204d9b329ad25ce134e9845761eb",
+                "url": "https://api.github.com/repos/hhvm/hsl/zipball/f43f027681402f0a6807325400a761106fa10274",
+                "reference": "f43f027681402f0a6807325400a761106fa10274",
                 "shasum": ""
             },
             "require": {
-                "hhvm": "^3.26.0",
+                "hhvm": "^3.27.0",
                 "hhvm/hhvm-autoload": "^1.4"
             },
             "require-dev": {
                 "91carriage/phpunit-hhi": "^5.7",
-                "facebook/fbexpect": "^0.4",
+                "facebook/fbexpect": "^1.0.0",
                 "phpunit/phpunit": "^5.7"
             },
             "type": "library",
@@ -153,7 +153,7 @@
                 "MIT"
             ],
             "description": "The Hack Standard Library",
-            "time": "2018-05-08T22:54:05+00:00"
+            "time": "2018-06-07T01:25:22+00:00"
         },
         {
             "name": "hhvm/type-assert",
@@ -1615,7 +1615,7 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.1.0",
+            "version": "v4.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",

--- a/src/Migrations/AssertToExpectMigration.php
+++ b/src/Migrations/AssertToExpectMigration.php
@@ -1,0 +1,296 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\Migrations;
+
+use namespace Facebook\HHAST;
+use function Facebook\HHAST\Missing;
+use type Facebook\HHAST\{
+  BackslashToken,
+  CommaToken,
+  DelimitedComment,
+  EditableList,
+  EditableNode,
+  FunctionCallExpression,
+  FunctionToken,
+  LeftParenToken,
+  ListItem,
+  MemberSelectionExpression,
+  NamespaceBody,
+  NamespaceDeclaration,
+  NamespaceEmptyBody,
+  NamespaceUseDeclaration,
+  NameToken,
+  QualifiedName,
+  RightParenToken,
+  SemicolonToken,
+  UseToken,
+  WhiteSpace,
+};
+use namespace HH\Lib\{Str, Vec, C};
+
+final class AssertToExpectMigration extends StepBasedMigration {
+
+  private bool $expectPresent = false;
+  private static ?NamespaceUseDeclaration $expectFunction = null;
+
+  private static function getExpectFunction(): NamespaceUseDeclaration {
+    if (self::$expectFunction !== null) {
+      return self::$expectFunction;
+    }
+    $sep = new BackslashToken(Missing(), Missing());
+    self::$expectFunction = new NamespaceUseDeclaration(
+      new UseToken(Missing(), new WhiteSpace(' ')),
+      new FunctionToken(Missing(), new WhiteSpace(' ')),
+      new QualifiedName(
+        new EditableList(
+          vec[
+            new ListItem(new NameToken(Missing(), Missing(), 'Facebook'), $sep),
+            new ListItem(new NameToken(Missing(), Missing(), 'FBExpect'), $sep),
+            new ListItem(
+              new NameToken(Missing(), Missing(), 'expect'),
+              Missing(),
+            ),
+          ],
+        ),
+      ),
+      new SemicolonToken(Missing(), new WhiteSpace("\n")),
+    );
+    return self::$expectFunction;
+  }
+
+  private function checkExpectFunctionPresent(
+    NamespaceUseDeclaration $node,
+  ): NamespaceUseDeclaration {
+    if ($this->expectPresent) {
+      return $node;
+    }
+    $curr = Str\trim($node->getCode());
+    $useExpectFunctionCode = Str\trim(self::getExpectFunction()->getCode());
+    if (Str\contains($curr, $useExpectFunctionCode)) {
+      $this->expectPresent = true;
+    }
+
+    return $node;
+  }
+
+  private function addExpectAfterUseFunction(
+    NamespaceUseDeclaration $node,
+  ): NamespaceUseDeclaration {
+    if ($this->expectPresent) {
+      return $node;
+    }
+    $useKind = $node->getKind();
+    if ($useKind !== null && $useKind instanceof FunctionToken) {
+      $node =
+        $node->insertAfter($node->getLastTokenx(), self::getExpectFunction());
+      $this->expectPresent = true;
+    }
+    return $node;
+  }
+
+  private function addExpectAfterUseDecl(
+    NamespaceUseDeclaration $node,
+  ): NamespaceUseDeclaration {
+    if ($this->expectPresent) {
+      return $node;
+    }
+    $this->expectPresent = true;
+    return
+      $node->insertAfter($node->getLastTokenx(), self::getExpectFunction());
+  }
+
+  private function addExpectAfterNamespaceDecl(
+    NamespaceDeclaration $node,
+  ): NamespaceDeclaration {
+    if ($this->expectPresent) {
+      return $node;
+    }
+    $this->expectPresent = true;
+    $body = $node->getBodyx();
+    $expectFunction = self::getExpectFunction();
+    if ($body instanceof NamespaceEmptyBody) {
+      return $node->insertAfter($node->getLastTokenx(), $expectFunction);
+    }
+    return $node->insertAfter(
+      $body->getFirstTokenx(),
+      $expectFunction->insertBefore(
+        $expectFunction->getFirstTokenx(),
+        new WhiteSpace("\t"),
+      ),
+    );
+  }
+
+  private function addExpectAfterComment(DelimitedComment $node): EditableNode {
+    if ($this->expectPresent) {
+      return $node;
+    }
+    $expectFunction = self::getExpectFunction();
+    $this->expectPresent = true;
+    if (!Str\contains($node->getText(), "/**")) {
+      return EditableList::concat(
+        $node,
+        $expectFunction->insertBefore(
+          $expectFunction->getFirstTokenx(),
+          new WhiteSpace("\n\n"),
+        )
+          ->replace(
+            $expectFunction->getLastTokenx()->getTrailing(),
+            new WhiteSpace(''),
+          ),
+      );
+    }
+    return $node;
+  }
+
+  private function assertToExpect(
+    FunctionCallExpression $node,
+  ): FunctionCallExpression {
+    $rec = $node->getReceiver();
+    if (!$rec instanceof MemberSelectionExpression) {
+      return $node;
+    }
+    $method = $rec->getName()->getCode();
+    if (!Str\starts_with($method, 'assert')) {
+      return $node;
+    }
+    $names = dict[
+      'assertSame' => 'toBeSame',
+      'assertEquals' => 'toBePHPEqual',
+      'assertTrue' => 'toBeTrue',
+      'assertFalse' => 'toBeFalse',
+      'assertNull' => 'toBeNull',
+      'assertEmpty' => 'toBeEmpty',
+      'assertGreaterThan' => 'toBeGreaterThan',
+      'assertGreaterThanOrEqualTo' => 'toBeGreaterThanOrEqualTo',
+      'assertLessThan' => 'toBeLessThan',
+      'assertLessThanOrEqualTo' => 'toBeLessThanOrEqualTo',
+      'assertRegExp' => 'toMatchRegExp',
+      'assertType' => 'toBeType',
+      'assertContains' => 'toContain',
+      'assertSubset' => 'toInclude',
+      'assertInstanceOf' => 'toBeInstanceOf',
+      // 'Not' Assertions
+      'assertNotSame' => 'toNotBeSame',
+      'assertNotEquals' => 'toNotBePHPEqual',
+      'assertNotNull' => 'toNotBeNull',
+      'assertNotEmpty' => 'toNotBeEmpty',
+      'assertNotRegExp' => 'toNotMatchRegExp',
+      'assertNotType' => 'toNotBeType',
+      'assertNotContains' => 'toNotContain',
+      'assertNotInstanceOf' => 'toNotBeInstanceOf',
+    ];
+    $params = vec($node->getArgumentListx()->getChildren());
+    $actual = Missing();
+    $args = Missing();
+    $func_name = $names[$method];
+    if (C\count($params) === 1) {
+      $actual = C\onlyx($params);
+    } else {
+      $expected = $params[0];
+      $actual = $params[1];
+      $rest = Vec\drop($params, 2);
+      if (C\count($rest) === 2) {
+        $rest[0] = $rest[0]->replace($rest[0]->getLastTokenx(), Missing());
+        $rest[1] = $rest[1]->insertAfter(
+          $rest[1]->getLastTokenx(),
+          new CommaToken(Missing(), new WhiteSpace(' ')),
+        );
+        $rest = Vec\reverse($rest);
+        $func_name = 'toEqualWithDelta';
+        $actual = $actual->replace($actual->getLastTokenx(), Missing());
+      } else if (C\is_empty($rest)) {
+        $expected = $expected->replace($expected->getLastTokenx(), Missing());
+      } else {
+        $actual = $actual->replace($actual->getLastTokenx(), Missing());
+      }
+      $args = new EditableList(Vec\concat(vec[$expected], $rest));
+    }
+
+    $rec = $node->getReceiver();
+    invariant(
+      $rec instanceof MemberSelectionExpression,
+      'receiver should be a member selection expression',
+    );
+    $new_node = $node
+      ->withReceiver(
+        $rec->withObject(
+          new FunctionCallExpression(
+            new NameToken(
+              $rec->getObject()->getFirstTokenx()->getLeading(),
+              Missing(),
+              'expect',
+            ),
+            new LeftParenToken(Missing(), Missing()),
+            new EditableList(vec[$actual]),
+            new RightParenToken(Missing(), Missing()),
+          ),
+        )
+          ->withName(new NameToken(Missing(), Missing(), $func_name)),
+      )
+      ->withArgumentList($args);
+
+    return $new_node;
+  }
+
+  <<__Override>>
+  final public function getSteps(): Traversable<IMigrationStep> {
+    $make_step_add = ($name, $impl) ==> new TypedMigrationStep(
+      $name,
+      NamespaceUseDeclaration::class,
+      NamespaceUseDeclaration::class,
+      $impl,
+    );
+    $make_step_add_namespace = ($name, $impl) ==> new TypedMigrationStep(
+      $name,
+      NamespaceDeclaration::class,
+      NamespaceDeclaration::class,
+      $impl,
+    );
+    $make_step_add_comment = ($name, $impl) ==> new TypedMigrationStep(
+      $name,
+      DelimitedComment::class,
+      EditableNode::class,
+      $impl,
+    );
+    $make_step_expect = ($name, $impl) ==> new TypedMigrationStep(
+      $name,
+      FunctionCallExpression::class,
+      FunctionCallExpression::class,
+      $impl,
+    );
+    return vec[
+      $make_step_add(
+        'check if expect function is present',
+        $node ==> $this->checkExpectFunctionPresent($node),
+      ),
+      $make_step_add(
+        'add expect after use function (if present)',
+        $node ==> $this->addExpectAfterUseFunction($node),
+      ),
+      $make_step_add(
+        'add expect after use declaration (if present)',
+        $node ==> $this->addExpectAfterUseDecl($node),
+      ),
+      $make_step_add_namespace(
+        'add expect after namespace declaration (if present)',
+        $node ==> $this->addExpectAfterNamespaceDecl($node),
+      ),
+      $make_step_add_comment(
+        'add expect at top of file after first non-docblock comment',
+        $node ==> $this->addExpectAfterComment($node),
+      ),
+      $make_step_expect(
+        'change assert calls to expect',
+        $node ==> $this->assertToExpect($node),
+      ),
+    ];
+  }
+}

--- a/src/Migrations/AssertToExpectMigration.php
+++ b/src/Migrations/AssertToExpectMigration.php
@@ -169,7 +169,7 @@ final class AssertToExpectMigration extends StepBasedMigration {
     $params = vec($node->getArgumentListx()->getChildren());
     $actual = C\firstx($params);
     $msg = Missing();
-    if (C\count($params) == 2) {
+    if (C\count($params) === 2) {
       $msg = C\lastx($params);
       $actual = $actual->replace($actual->getLastTokenx(), Missing());
     }

--- a/src/Migrations/AssertToExpectMigration.php
+++ b/src/Migrations/AssertToExpectMigration.php
@@ -151,7 +151,7 @@ final class AssertToExpectMigration extends StepBasedMigration {
   }
 
   private function assertSingleArgToExpect(
-     FunctionCallExpression $node,
+    FunctionCallExpression $node,
   ): FunctionCallExpression {
     $method = self::isAssert($node);
     $single_arg_names = dict[
@@ -174,7 +174,8 @@ final class AssertToExpectMigration extends StepBasedMigration {
       $actual = $actual->replace($actual->getLastTokenx(), Missing());
     }
     $func_name = $single_arg_names[$method];
-    return self::getNewNode($node, $actual, new EditableList(vec[$msg]), $func_name);
+    return
+      self::getNewNode($node, $actual, new EditableList(vec[$msg]), $func_name);
   }
 
   private function assertMultiArgToExpect(
@@ -288,7 +289,12 @@ final class AssertToExpectMigration extends StepBasedMigration {
     ];
   }
 
-  private static function getNewNode(FunctionCallExpression $node, EditableNode $actual, EditableList $args, string $funcName): FunctionCallExpression {
+  private static function getNewNode(
+    FunctionCallExpression $node,
+    EditableNode $actual,
+    EditableList $args,
+    string $funcName,
+  ): FunctionCallExpression {
     $rec = $node->getReceiver();
     invariant(
       $rec instanceof MemberSelectionExpression,

--- a/src/Migrations/AssertToExpectMigration.php
+++ b/src/Migrations/AssertToExpectMigration.php
@@ -150,24 +150,40 @@ final class AssertToExpectMigration extends StepBasedMigration {
     return $node;
   }
 
-  private function assertToExpect(
-    FunctionCallExpression $node,
+  private function assertSingleArgToExpect(
+     FunctionCallExpression $node,
   ): FunctionCallExpression {
-    $rec = $node->getReceiver();
-    if (!$rec instanceof MemberSelectionExpression) {
-      return $node;
-    }
-    $method = $rec->getName()->getCode();
-    if (!Str\starts_with($method, 'assert')) {
-      return $node;
-    }
-    $names = dict[
-      'assertSame' => 'toBeSame',
-      'assertEquals' => 'toBePHPEqual',
+    $method = self::isAssert($node);
+    $single_arg_names = dict[
       'assertTrue' => 'toBeTrue',
       'assertFalse' => 'toBeFalse',
       'assertNull' => 'toBeNull',
       'assertEmpty' => 'toBeEmpty',
+      'assertNotNull' => 'toNotBeNull',
+      'assertNotEmpty' => 'toNotBeEmpty',
+    ];
+    if (Str\is_empty($method) || !C\contains_key($single_arg_names, $method)) {
+      return $node;
+    }
+
+    $params = vec($node->getArgumentListx()->getChildren());
+    $actual = C\firstx($params);
+    $msg = Missing();
+    if (C\count($params) == 2) {
+      $msg = C\lastx($params);
+      $actual = $actual->replace($actual->getLastTokenx(), Missing());
+    }
+    $func_name = $single_arg_names[$method];
+    return self::getNewNode($node, $actual, new EditableList(vec[$msg]), $func_name);
+  }
+
+  private function assertMultiArgToExpect(
+    FunctionCallExpression $node,
+  ): FunctionCallExpression {
+    $method = self::isAssert($node);
+    $two_arg_names = dict[
+      'assertSame' => 'toBeSame',
+      'assertEquals' => 'toBePHPEqual',
       'assertGreaterThan' => 'toBeGreaterThan',
       'assertGreaterThanOrEqualTo' => 'toBeGreaterThanOrEqualTo',
       'assertLessThan' => 'toBeLessThan',
@@ -180,68 +196,42 @@ final class AssertToExpectMigration extends StepBasedMigration {
       // 'Not' Assertions
       'assertNotSame' => 'toNotBeSame',
       'assertNotEquals' => 'toNotBePHPEqual',
-      'assertNotNull' => 'toNotBeNull',
-      'assertNotEmpty' => 'toNotBeEmpty',
       'assertNotRegExp' => 'toNotMatchRegExp',
       'assertNotType' => 'toNotBeType',
       'assertNotContains' => 'toNotContain',
       'assertNotInstanceOf' => 'toNotBeInstanceOf',
     ];
-    $params = vec($node->getArgumentListx()->getChildren());
-    $actual = Missing();
-    $args = Missing();
-    $func_name = $names[$method];
-    if (C\count($params) === 1) {
-      $actual = C\onlyx($params);
-    } else {
-      $expected = $params[0];
-      $actual = $params[1];
-      $rest = Vec\drop($params, 2);
-      if (C\count($rest) === 2) {
-        $rest[0] = $rest[0]->replace($rest[0]->getLastTokenx(), Missing());
-        $rest[1] = $rest[1]->insertAfter(
-          $rest[1]->getLastTokenx(),
-          new CommaToken(Missing(), new WhiteSpace(' ')),
-        );
-        $rest = Vec\reverse($rest);
-        $func_name = 'toEqualWithDelta';
-        $actual = $actual->replace($actual->getLastTokenx(), Missing());
-      } else if (C\is_empty($rest)) {
-        $expected = $expected->replace($expected->getLastTokenx(), Missing());
-      } else {
-        $actual = $actual->replace($actual->getLastTokenx(), Missing());
-      }
-      $args = new EditableList(Vec\concat(vec[$expected], $rest));
+    if (Str\is_empty($method) || !C\contains_key($two_arg_names, $method)) {
+      return $node;
     }
+    $params = vec($node->getArgumentListx()->getChildren());
+    $args = Missing();
+    $expected = $params[0];
+    $actual = $params[1];
+    $func_name = $two_arg_names[$method];
+    $rest = Vec\drop($params, 2);
+    if (C\count($rest) === 2) {
+      $rest[0] = $rest[0]->replace($rest[0]->getLastTokenx(), Missing());
+      $rest[1] = $rest[1]->insertAfter(
+        $rest[1]->getLastTokenx(),
+        new CommaToken(Missing(), new WhiteSpace(' ')),
+      );
+      $rest = Vec\reverse($rest);
+      $func_name = 'toEqualWithDelta';
+      $actual = $actual->replace($actual->getLastTokenx(), Missing());
+    } else if (C\is_empty($rest)) {
+      $expected = $expected->replace($expected->getLastTokenx(), Missing());
+    } else {
+      $actual = $actual->replace($actual->getLastTokenx(), Missing());
+    }
+    $args = new EditableList(Vec\concat(vec[$expected], $rest));
 
-    $rec = $node->getReceiver();
-    invariant(
-      $rec instanceof MemberSelectionExpression,
-      'receiver should be a member selection expression',
-    );
-    $new_node = $node
-      ->withReceiver(
-        $rec->withObject(
-          new FunctionCallExpression(
-            new NameToken(
-              $rec->getObject()->getFirstTokenx()->getLeading(),
-              Missing(),
-              'expect',
-            ),
-            new LeftParenToken(Missing(), Missing()),
-            new EditableList(vec[$actual]),
-            new RightParenToken(Missing(), Missing()),
-          ),
-        )
-          ->withName(new NameToken(Missing(), Missing(), $func_name)),
-      )
-      ->withArgumentList($args);
-
-    return $new_node;
+    return self::getNewNode($node, $actual, $args, $func_name);
   }
 
   <<__Override>>
   final public function getSteps(): Traversable<IMigrationStep> {
+    $this->expectPresent = false;
     $make_step_add = ($name, $impl) ==> new TypedMigrationStep(
       $name,
       NamespaceUseDeclaration::class,
@@ -288,9 +278,52 @@ final class AssertToExpectMigration extends StepBasedMigration {
         $node ==> $this->addExpectAfterComment($node),
       ),
       $make_step_expect(
-        'change assert calls to expect',
-        $node ==> $this->assertToExpect($node),
+        'change single arg assert calls to expect',
+        $node ==> $this->assertSingleArgToExpect($node),
+      ),
+      $make_step_expect(
+        'change multi arg assert calls to expect',
+        $node ==> $this->assertMultiArgToExpect($node),
       ),
     ];
+  }
+
+  private static function getNewNode(FunctionCallExpression $node, EditableNode $actual, EditableList $args, string $funcName): FunctionCallExpression {
+    $rec = $node->getReceiver();
+    invariant(
+      $rec instanceof MemberSelectionExpression,
+      'receiver should be a member selection expression',
+    );
+    $new_node = $node
+      ->withReceiver(
+        $rec->withObject(
+          new FunctionCallExpression(
+            new NameToken(
+              $rec->getObject()->getFirstTokenx()->getLeading(),
+              Missing(),
+              'expect',
+            ),
+            new LeftParenToken(Missing(), Missing()),
+            new EditableList(vec[$actual]),
+            new RightParenToken(Missing(), Missing()),
+          ),
+        )
+          ->withName(new NameToken(Missing(), Missing(), $funcName)),
+      )
+      ->withArgumentList($args);
+
+    return $new_node;
+  }
+
+  private static function isAssert(FunctionCallExpression $node): string {
+    $rec = $node->getReceiver();
+    if (!$rec instanceof MemberSelectionExpression) {
+      return '';
+    }
+    $method = $rec->getName()->getCode();
+    if (!Str\starts_with($method, 'assert')) {
+      return '';
+    }
+    return $method;
   }
 }

--- a/src/__Private/MigrationCLI.php
+++ b/src/__Private/MigrationCLI.php
@@ -14,6 +14,7 @@ use namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Str, Vec};
 use type Facebook\HHAST\Migrations\{
   AddFixMesMigration,
+  AssertToExpectMigration,
   BaseMigration,
   CallTimePassByReferenceMigration,
   IMigrationWithFileList,
@@ -46,6 +47,11 @@ class MigrationCLI extends CLIWithRequiredArguments {
   <<__Override>>
   protected function getSupportedOptions(): vec<CLIOptions\CLIOption> {
     return vec[
+      CLIOptions\flag(
+        () ==> { $this->migrations[] = AssertToExpectMigration::class; },
+        'Change assert calls to expect',
+        '--expect',
+      ),
       CLIOptions\flag(
         () ==> { $this->migrations[] = ImplicitShapeSubtypesMigration::class; },
         'Allow implicit structural subtyping of all shapes',

--- a/tests/MigrationsTest.php
+++ b/tests/MigrationsTest.php
@@ -20,22 +20,26 @@ final class MigrationsTest extends TestCase {
   public function getMigrations(
   ): array<(classname<Migrations\BaseMigration>, string)> {
     $migrations = [
+      // tuple(
+      //   Migrations\OptionalShapeFieldsMigration::class,
+      //   'migrations/optional_shape_fields.php',
+      // ),
+      // tuple(
+      //   Migrations\ImplicitShapeSubtypesMigration::class,
+      //   'migrations/implicit_shape_subtypes.php',
+      // ),
+      // tuple(
+      //   Migrations\CallTimePassByReferenceMigration::class,
+      //   'migrations/call_time_pass_by_reference.php',
+      // ),
+      // tuple(
+      //   Migrations\AddFixMesMigration::class,
+      //   'migrations/add_fixmes.php',
+      // ),
       tuple(
-        Migrations\OptionalShapeFieldsMigration::class,
-        'migrations/optional_shape_fields.php',
-      ),
-      tuple(
-        Migrations\ImplicitShapeSubtypesMigration::class,
-        'migrations/implicit_shape_subtypes.php',
-      ),
-      tuple(
-        Migrations\CallTimePassByReferenceMigration::class,
-        'migrations/call_time_pass_by_reference.php',
-      ),
-      tuple(
-        Migrations\AddFixMesMigration::class,
-        'migrations/add_fixmes.php',
-      ),
+        Migrations\AssertToExpectMigration::class,
+        'migrations/change_assert_to_expect.php',
+      )
     ];
 
     if (\version_compare(\HHVM_VERSION, '3.25.0-dev', '>=')) {

--- a/tests/MigrationsTest.php
+++ b/tests/MigrationsTest.php
@@ -20,22 +20,22 @@ final class MigrationsTest extends TestCase {
   public function getMigrations(
   ): array<(classname<Migrations\BaseMigration>, string)> {
     $migrations = [
-      // tuple(
-      //   Migrations\OptionalShapeFieldsMigration::class,
-      //   'migrations/optional_shape_fields.php',
-      // ),
-      // tuple(
-      //   Migrations\ImplicitShapeSubtypesMigration::class,
-      //   'migrations/implicit_shape_subtypes.php',
-      // ),
-      // tuple(
-      //   Migrations\CallTimePassByReferenceMigration::class,
-      //   'migrations/call_time_pass_by_reference.php',
-      // ),
-      // tuple(
-      //   Migrations\AddFixMesMigration::class,
-      //   'migrations/add_fixmes.php',
-      // ),
+      tuple(
+        Migrations\OptionalShapeFieldsMigration::class,
+        'migrations/optional_shape_fields.php',
+      ),
+      tuple(
+        Migrations\ImplicitShapeSubtypesMigration::class,
+        'migrations/implicit_shape_subtypes.php',
+      ),
+      tuple(
+        Migrations\CallTimePassByReferenceMigration::class,
+        'migrations/call_time_pass_by_reference.php',
+      ),
+      tuple(
+        Migrations\AddFixMesMigration::class,
+        'migrations/add_fixmes.php',
+      ),
       tuple(
         Migrations\AssertToExpectMigration::class,
         'migrations/change_assert_to_expect.php',

--- a/tests/fixtures/migrations/change_assert_to_expect.php.expect
+++ b/tests/fixtures/migrations/change_assert_to_expect.php.expect
@@ -9,10 +9,11 @@ public class Test {
 
   public function testMethod(): void {
     expect($a)->toBeSame($a);
-    expect('bar')->toBePHPEqual('foo');
-    expect(2)->toEqualWithDelta(1, .1, 'msg');
+    expect($b)->toBePHPEqual($a);
+    expect($b)->toBePHPEqual($a, 'msg');
+    expect($b)->toEqualWithDelta($a, $delta, 'msg');
     expect($obj)->toBeNull();
-    expect('foo')->toBeTrue();
+    expect('foo')->toBeTrue('msg');
     expect(vec[1, 2, 3])->toBeFalse();
     expect($obj)->toBeInstanceOf(HackTestCase::class, 'Not an instance of HackTestCase!');
     expect(2)->toBeGreaterThanOrEqualTo(1, '2 > 1');

--- a/tests/fixtures/migrations/change_assert_to_expect.php.expect
+++ b/tests/fixtures/migrations/change_assert_to_expect.php.expect
@@ -1,0 +1,20 @@
+<?hh //strict
+
+use namespace hi;
+use function hello;
+use function Facebook\FBExpect\expect;
+use type that;
+
+public class Test {
+
+  public function testMethod(): void {
+    expect($a)->toBeSame($a);
+    expect('bar')->toBePHPEqual('foo');
+    expect(2)->toEqualWithDelta(1, .1, 'msg');
+    expect($obj)->toBeNull();
+    expect('foo')->toBeTrue();
+    expect(vec[1, 2, 3])->toBeFalse();
+    expect($obj)->toBeInstanceOf(HackTestCase::class, 'Not an instance of HackTestCase!');
+    expect(2)->toBeGreaterThanOrEqualTo(1, '2 > 1');
+  }
+}

--- a/tests/fixtures/migrations/change_assert_to_expect.php.in
+++ b/tests/fixtures/migrations/change_assert_to_expect.php.in
@@ -1,0 +1,19 @@
+<?hh //strict
+
+use namespace hi;
+use function hello;
+use type that;
+
+public class Test {
+
+  public function testMethod(): void {
+    $this->assertSame($a, $a);
+    $this->assertEquals('foo', 'bar');
+    $this->assertEquals(1, 2, 'msg', .1);
+    $this->assertNull($obj);
+    $this->assertTrue('foo');
+    $this->assertFalse(vec[1, 2, 3]);
+    $this->assertInstanceOf(HackTestCase::class, $obj, 'Not an instance of HackTestCase!');
+    $this->assertGreaterThanOrEqualTo(1, 2, '2 > 1');
+  }
+}

--- a/tests/fixtures/migrations/change_assert_to_expect.php.in
+++ b/tests/fixtures/migrations/change_assert_to_expect.php.in
@@ -8,10 +8,11 @@ public class Test {
 
   public function testMethod(): void {
     $this->assertSame($a, $a);
-    $this->assertEquals('foo', 'bar');
-    $this->assertEquals(1, 2, 'msg', .1);
+    $this->assertEquals($a, $b);
+    $this->assertEquals($a, $b, 'msg');
+    $this->assertEquals($a, $b, 'msg', $delta);
     $this->assertNull($obj);
-    $this->assertTrue('foo');
+    $this->assertTrue('foo', 'msg');
     $this->assertFalse(vec[1, 2, 3]);
     $this->assertInstanceOf(HackTestCase::class, $obj, 'Not an instance of HackTestCase!');
     $this->assertGreaterThanOrEqualTo(1, 2, '2 > 1');


### PR DESCRIPTION
- Migrates assert calls to their respective expect function (let me know if I missed any others that directly translate)
- Adds 'use function Facebook\FBExpect\expect' according to #91 
- Doesn't handle all of the cases with comments correctly...working on it

Will add examples of each case listed in #91 , or perhaps refactor how MigrationsTest works (currently can only test one .in and .expect file)