### PR TITLE
Add auto-fixing linter for unused use statements

### DIFF
--- a/src/INamespaceUseDeclaration.php
+++ b/src/INamespaceUseDeclaration.php
@@ -27,4 +27,6 @@ interface INamespaceUseDeclaration {
   public function hasClauses(): bool;
   public function getClauses(): EditableList;
   public function getClausesx(): EditableList;
+
+  public function getSemicolon(): ?SemicolonToken;
  }

--- a/src/Linters/AsyncFunctionAndMethodLinter.php
+++ b/src/Linters/AsyncFunctionAndMethodLinter.php
@@ -11,13 +11,11 @@
 namespace Facebook\HHAST\Linters;
 
 use type Facebook\HHAST\{
-  EditableNode,
   FunctionDeclaration,
   GenericTypeSpecifier,
-  IFunctionishDeclaration,
   MethodishDeclaration,
 };
-use namespace HH\Lib\{C, Str};
+use namespace HH\Lib\Str;
 
 class AsyncFunctionAndMethodLinter extends FunctionNamingLinter {
   <<__Override>>

--- a/src/Linters/AutoFixingLineLinter.php
+++ b/src/Linters/AutoFixingLineLinter.php
@@ -10,8 +10,6 @@
 
 namespace Facebook\HHAST\Linters;
 
-use type Facebook\HHAST\EditableNode;
-use namespace Facebook\HHAST;
 use namespace HH\Lib\Str;
 
 abstract class AutoFixingLineLinter<Terr as FixableLineLintError>

--- a/src/Linters/AutoFixingLinter.php
+++ b/src/Linters/AutoFixingLinter.php
@@ -10,8 +10,6 @@
 
 namespace Facebook\HHAST\Linters;
 
-use type Facebook\HHAST\EditableNode;
-use namespace Facebook\HHAST;
 
 interface AutoFixingLinter<Terror as FixableLintError> {
   require extends BaseLinter;

--- a/src/Linters/BaseASTLinter.php
+++ b/src/Linters/BaseASTLinter.php
@@ -12,7 +12,7 @@ namespace Facebook\HHAST\Linters;
 
 use type Facebook\HHAST\EditableNode;
 use namespace Facebook\HHAST;
-use namespace Facebook\HHAST\Linters\{LinterException, SuppressASTLinter};
+use namespace Facebook\HHAST\Linters\SuppressASTLinter;
 
 abstract class BaseASTLinter<
   T as HHAST\EditableNode,

--- a/src/Linters/CamelCasedMethodsUnderscoredFunctionsLinter.php
+++ b/src/Linters/CamelCasedMethodsUnderscoredFunctionsLinter.php
@@ -11,9 +11,7 @@
 namespace Facebook\HHAST\Linters;
 
 use type Facebook\HHAST\{
-  EditableNode,
   FunctionDeclaration,
-  IFunctionishDeclaration,
   MethodishDeclaration
 };
 use namespace HH\Lib\{C, Str};

--- a/src/Linters/DontAwaitInALoopLinter.php
+++ b/src/Linters/DontAwaitInALoopLinter.php
@@ -14,22 +14,13 @@ use type Facebook\HHAST\{
   AnonymousFunction,
   AwaitableCreationExpression,
   AwaitToken,
-  CompoundStatement,
-  DotDotDotToken,
   EditableList,
   EditableNode,
-  EndOfLine,
-  IControlFlowStatement,
   ILoopStatement,
   LambdaExpression,
-  LeftBraceToken,
-  SingleLineComment,
   PrefixUnaryExpression,
-  RightBraceToken,
-  WhiteSpace,
-  __Private\PerfCounter
 };
-use function Facebook\HHAST\{Missing, find_position, find_offset};
+use function Facebook\HHAST\find_position;
 use namespace Facebook\TypeAssert;
 use namespace HH\Lib\{C, Vec};
 

--- a/src/Linters/FixableASTLintError.php
+++ b/src/Linters/FixableASTLintError.php
@@ -11,7 +11,6 @@
 namespace Facebook\HHAST\Linters;
 
 use type Facebook\HHAST\EditableNode;
-use function Facebook\HHAST\find_position;
 
 class FixableASTLintError<
   Tnode as EditableNode,

--- a/src/Linters/FunctionNamingLintError.php
+++ b/src/Linters/FunctionNamingLintError.php
@@ -15,7 +15,6 @@ use type Facebook\HHAST\{
   IFunctionishDeclaration,
   MethodishDeclaration
 };
-use function Facebook\HHAST\find_position;
 use function Facebook\HHAST\__Private\execute;
 use namespace HH\Lib\Str;
 

--- a/src/Linters/FunctionNamingLinter.php
+++ b/src/Linters/FunctionNamingLinter.php
@@ -21,7 +21,6 @@ use type Facebook\HHAST\{
   FunctionDeclaration,
   IFunctionishDeclaration,
   MethodishDeclaration,
-  NameToken,
   StaticToken,
 };
 use namespace Facebook\HHAST;

--- a/src/Linters/LSPAutoFixingLinter.php
+++ b/src/Linters/LSPAutoFixingLinter.php
@@ -10,8 +10,6 @@
 
 namespace Facebook\HHAST\Linters;
 
-use type Facebook\HHAST\EditableNode;
-use namespace Facebook\HHAST;
 
 interface LSPAutoFixingLinter<Terror as FixableLintError> extends AutoFixingLinter<Terror> {
   public function getCodeActionForError(

--- a/src/Linters/LicenseHeaderLinter.php
+++ b/src/Linters/LicenseHeaderLinter.php
@@ -18,7 +18,6 @@ use type Facebook\HHAST\{
   EndOfLine,
   Script,
 };
-use function Facebook\HHAST\Missing;
 use namespace Facebook\TypeAssert;
 use namespace HH\Lib\{C, Str, Vec};
 

--- a/src/Linters/LinterException.php
+++ b/src/Linters/LinterException.php
@@ -10,7 +10,7 @@
 
 namespace Facebook\HHAST\Linters;
 
-use namespace HH\Lib\{C, Str, Vec};
+use namespace HH\Lib\Str;
 
 final class LinterException extends \Exception {
   public function __construct(

--- a/src/Linters/MethodCallOnConstructorLinter.php
+++ b/src/Linters/MethodCallOnConstructorLinter.php
@@ -19,7 +19,6 @@ use type Facebook\HHAST\{
   ParenthesizedExpression,
 };
 use function Facebook\HHAST\Missing;
-use namespace HH\Lib\Str;
 
 final class MethodCallOnConstructorLinter
   extends AutoFixingASTLinter<MemberSelectionExpression> {

--- a/src/Linters/MustUseBracesForControlFlowLinter.php
+++ b/src/Linters/MustUseBracesForControlFlowLinter.php
@@ -26,8 +26,6 @@ use type Facebook\HHAST\{
   WhileStatement,
   WhiteSpace
 };
-use function Facebook\HHAST\resolve_type;
-use namespace Facebook\TypeAssert;
 use namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Str, Vec};
 

--- a/src/Linters/MustUseOverrideAttributeLinter.php
+++ b/src/Linters/MustUseOverrideAttributeLinter.php
@@ -20,7 +20,6 @@ use type Facebook\HHAST\{
   ListItem,
   MethodishDeclaration,
   PrivateToken,
-  SimpleTypeSpecifier,
 };
 use namespace Facebook\TypeAssert;
 use function Facebook\HHAST\resolve_type;

--- a/src/Linters/NoBasicAssignmentFunctionParameterLinter.php
+++ b/src/Linters/NoBasicAssignmentFunctionParameterLinter.php
@@ -23,7 +23,7 @@ use type Facebook\HHAST\{
 };
 
 use namespace Facebook\TypeAssert;
-use namespace HH\Lib\{C, Str, Vec};
+use namespace HH\Lib\{C, Vec};
 
 class NoBasicAssignmentFunctionParameterLinter
   extends AutoFixingASTLinter<FunctionCallExpression> {

--- a/src/Linters/NoPHPEqualityLinter.php
+++ b/src/Linters/NoPHPEqualityLinter.php
@@ -19,9 +19,7 @@ use type Facebook\HHAST\{
   ExclamationEqualEqualToken,
   LessThanGreaterThanToken,
 };
-use function Facebook\HHAST\Missing;
-use namespace Facebook\TypeAssert;
-use namespace HH\Lib\{C, Str, Vec};
+use namespace HH\Lib\Str;
 
 final class NoPHPEqualityLinter
   extends AutoFixingASTLinter<BinaryExpression> {

--- a/src/Linters/NoStringInterpolationLinter.php
+++ b/src/Linters/NoStringInterpolationLinter.php
@@ -18,19 +18,14 @@ use type Facebook\HHAST\{
   DoubleQuotedStringLiteralTailToken,
   EditableList,
   EditableNode,
-  EditableSyntax,
   EmbeddedBracedExpression,
   HeredocStringLiteralHeadToken,
   LiteralExpression,
   NameToken,
-  QualifiedNameExpression,
-  QualifiedNameToken,
   StringLiteralBodyToken,
   VariableToken,
-  __Private\PerfCounter,
 };
 use function Facebook\HHAST\Missing;
-use namespace Facebook\TypeAssert;
 use namespace HH\Lib\{C, Vec};
 
 final class NoStringInterpolationLinter

--- a/src/Linters/StrictModeOnlyLinter.php
+++ b/src/Linters/StrictModeOnlyLinter.php
@@ -18,7 +18,6 @@ use type Facebook\HHAST\{
   SingleLineComment,
   WhiteSpace,
 };
-use namespace HH\Lib\C;
 
 class StrictModeOnlyLinter extends AutoFixingASTLinter<MarkupSuffix> {
   <<__Override>>

--- a/src/Linters/UnusedParameterLinter.php
+++ b/src/Linters/UnusedParameterLinter.php
@@ -13,13 +13,11 @@ namespace Facebook\HHAST\Linters;
 use type Facebook\HHAST\{
   EditableNode,
   FunctionDeclaration,
-  FunctionDeclarationHeader,
   IFunctionishDeclaration,
   MethodishDeclaration,
   ParameterDeclaration,
   VariableToken,
 };
-use function Facebook\HHAST\Missing;
 use namespace HH\Lib\{C, Str};
 
 final class UnusedParameterLinter

--- a/src/Linters/UnusedUseClauseLinter.php
+++ b/src/Linters/UnusedUseClauseLinter.php
@@ -106,9 +106,8 @@ final class UnusedUseClauseLinter
       }
 
       if ($kind instanceof ConstToken) {
-        if (!C\contains($used['constants'], $as)) {
-          $unused[] = tuple($as, $clause);
-        }
+        // unsupported
+        continue;
         continue;
       }
 
@@ -183,7 +182,9 @@ final class UnusedUseClauseLinter
           ),
         );
       }
-      $clause = $clause->withName($name);
+      $clause = $clause
+        ->withName($name)
+        ->without($clause->getFirstTokenx()->getLeading());
 
       $fixed = new NamespaceUseDeclaration(
         $node->getKeyword(),
@@ -221,7 +222,6 @@ final class UnusedUseClauseLinter
     'namespaces' => keyset<string>,
     'types' => keyset<string>,
     'functions' => keyset<string>,
-    'constants' => keyset<string>,
   ) {
     return HHAST\get_unresolved_referenced_names($this->getAST());
   }

--- a/src/Linters/UnusedUseClauseLinter.php
+++ b/src/Linters/UnusedUseClauseLinter.php
@@ -164,11 +164,8 @@ final class UnusedUseClauseLinter
         $name = new QualifiedName(
           EditableList::fromItems(
             Vec\concat(
-              $node->getPrefix()->getParts()->getItems(),
-              vec[
-                (new BackslashToken(HHAST\Missing(), HHAST\Missing())),
-                $name,
-              ],
+              $node->getPrefix()->getParts()->getChildren(),
+              vec[$name],
             ),
           ),
         );
@@ -180,20 +177,20 @@ final class UnusedUseClauseLinter
         $name = new QualifiedName(
           EditableList::fromItems(
             Vec\concat(
-              $node->getPrefix()->getParts()->getItems(),
-              vec[
-                (new BackslashToken(HHAST\Missing(), HHAST\Missing())),
-              ],
-              $name->getParts()->getItems(),
+              $node->getPrefix()->getParts()->getChildren(),
+              $name->getParts()->getChildren(),
             ),
           ),
         );
       }
+      $clause = $clause->withName($name);
 
       $fixed = new NamespaceUseDeclaration(
         $node->getKeyword(),
         $node->getKind() ?? HHAST\Missing(),
-        $clause,
+        EditableList::fromItems(
+          vec[new HHAST\ListItem($clause, HHAST\Missing())],
+        ),
         $node->getSemicolon() ?? HHAST\Missing(),
       );
     } else {
@@ -208,7 +205,8 @@ final class UnusedUseClauseLinter
         },
       );
     }
-    $last = C\lastx($fixed->getClauses()->getChildrenOfType(HHAST\ListItem::class));
+    $last =
+      C\lastx($fixed->getClauses()->getChildrenOfType(HHAST\ListItem::class));
     $sep = $last->getSeparator();
 
     if ($sep && !Str\contains($sep->getTrailing()->getCode(), "\n")) {

--- a/src/Linters/UnusedUseClauseLinter.php
+++ b/src/Linters/UnusedUseClauseLinter.php
@@ -50,14 +50,10 @@ final class UnusedUseClauseLinter
 
     return new FixableASTLintError(
       $this,
-      C\count($unused) === 1
-        ? ('`'.C\firstx($unused)[0].'` is not used')
-        : (
-            $unused
-            |> Vec\map($$, $p ==> '`'.$p[0].'`')
-            |> Str\join($$, ', ')
-            |> $$.' are not used'
-          ),
+      $unused
+        |> Vec\map($$, $p ==> '`'.$p[0].'`')
+        |> Str\join($$, ', ')
+        |> $$.((C\count($unused) === 1) ? ' is' : ' are').' not used',
       $node,
     );
   }
@@ -104,7 +100,6 @@ final class UnusedUseClauseLinter
 
       if ($kind instanceof ConstToken) {
         // unsupported
-        continue;
         continue;
       }
 

--- a/src/Linters/UnusedUseClauseLinter.php
+++ b/src/Linters/UnusedUseClauseLinter.php
@@ -1,0 +1,128 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\Linters;
+
+use type Facebook\HHAST\{
+  ConstToken,
+  EditableNode,
+  FunctionToken,
+  INamespaceUseDeclaration,
+  NamespaceGroupUseDeclaration,
+  NamespaceUseDeclaration,
+  NamespaceUseClause,
+  NamespaceToken,
+  NameToken,
+  ScopeResolutionExpression,
+  SimpleTypeSpecifier,
+  TypeToken,
+  QualifiedName,
+};
+use namespace Facebook\HHAST;
+use namespace Facebook\TypeAssert;
+use namespace HH\Lib\{C, Str};
+
+final class UnusedUseClauseLinter
+  extends ASTLinter<INamespaceUseDeclaration> {
+  <<__Override>>
+  protected static function getTargetType(
+  ): classname<INamespaceUseDeclaration> {
+    return INamespaceUseDeclaration::class;
+  }
+
+  <<__Override>>
+  public function getLintErrorForNode(
+    INamespaceUseDeclaration $node,
+    vec<EditableNode> $_context,
+  ): ?ASTLintError<INamespaceUseDeclaration> {
+    if (!$node instanceof NamespaceUseDeclaration) {
+      // TODO: group use
+      return null;
+    }
+    $clauses = $node->getClauses()->getItemsOfType(NamespaceUseClause::class);
+    $prefix = '';
+
+    $used = $this->getUnresolvedReferencedNames();
+    $unused = keyset[];
+    foreach ($clauses as $clause) {
+      $as = $clause->getAlias();
+      if ($as !== null) {
+        $as = $as->getText();
+      } else {
+        $name = $clause->getName();
+        if ($name instanceof NameToken) {
+          $as = $name->getText();
+        } else {
+          invariant($name instanceof QualifiedName, "Unhandled name type");
+          $as = $name->getParts()->getItemsOfType(NameToken::class)
+            |> C\lastx($$)->getText();
+        }
+      }
+      $kind = $node->getKind();
+      if ($kind instanceof NamespaceToken) {
+        if (!C\contains($used['namespaces'], $as)) {
+          $unused[] = $as;
+        }
+        continue;
+      }
+      if ($kind instanceof TypeToken) {
+        if (!C\contains($used['types'], $as)) {
+          $unused[] = $as;
+        }
+        continue;
+      }
+
+      if ($kind instanceof FunctionToken) {
+        if (!C\contains($used['functions'], $as)) {
+          $unused[] = $as;
+        }
+        continue;
+      }
+
+      if ($kind instanceof ConstToken) {
+        if (!C\contains($used['constants'], $as)) {
+          $unused[] = $as;
+        }
+        continue;
+      }
+
+      invariant($kind === null, 'Unhandled kind: %s', \get_class($kind));
+      if (C\contains($used['namespaces'], $as)) {
+        continue;
+      }
+      if (C\contains($used['types'], $as)) {
+        continue;
+      }
+      $unused[] = $as;
+    }
+
+    if (C\is_empty($unused)) {
+      return null;
+    }
+
+    return new ASTLintError(
+      $this,
+      C\count($unused) === 1
+        ? (C\first($unused).' is not used')
+        : (Str\join($unused, ', ').'are not used'),
+      $node,
+    );
+  }
+
+  <<__Memoize>>
+  private function getUnresolvedReferencedNames(): shape(
+    'namespaces' => keyset<string>,
+    'types' => keyset<string>,
+    'functions' => keyset<string>,
+    'constants' => keyset<string>,
+  ) {
+    return HHAST\get_unresolved_referenced_names($this->getAST());
+  }
+}

--- a/src/Linters/UnusedUseClauseLinter.php
+++ b/src/Linters/UnusedUseClauseLinter.php
@@ -11,7 +11,6 @@
 namespace Facebook\HHAST\Linters;
 
 use type Facebook\HHAST\{
-  BackslashToken,
   ConstToken,
   EditableList,
   EditableNode,
@@ -23,8 +22,6 @@ use type Facebook\HHAST\{
   NamespaceUseClause,
   NamespaceToken,
   NameToken,
-  ScopeResolutionExpression,
-  SimpleTypeSpecifier,
   TypeToken,
   QualifiedName,
 };

--- a/src/Linters/UseStatementWIthoutKindLinter.php
+++ b/src/Linters/UseStatementWIthoutKindLinter.php
@@ -16,14 +16,11 @@ use type Facebook\HHAST\{
   NamespaceUseClause,
   NamespaceToken,
   NameToken,
-  ScopeResolutionExpression,
-  SimpleTypeSpecifier,
   TypeToken,
   QualifiedName,
 };
 use namespace Facebook\HHAST;
-use namespace Facebook\TypeAssert;
-use namespace HH\Lib\{C, Keyset, Str};
+use namespace HH\Lib\{C, Keyset};
 
 final class UseStatementWithoutKindLinter
   extends AutoFixingASTLinter<INamespaceUseDeclaration> {

--- a/src/Linters/UseStatementWIthoutKindLinter.php
+++ b/src/Linters/UseStatementWIthoutKindLinter.php
@@ -111,7 +111,6 @@ final class UseStatementWithoutKindLinter
     'namespaces' => keyset<string>,
     'types' => keyset<string>,
     'functions' => keyset<string>,
-    'constants' => keyset<string>,
   ) {
     return HHAST\get_unresolved_referenced_names($this->getAST());
   }

--- a/src/Linters/UseStatementWithAsLinter.php
+++ b/src/Linters/UseStatementWithAsLinter.php
@@ -10,11 +10,7 @@
 
 namespace Facebook\HHAST\Linters;
 
-use type Facebook\HHAST\{AsToken, EditableNode, NamespaceUseClause};
-use namespace Facebook\HHAST;
-use namespace Facebook\TypeAssert;
-use function Facebook\HHAST\resolve_type;
-use namespace HH\Lib\{C, Str, Vec};
+use type Facebook\HHAST\{EditableNode, NamespaceUseClause};
 
 class UseStatementWithAsLinter extends ASTLinter<NamespaceUseClause> {
   <<__Override>>

--- a/src/Linters/UseStatementWithLeadingBackslashLinter.php
+++ b/src/Linters/UseStatementWithLeadingBackslashLinter.php
@@ -17,12 +17,7 @@ use type Facebook\HHAST\{
   NamespaceGroupUseDeclaration,
   NamespaceUseDeclaration,
   NamespaceUseClause,
-  NamespaceToken,
-  NameToken,
 };
-use namespace Facebook\HHAST;
-use namespace Facebook\TypeAssert;
-use namespace HH\Lib\{C, Keyset, Str};
 
 final class UseStatementWithLeadingBackslashLinter
   extends AutoFixingASTLinter<INamespaceUseDeclaration> {

--- a/src/Linters/suppress_ast_linter_error.php
+++ b/src/Linters/suppress_ast_linter_error.php
@@ -28,7 +28,6 @@ use type Facebook\HHAST\Linters\{
   LintError,
 };
 
-use namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Str, Vec};
 
 /**

--- a/src/Migrations/AddFixMesMigration.php
+++ b/src/Migrations/AddFixMesMigration.php
@@ -10,10 +10,7 @@
 
 namespace Facebook\HHAST\Migrations;
 
-use function Facebook\HHAST\{
-  find_node_at_position,
-  Missing,
-};
+use function Facebook\HHAST\find_node_at_position;
 use type Facebook\HHAST\__Private\TTypecheckerError;
 use type Facebook\HHAST\{
   EditableList,

--- a/src/Migrations/AssertToExpectMigration.php
+++ b/src/Migrations/AssertToExpectMigration.php
@@ -10,7 +10,6 @@
 
 namespace Facebook\HHAST\Migrations;
 
-use namespace Facebook\HHAST;
 use function Facebook\HHAST\Missing;
 use type Facebook\HHAST\{
   BackslashToken,
@@ -24,7 +23,6 @@ use type Facebook\HHAST\{
   ListItem,
   MemberSelectionExpression,
   MinusGreaterThanToken,
-  NamespaceBody,
   NamespaceDeclaration,
   NamespaceEmptyBody,
   NamespaceUseDeclaration,

--- a/src/Migrations/IMigrationWithFileList.php
+++ b/src/Migrations/IMigrationWithFileList.php
@@ -10,7 +10,6 @@
 
 namespace Facebook\HHAST\Migrations;
 
-use type Facebook\HHAST\EditableNode;
 
 interface IMigrationWithFileList {
   require extends BaseMigration;

--- a/src/Migrations/ImplicitShapeSubtypesMigration.php
+++ b/src/Migrations/ImplicitShapeSubtypesMigration.php
@@ -11,7 +11,7 @@
 namespace Facebook\HHAST\Migrations;
 
 use namespace Facebook\HHAST;
-use namespace HH\Lib\{C, Str, Vec};
+use namespace HH\Lib\{C, Str};
 use namespace Facebook\TypeAssert;
 
 final class ImplicitShapeSubtypesMigration extends StepBasedMigration {

--- a/src/Migrations/OptionalShapeFieldsMigration.php
+++ b/src/Migrations/OptionalShapeFieldsMigration.php
@@ -11,8 +11,6 @@
 namespace Facebook\HHAST\Migrations;
 
 use namespace Facebook\HHAST;
-use namespace HH\Lib\{C, Str, Vec};
-use namespace Facebook\TypeAssert;
 
 final class OptionalShapeFieldsMigration extends StepBasedMigration {
   private static function makeNullableFieldsOptional(

--- a/src/__Private/CodegenCLI.php
+++ b/src/__Private/CodegenCLI.php
@@ -11,7 +11,6 @@
 namespace Facebook\HHAST\__Private;
 
 use namespace Facebook\TypeAssert;
-use namespace HH\Lib\{C, Dict, Str, Vec};
 use type Facebook\CLILib\CLIBase;
 use namespace Facebook\CLILib\CLIOptions;
 

--- a/src/__Private/LSPImpl/CodeActionCommand.php
+++ b/src/__Private/LSPImpl/CodeActionCommand.php
@@ -10,10 +10,7 @@
 
 namespace Facebook\HHAST\__Private\LSPImpl;
 
-use type Facebook\HHAST\__Private\{
-  LintRunConfig,
-  LintRunLSPCodeActionEventHandler,
-};
+use type Facebook\HHAST\__Private\LintRunConfig;
 use namespace Facebook\HHAST\__Private\{LSP, LSPLib};
 use namespace Facebook\HHAST\Linters;
 use namespace HH\Lib\{C, Str, Vec};

--- a/src/__Private/LSPImpl/DidChangeWatchedFilesNotification.php
+++ b/src/__Private/LSPImpl/DidChangeWatchedFilesNotification.php
@@ -11,11 +11,9 @@
 namespace Facebook\HHAST\__Private\LSPImpl;
 
 use type Facebook\HHAST\__Private\{
-  LintRun,
   LintRunConfig,
   LintRunLSPPublishDiagnosticsEventHandler,
 };
-use type Facebook\CLILib\ITerminal;
 use namespace Facebook\HHAST\__Private\{LSP, LSPLib};
 use namespace HH\Lib\{C, Str, Vec};
 

--- a/src/__Private/LSPImpl/DidCloseTextDocumentNotification.php
+++ b/src/__Private/LSPImpl/DidCloseTextDocumentNotification.php
@@ -10,8 +10,7 @@
 
 namespace Facebook\HHAST\__Private\LSPImpl;
 
-use type Facebook\HHAST\__Private\LintRun;
-use namespace Facebook\HHAST\__Private\{LSP, LSPLib};
+use namespace Facebook\HHAST\__Private\LSPLib;
 use namespace HH\Lib\Str;
 
 final class DidCloseTextDocumentNotification

--- a/src/__Private/LSPImpl/DidOpenTextDocumentNotification.php
+++ b/src/__Private/LSPImpl/DidOpenTextDocumentNotification.php
@@ -11,12 +11,10 @@
 namespace Facebook\HHAST\__Private\LSPImpl;
 
 use type Facebook\HHAST\__Private\{
-  LintRun,
   LintRunConfig,
   LintRunLSPPublishDiagnosticsEventHandler,
 };
-use type Facebook\CLILib\ITerminal;
-use namespace Facebook\HHAST\__Private\{LSP, LSPLib};
+use namespace Facebook\HHAST\__Private\LSPLib;
 use namespace HH\Lib\Str;
 
 final class DidOpenTextDocumentNotification

--- a/src/__Private/LSPImpl/DidSaveTextDocumentNotification.php
+++ b/src/__Private/LSPImpl/DidSaveTextDocumentNotification.php
@@ -11,12 +11,10 @@
 namespace Facebook\HHAST\__Private\LSPImpl;
 
 use type Facebook\HHAST\__Private\{
-  LintRun,
   LintRunConfig,
   LintRunLSPPublishDiagnosticsEventHandler,
 };
-use type Facebook\CLILib\ITerminal;
-use namespace Facebook\HHAST\__Private\{LSP, LSPLib};
+use namespace Facebook\HHAST\__Private\LSPLib;
 use namespace HH\Lib\Str;
 
 final class DidSaveTextDocumentNotification

--- a/src/__Private/LSPImpl/InitializedNotification.php
+++ b/src/__Private/LSPImpl/InitializedNotification.php
@@ -10,7 +10,7 @@
 
 namespace Facebook\HHAST\__Private\LSPImpl;
 
-use namespace Facebook\HHAST\__Private\{LSP, LSPLib};
+use namespace Facebook\HHAST\__Private\LSPLib;
 
 final class InitializedNotification
   extends LSPLib\InitializedNotification<LSPLib\ServerState> {

--- a/src/__Private/LSPImpl/Server.php
+++ b/src/__Private/LSPImpl/Server.php
@@ -16,9 +16,9 @@ use type Facebook\HHAST\__Private\{
   LintRunLSPPublishDiagnosticsEventHandler,
   LintRun,
 };
-use namespace Facebook\HHAST\__Private\{LSP, LSPImpl, LSPLib};
-use type Facebook\CLILib\{ExitException, ITerminal, Terminal};
-use namespace HH\Lib\{Str, Tuple, Vec};
+use namespace Facebook\HHAST\__Private\{LSPImpl, LSPLib};
+use type Facebook\CLILib\{ExitException, ITerminal};
+use namespace HH\Lib\Str;
 
 final class Server extends LSPLib\Server<ServerState> {
   public function __construct(

--- a/src/__Private/LSPImpl/relint_uri_async.php
+++ b/src/__Private/LSPImpl/relint_uri_async.php
@@ -14,7 +14,6 @@ use type Facebook\HHAST\__Private\{
   LintRun,
   LintRunConfig,
   LintRunEventHandler,
-  LintRunLSPEventHandler,
 };
 use namespace HH\Lib\Str;
 

--- a/src/__Private/LSPImpl/relint_uris_async.php
+++ b/src/__Private/LSPImpl/relint_uris_async.php
@@ -11,9 +11,8 @@
 namespace Facebook\HHAST\__Private\LSPImpl;
 
 use type Facebook\HHAST\__Private\{
-  LintRun,
   LintRunConfig, LintRunEventHandler};
-use namespace HH\Lib\{Str, Vec};
+use namespace HH\Lib\Vec;
 
 async function relint_uris_async(
   LintRunEventHandler $handler,

--- a/src/__Private/LSPLib/Client.php
+++ b/src/__Private/LSPLib/Client.php
@@ -12,7 +12,6 @@ namespace Facebook\HHAST\__Private\LSPLib;
 
 use namespace Facebook\HHAST\__Private\LSP;
 
-use namespace HH\Lib\C;
 
 abstract class Client {
 

--- a/src/__Private/LintRunConfig.php
+++ b/src/__Private/LintRunConfig.php
@@ -72,6 +72,7 @@ final class LintRunConfig {
       Linters\MustUseOverrideAttributeLinter::class,
       Linters\NoPHPEqualityLinter::class,
       Linters\UnusedParameterLinter::class,
+      Linters\UnusedUseClauseLinter::class,
       Linters\UseStatementWithLeadingBackslashLinter::class,
       Linters\UseStatementWithoutKindLinter::class,
       Linters\NoWhitespaceAtEndOfLineLinter::class,

--- a/src/__Private/LintRunEventHandler.php
+++ b/src/__Private/LintRunEventHandler.php
@@ -10,7 +10,6 @@
 
 namespace Facebook\HHAST\__Private;
 
-use type Facebook\CLILib\OutputInterface;
 use namespace Facebook\HHAST\Linters;
 
 /**

--- a/src/__Private/LintRunJSONEventHandler.php
+++ b/src/__Private/LintRunJSONEventHandler.php
@@ -12,7 +12,7 @@ namespace Facebook\HHAST\__Private;
 
 use type Facebook\CLILib\ITerminal;
 use namespace Facebook\HHAST\Linters;
-use namespace HH\Lib\{C, Vec};
+use namespace HH\Lib\Vec;
 
 final class LintRunJSONEventHandler implements LintRunEventHandler {
   const type TOutput = shape(

--- a/src/__Private/LintRunLSPPublishDiagnosticsEventHandler.php
+++ b/src/__Private/LintRunLSPPublishDiagnosticsEventHandler.php
@@ -11,7 +11,7 @@
 namespace Facebook\HHAST\__Private;
 
 use namespace Facebook\HHAST\Linters;
-use namespace HH\Lib\{C, Dict, Str, Vec};
+use namespace HH\Lib\{C, Str, Vec};
 
 final class LintRunLSPPublishDiagnosticsEventHandler
   implements LintRunEventHandler {

--- a/src/__Private/LinterCLI.php
+++ b/src/__Private/LinterCLI.php
@@ -10,9 +10,8 @@
 
 namespace Facebook\HHAST\__Private;
 
-use type Facebook\TypeAssert\TypeAssert;
 use namespace Facebook\HHAST\Linters;
-use namespace HH\Lib\{C, Dict, Math, Str, Vec};
+use namespace HH\Lib\{C, Math, Str, Vec};
 
 use type Facebook\CLILib\{CLIWithArguments, ExitException, Terminal};
 use namespace Facebook\CLILib\CLIOptions;

--- a/src/__Private/LoggingInputTap.php
+++ b/src/__Private/LoggingInputTap.php
@@ -11,7 +11,6 @@
 namespace Facebook\HHAST\__Private;
 
 use type Facebook\CLILib\InputInterface;
-use namespace HH\Lib\Str;
 
 final class LoggingInputTap implements InputInterface {
   public function __construct(

--- a/src/__Private/LoggingOutputTap.php
+++ b/src/__Private/LoggingOutputTap.php
@@ -11,7 +11,6 @@
 namespace Facebook\HHAST\__Private;
 
 use type Facebook\CLILib\OutputInterface;
-use namespace HH\Lib\Str;
 
 final class LoggingOutputTap implements OutputInterface {
   public function __construct(

--- a/src/__Private/ParserConcurrencyLease.php
+++ b/src/__Private/ParserConcurrencyLease.php
@@ -10,8 +10,6 @@
 
 namespace Facebook\HHAST\__Private;
 
-use type Facebook\CLILib\ExitException;
-use namespace HH\Lib\{Str, Vec};
 
 final class ParserConcurrencyLease implements \IDisposable {
   const int LIMIT = 8; // Random number

--- a/src/__Private/Resolution/get_current_namespace.php
+++ b/src/__Private/Resolution/get_current_namespace.php
@@ -12,7 +12,6 @@ namespace Facebook\HHAST\__Private\Resolution;
 
 use type Facebook\HHAST\{
   EditableNode,
-  NamespaceBody,
   NamespaceDeclaration,
   NamespaceEmptyBody,
   Script,

--- a/src/__Private/Resolution/get_current_uses.php
+++ b/src/__Private/Resolution/get_current_uses.php
@@ -13,9 +13,6 @@ namespace Facebook\HHAST\__Private\Resolution;
 use type Facebook\HHAST\{
   EditableNode,
   NamespaceBody,
-  NamespaceDeclaration,
-  NamespaceEmptyBody,
-  NamespaceUseDeclaration,
   Script,
 };
 use namespace Facebook\TypeAssert;

--- a/src/__Private/Resolution/get_uses_directly_in_scope.php
+++ b/src/__Private/Resolution/get_uses_directly_in_scope.php
@@ -12,16 +12,13 @@ namespace Facebook\HHAST\__Private\Resolution;
 
 use type Facebook\HHAST\{
   EditableNode,
-  NamespaceBody,
-  NamespaceDeclaration,
-  NamespaceEmptyBody,
   NamespaceGroupUseDeclaration,
   NamespaceToken,
   NamespaceUseClause,
   NamespaceUseDeclaration,
   TypeToken
 };
-use namespace HH\Lib\{C, Str, Vec};
+use namespace HH\Lib\{C, Str};
 
 function get_uses_directly_in_scope(
   EditableNode $scope,

--- a/src/__Private/codegen/CodegenBase.php
+++ b/src/__Private/codegen/CodegenBase.php
@@ -16,7 +16,7 @@ use type Facebook\HackCodegen\{
   HackfmtFormatter,
 };
 
-use namespace HH\Lib\{C, Dict, Str, Vec};
+use namespace HH\Lib\{C, Dict, Vec};
 
 abstract class CodegenBase {
   private Schema\TSchema $schema;

--- a/src/__Private/codegen/CodegenSyntax.php
+++ b/src/__Private/codegen/CodegenSyntax.php
@@ -18,7 +18,6 @@ use type Facebook\HackCodegen\{
   HackBuilderValues
 };
 
-use namespace Facebook\TypeAssert;
 use namespace HH\Lib\{C, Dict, Keyset, Str, Vec};
 
 final class CodegenSyntax extends CodegenBase {

--- a/src/__Private/execute.php
+++ b/src/__Private/execute.php
@@ -10,7 +10,6 @@
 
 namespace Facebook\HHAST\__Private;
 
-use namespace HH\Lib\Vec;
 
 // A wrapper around the built-in exec with a nicer signature.
 // * returns a result rather than filling an out-parameter

--- a/src/__Private/get_typechecker_errors.php
+++ b/src/__Private/get_typechecker_errors.php
@@ -10,9 +10,8 @@
 
 namespace Facebook\HHAST\__Private;;
 
-use type Facebook\HHAST\EditableNode;
 
-use namespace HH\Lib\{C, Str, Vec};
+use namespace HH\Lib\Str;
 use namespace Facebook\TypeAssert;
 
 type TTypecheckerError = shape(

--- a/src/entrypoints.php
+++ b/src/entrypoints.php
@@ -10,7 +10,7 @@
 
 namespace Facebook\HHAST;
 
-use namespace HH\Lib\{Keyset, Str};
+use namespace HH\Lib\Str;
 
 function from_json(
   dict<string, mixed> $json,

--- a/src/find_node_at_offset.php
+++ b/src/find_node_at_offset.php
@@ -10,7 +10,6 @@
 
 namespace Facebook\HHAST;
 
-use namespace HH\Lib\{C, Str, Vec};
 
 function find_node_at_offset(
   EditableNode $root,

--- a/src/find_node_at_position.php
+++ b/src/find_node_at_position.php
@@ -10,7 +10,6 @@
 
 namespace Facebook\HHAST;
 
-use namespace HH\Lib\{C, Str, Vec};
 
 function find_node_at_position(
   EditableNode $root,

--- a/src/find_offset.php
+++ b/src/find_offset.php
@@ -10,7 +10,6 @@
 
 namespace Facebook\HHAST;
 
-use namespace HH\Lib\{C, Vec};
 
 function find_offset_after_leading(
   EditableNode $root,

--- a/src/get_unresolved_referenced_names.php
+++ b/src/get_unresolved_referenced_names.php
@@ -23,13 +23,11 @@ function get_unresolved_referenced_names(
   'namespaces' => keyset<string>,
   'types' => keyset<string>,
   'functions' => keyset<string>,
-  'constants' => keyset<string>,
 ) {
   $ret = shape(
     'namespaces' => keyset[],
     'types' => keyset[],
     'functions' => keyset[],
-    'constants' => keyset[],
   );
 
   foreach ($root->traverse() as $node) {

--- a/src/get_unresolved_referenced_names.php
+++ b/src/get_unresolved_referenced_names.php
@@ -57,6 +57,14 @@ function get_unresolved_referenced_names(
       continue;
     }
 
+    if ($node instanceof InstanceofExpression) {
+      $name = $node->getRightOperand();
+      if ($name instanceof NameToken) {
+        $ret['types'][] = $name->getText();
+      }
+      continue;
+    }
+
     if ($node instanceof FunctionCallExpression) {
       $name = $node->getReceiver();
       if ($name instanceof NameToken) {

--- a/src/get_unresolved_referenced_names.php
+++ b/src/get_unresolved_referenced_names.php
@@ -35,19 +35,25 @@ function get_unresolved_referenced_names(
   foreach ($root->traverse() as $node) {
     if ($node instanceof QualifiedName) {
       $name = C\firstx($node->getParts()->getItems());
-      if (!$name instanceof NameToken) {
-        continue;
+      if ($name instanceof NameToken) {
+        $ret['namespaces'][] = $name->getText();
       }
-      $ret['namespaces'][] = $name->getText();
       continue;
     }
 
     if ($node instanceof SimpleTypeSpecifier) {
       $name = $node->getSpecifierx();
-      if (!$name instanceof NameToken) {
-        continue;
+      if ($name instanceof NameToken) {
+        $ret['types'][] = $name->getText();
       }
-      $ret['types'][] = $name->getText();
+      continue;
+    }
+
+    if ($node instanceof FunctionCallExpression) {
+      $name = $node->getReceiver();
+      if ($name instanceof NameToken) {
+        $ret['functions'][] = $name->getText();
+      }
       continue;
     }
   }

--- a/src/get_unresolved_referenced_names.php
+++ b/src/get_unresolved_referenced_names.php
@@ -49,6 +49,14 @@ function get_unresolved_referenced_names(
       continue;
     }
 
+    if ($node instanceof ScopeResolutionExpression) {
+      $name = $node->getQualifier();
+      if ($name instanceof NameToken) {
+        $ret['types'][] = $name->getText();
+      }
+      continue;
+    }
+
     if ($node instanceof FunctionCallExpression) {
       $name = $node->getReceiver();
       if ($name instanceof NameToken) {

--- a/src/get_unresolved_referenced_names.php
+++ b/src/get_unresolved_referenced_names.php
@@ -10,7 +10,7 @@
 
 namespace Facebook\HHAST;
 
-use namespace HH\Lib\{C, Str, Vec};
+use namespace HH\Lib\C;
 
 /** Given a tree, provide a list of names that are referenced by the code.
  *

--- a/src/nodes/AlternateLoopStatement.php
+++ b/src/nodes/AlternateLoopStatement.php
@@ -10,7 +10,6 @@
 
 namespace Facebook\HHAST;
 
-use namespace HH\Lib\{Str, Vec};
 
 final class AlternateLoopStatement extends AlternateLoopStatementGeneratedBase {
   <<__Override>>

--- a/src/nodes/EditableToken.php
+++ b/src/nodes/EditableToken.php
@@ -11,7 +11,7 @@
 namespace Facebook\HHAST;
 
 use namespace Facebook\TypeAssert;
-use namespace HH\Lib\{C, Str};
+use namespace HH\Lib\Str;
 
 abstract class EditableToken extends EditableNode {
   private string $_token_kind;

--- a/src/nodes/EditableTokenWithFixedText.php
+++ b/src/nodes/EditableTokenWithFixedText.php
@@ -10,8 +10,6 @@
 
 namespace Facebook\HHAST;
 
-use namespace Facebook\TypeAssert;
-use namespace HH\Lib\{C, Str};
 
 <<__ConsistentConstruct>>
 abstract class EditableTokenWithFixedText extends EditableToken {

--- a/src/offset_from_position.php
+++ b/src/offset_from_position.php
@@ -10,7 +10,7 @@
 
 namespace Facebook\HHAST;
 
-use namespace HH\Lib\{C, Str, Vec};
+use namespace HH\Lib\{Str, Vec};
 
 function offset_from_position(
   EditableNode $root,

--- a/src/resolve_type.php
+++ b/src/resolve_type.php
@@ -11,7 +11,6 @@
 namespace Facebook\HHAST;
 
 use type Facebook\HHAST\EditableNode;
-use namespace Facebook\TypeAssert;
 use namespace HH\Lib\{C, Str, Vec};
 use namespace Facebook\HHAST\__Private\Resolution;
 

--- a/tests/AsyncFunctionAndMethodLinterTest.php
+++ b/tests/AsyncFunctionAndMethodLinterTest.php
@@ -11,9 +11,6 @@
 
 namespace Facebook\HHAST;
 
-use function Facebook\FBExpect\expect;
-use namespace HH\Lib\{C, Str, Vec};
-use namespace Facebook\HHAST;
 
 final class AsyncFunctionAndMethodLinterTest extends TestCase {
   use LinterTestTrait;

--- a/tests/AutoFixingLinterTestTrait.php
+++ b/tests/AutoFixingLinterTestTrait.php
@@ -12,8 +12,7 @@
 namespace Facebook\HHAST;
 
 use function Facebook\HHAST\TestLib\expect;
-use namespace HH\Lib\{C, Str, Vec};
-use namespace Facebook\HHAST;
+use namespace HH\Lib\{Str, Vec};
 
 trait AutoFixingLinterTestTrait<Terror as Linters\FixableLintError> {
   require extends TestCase;

--- a/tests/CamelCasedMethodsUnderscoredFunctionsLinterTest.php
+++ b/tests/CamelCasedMethodsUnderscoredFunctionsLinterTest.php
@@ -11,9 +11,6 @@
 
 namespace Facebook\HHAST;
 
-use function Facebook\FBExpect\expect;
-use namespace HH\Lib\{C, Str, Vec};
-use namespace Facebook\HHAST;
 
 final class CamelCasedMethodsUnderscoredFunctionsLinterTest extends TestCase {
   use LinterTestTrait;

--- a/tests/JSONOutputTest.php
+++ b/tests/JSONOutputTest.php
@@ -11,8 +11,6 @@
 
 namespace Facebook\HHAST;
 
-use type Facebook\CLILib\TestLib\{StringInput, StringOutput};
-use type Facebook\CLILib\Terminal;
 use function Facebook\FBExpect\expect;
 use namespace Facebook\TypeAssert;
 use namespace HH\Lib\{C, Keyset, Vec};

--- a/tests/LSPServerTest.php
+++ b/tests/LSPServerTest.php
@@ -13,7 +13,7 @@ namespace Facebook\HHAST;
 
 use function Facebook\FBExpect\expect;
 use namespace Facebook\HHAST\__Private\LSP;
-use namespace HH\Lib\{Str, Tuple};
+use namespace HH\Lib\Str;
 
 final class LSPServerTest extends TestCase {
   use LinterCLITestTrait;

--- a/tests/LicenseHeaderLinterTest.php
+++ b/tests/LicenseHeaderLinterTest.php
@@ -10,9 +10,6 @@
 
 namespace Facebook\HHAST;
 
-use function Facebook\FBExpect\expect;
-use namespace HH\Lib\{C, Str, Vec};
-use namespace Facebook\HHAST;
 
 final class LicenseHeaderLinterTest extends TestCase {
   use AutoFixingLinterTestTrait<Linters\FixableASTLintError<Script>>;

--- a/tests/LinterTestTrait.php
+++ b/tests/LinterTestTrait.php
@@ -13,7 +13,6 @@ namespace Facebook\HHAST;
 
 use function Facebook\HHAST\TestLib\expect;
 use namespace HH\Lib\{C, Str, Vec};
-use namespace Facebook\HHAST;
 
 trait LinterTestTrait {
   require extends TestCase;

--- a/tests/MigrationsTest.php
+++ b/tests/MigrationsTest.php
@@ -13,7 +13,6 @@ namespace Facebook\HHAST;
 
 use function Facebook\HHAST\TestLib\expect;
 use namespace Facebook\HHAST;
-use namespace HH\Lib\{C, Str};
 use namespace Facebook\TypeAssert;
 
 final class MigrationsTest extends TestCase {

--- a/tests/MustUseBracesForControlFlowLinterTest.php
+++ b/tests/MustUseBracesForControlFlowLinterTest.php
@@ -11,9 +11,6 @@
 
 namespace Facebook\HHAST;
 
-use function Facebook\FBExpect\expect;
-use namespace HH\Lib\{C, Str, Vec};
-use namespace Facebook\HHAST;
 
 final class MustUseBracesForControlFlowLinterTest extends TestCase {
   use AutoFixingLinterTestTrait<

--- a/tests/MustUseOverrideAttributeLinterTest.php
+++ b/tests/MustUseOverrideAttributeLinterTest.php
@@ -11,9 +11,6 @@
 
 namespace Facebook\HHAST;
 
-use function Facebook\FBExpect\expect;
-use namespace HH\Lib\{C, Str, Vec};
-use namespace Facebook\HHAST;
 
 final class MustUseOverrideAttributeLinterTest extends TestCase {
   use AutoFixingLinterTestTrait<

--- a/tests/NoBasicAssignmentFunctionParameterLinterTest.php
+++ b/tests/NoBasicAssignmentFunctionParameterLinterTest.php
@@ -11,9 +11,6 @@
 
 namespace Facebook\HHAST;
 
-use function Facebook\FBExpect\expect;
-use namespace HH\Lib\{C, Str, Vec};
-use namespace Facebook\HHAST;
 
 final class NoBasicAssignmentFunctionParameterLinterTest extends TestCase {
   use LinterTestTrait;

--- a/tests/NoWhitespaceAtEndOfLineLinterTest.php
+++ b/tests/NoWhitespaceAtEndOfLineLinterTest.php
@@ -10,9 +10,6 @@
 
 namespace Facebook\HHAST;
 
-use function Facebook\FBExpect\expect;
-use namespace HH\Lib\{C, Str, Vec};
-use namespace Facebook\HHAST;
 
 final class NoWhitespaceAtEndOfLineLinterTest extends TestCase {
   use AutoFixingLinterTestTrait<Linters\FixableLineLintError>;

--- a/tests/NodeAtPositionTest.php
+++ b/tests/NodeAtPositionTest.php
@@ -12,7 +12,6 @@
 namespace Facebook\HHAST;
 
 use function Facebook\FBExpect\expect;
-use namespace HH\Lib\{C, Vec};
 
 final class NodeAtPositionTest extends TestCase {
   public function getExamples(): array<(string, (int, int), classname<EditableNode>, string)> {

--- a/tests/PHPTest.php
+++ b/tests/PHPTest.php
@@ -12,7 +12,7 @@
 namespace Facebook\HHAST;
 
 use function Facebook\FBExpect\expect;
-use namespace HH\Lib\{C, Str, Vec};
+use namespace HH\Lib\C;
 
 final class PHPTest extends TestCase {
   public function testPHPOnlyFeature(): void {

--- a/tests/ResolutionTest.php
+++ b/tests/ResolutionTest.php
@@ -13,7 +13,6 @@ namespace Facebook\HHAST;
 
 use function Facebook\FBExpect\expect;
 use namespace Facebook\HHAST\__Private\Resolution;
-use namespace HH\Lib\{C, Vec};
 
 final class ResolutionTest extends TestCase {
   public function testWithoutNamespaces(): void {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,9 +11,7 @@
 
 namespace Facebook\HHAST;
 
-use function Facebook\FBExpect\expect;
-use namespace Facebook\HHAST;
-use namespace HH\Lib\{C, Str};
+use namespace HH\Lib\C;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase {
   protected static function getNodeAndParents(

--- a/tests/TestLib/ExpectObj.php
+++ b/tests/TestLib/ExpectObj.php
@@ -11,7 +11,7 @@
 
 namespace Facebook\HHAST\TestLib;
 
-use namespace HH\Lib\{C, Str};
+use namespace HH\Lib\Str;
 
 final class ExpectObj<T> extends \Facebook\FBExpect\ExpectObj<T> {
   public function __construct(private T $var) {

--- a/tests/TestLib/TemporaryProject.php
+++ b/tests/TestLib/TemporaryProject.php
@@ -11,7 +11,7 @@
 
 namespace Facebook\HHAST\TestLib;
 
-use namespace HH\Lib\{C, Str};
+use namespace HH\Lib\Str;
 
 final class TemporaryProject implements \IDisposable {
   private resource $hhServer;

--- a/tests/UnusedUseClauseLinterTest.php
+++ b/tests/UnusedUseClauseLinterTest.php
@@ -1,0 +1,38 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class UnusedUseClauseLinter extends TestCase {
+  use AutoFixingLinterTestTrait<Linters\FixableASTLintError<INamespaceUseDeclaration>>;
+
+  protected function getLinter(
+    string $file,
+  ): Linters\AutoFixingASTLinter<INamespaceUseDeclaration> {
+    return new Linters\UnusedUseClauseLinter($file);
+  }
+
+  public function getCleanExamples(): array<array<string>> {
+    return [
+      ["<?hh\nuse type Foo; Foo::bar();"],
+      ["<?hh\nuse type Foo; \$x instanceof Foo;"],
+      ["<?hh\nuse type Foo; class Bar<T as Foo>(): void {}"],
+      ["<?hh\nuse type Foo; new Foo();"],
+      ["<?hh\nuse type Foo; function bar(Foo \$in): void {}"],
+      ["<?hh\nuse type Foo; function bar(): Foo {}"],
+      ["<?hh\nuse namespace Foo; Foo\bar();"],
+      ["<?hh\nuse namespace Foo; new Foo\Bar();"],
+      ["<?hh\nuse Foo; new Foo();"],
+      ["<?hh\nuse Foo; new Foo\Bar();"],
+      ["<?hh\nuse function foo; foo();"],
+      ["<?hh\nuse const FOO; var_dump(FOO);"],
+    ];
+  }
+}

--- a/tests/fixtures/UnusedUseClauseLinter/collapsing.php.autofix.expect
+++ b/tests/fixtures/UnusedUseClauseLinter/collapsing.php.autofix.expect
@@ -1,0 +1,7 @@
+<?hh
+
+use namespace HH\Lib\C;
+use namespace HH\Lib\C;
+use namespace HH\Lib\C;
+
+C\foo();

--- a/tests/fixtures/UnusedUseClauseLinter/collapsing.php.expect
+++ b/tests/fixtures/UnusedUseClauseLinter/collapsing.php.expect
@@ -1,0 +1,17 @@
+[
+    {
+        "blame": "\nuse namespace HH\\Lib\\{C, Str};\n",
+        "blame_pretty": "\nuse namespace HH\\Lib\\{C, Str};\n",
+        "description": "`Str` is not used"
+    },
+    {
+        "blame": "use namespace HH\\Lib\\C, HH\\Lib\\Str;\n",
+        "blame_pretty": "use namespace HH\\Lib\\C, HH\\Lib\\Str;\n",
+        "description": "`Str` is not used"
+    },
+    {
+        "blame": "use namespace HH\\Lib\\{\n  C,\n  Str,\n};\n",
+        "blame_pretty": "use namespace HH\\Lib\\{\n  C,\n  Str,\n};\n",
+        "description": "`Str` is not used"
+    }
+]

--- a/tests/fixtures/UnusedUseClauseLinter/collapsing.php.in
+++ b/tests/fixtures/UnusedUseClauseLinter/collapsing.php.in
@@ -1,0 +1,10 @@
+<?hh
+
+use namespace HH\Lib\{C, Str};
+use namespace HH\Lib\C, HH\Lib\Str;
+use namespace HH\Lib\{
+  C,
+  Str,
+};
+
+C\foo();

--- a/tests/fixtures/UnusedUseClauseLinter/group_use.php.autofix.expect
+++ b/tests/fixtures/UnusedUseClauseLinter/group_use.php.autofix.expect
@@ -1,0 +1,22 @@
+<?hh
+
+use namespace Foo\{B, C};
+use namespace Foo\{A, C};
+use namespace Foo\{A, B};
+
+use namespace Foo\{
+    B,
+    C,
+};
+use namespace Foo\{
+    A,
+    C,
+};
+use namespace Foo\{
+    A,
+    B,
+};
+
+A\foo();
+B\bar();
+C\baz();

--- a/tests/fixtures/UnusedUseClauseLinter/group_use.php.expect
+++ b/tests/fixtures/UnusedUseClauseLinter/group_use.php.expect
@@ -1,0 +1,32 @@
+[
+    {
+        "blame": "\nuse namespace Foo\\{UnusedFirst, B, C};\n",
+        "blame_pretty": "\nuse namespace Foo\\{UnusedFirst, B, C};\n",
+        "description": "`UnusedFirst` is not used"
+    },
+    {
+        "blame": "use namespace Foo\\{A, UnusedMid, C};\n",
+        "blame_pretty": "use namespace Foo\\{A, UnusedMid, C};\n",
+        "description": "`UnusedMid` is not used"
+    },
+    {
+        "blame": "use namespace Foo\\{A, B, UnusedLast};\n",
+        "blame_pretty": "use namespace Foo\\{A, B, UnusedLast};\n",
+        "description": "`UnusedLast` is not used"
+    },
+    {
+        "blame": "\nuse namespace Foo\\{\n    UnusedFirst,\n    B,\n    C,\n};\n",
+        "blame_pretty": "\nuse namespace Foo\\{\n    UnusedFirst,\n    B,\n    C,\n};\n",
+        "description": "`UnusedFirst` is not used"
+    },
+    {
+        "blame": "use namespace Foo\\{\n    A,\n    UnusedMid,\n    C,\n};\n",
+        "blame_pretty": "use namespace Foo\\{\n    A,\n    UnusedMid,\n    C,\n};\n",
+        "description": "`UnusedMid` is not used"
+    },
+    {
+        "blame": "use namespace Foo\\{\n    A,\n    B,\n    UnusedLast,\n};\n",
+        "blame_pretty": "use namespace Foo\\{\n    A,\n    B,\n    UnusedLast,\n};\n",
+        "description": "`UnusedLast` is not used"
+    }
+]

--- a/tests/fixtures/UnusedUseClauseLinter/group_use.php.in
+++ b/tests/fixtures/UnusedUseClauseLinter/group_use.php.in
@@ -1,0 +1,25 @@
+<?hh
+
+use namespace Foo\{UnusedFirst, B, C};
+use namespace Foo\{A, UnusedMid, C};
+use namespace Foo\{A, B, UnusedLast};
+
+use namespace Foo\{
+    UnusedFirst,
+    B,
+    C,
+};
+use namespace Foo\{
+    A,
+    UnusedMid,
+    C,
+};
+use namespace Foo\{
+    A,
+    B,
+    UnusedLast,
+};
+
+A\foo();
+B\bar();
+C\baz();

--- a/tests/fixtures/UnusedUseClauseLinter/types.php.autofix.expect
+++ b/tests/fixtures/UnusedUseClauseLinter/types.php.autofix.expect
@@ -1,0 +1,17 @@
+<?hh
+
+use type Foo\{
+  ParameterType,
+  ReturnType,
+  GenericType,
+  UsedTrait,
+  InstanceOfType,
+};
+
+function foo(ParameterType $in): ReturnType {
+  return $in instanceof InstanceOfType;
+}
+
+class MyClass<T as GenericType> {
+  use UsedTrait;
+}

--- a/tests/fixtures/UnusedUseClauseLinter/types.php.expect
+++ b/tests/fixtures/UnusedUseClauseLinter/types.php.expect
@@ -1,0 +1,7 @@
+[
+    {
+        "blame": "\nuse type Foo\\{\n  Unused,\n  ParameterType,\n  ReturnType,\n  GenericType,\n  UsedTrait,\n  InstanceOfType,\n};\n",
+        "blame_pretty": "\nuse type Foo\\{\n  Unused,\n  ParameterType,\n  ReturnType,\n  GenericType,\n  UsedTrait,\n  InstanceOfType,\n};\n",
+        "description": "`Unused` is not used"
+    }
+]

--- a/tests/fixtures/UnusedUseClauseLinter/types.php.in
+++ b/tests/fixtures/UnusedUseClauseLinter/types.php.in
@@ -1,0 +1,18 @@
+<?hh
+
+use type Foo\{
+  Unused,
+  ParameterType,
+  ReturnType,
+  GenericType,
+  UsedTrait,
+  InstanceOfType,
+};
+
+function foo(ParameterType $in): ReturnType {
+  return $in instanceof InstanceOfType;
+}
+
+class MyClass<T as GenericType> {
+  use UsedTrait;
+}


### PR DESCRIPTION
- does not support `use constant` as that's too involved
- test run will fail, as I've omitted the fixes to HHAST itself - those are here: https://gist.github.com/fredemmott/1c66c2d3066be80697d98110c4ebca5a

I've not included the fixes in this PR as they make the PR too big to be reviewable - will add them before merging.