### PR TITLE
Use only one bool

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -3,4 +3,4 @@ enable_experimental_tc_features = no_fallback_in_namespaces, unpacking_check_ari
 safe_array = true
 safe_vector_array = true
 disallow_destruct = true
-forward_compatibility_level=3.28
+forward_compatibility_level=3.27

--- a/.hhconfig
+++ b/.hhconfig
@@ -3,4 +3,4 @@ enable_experimental_tc_features = no_fallback_in_namespaces, unpacking_check_ari
 safe_array = true
 safe_vector_array = true
 disallow_destruct = true
-forward_compatibility_level=3.27
+forward_compatibility_level=3.28


### PR DESCRIPTION
Don't need two booleans to determine whether we need to add `use function Facebook\FBExpect\expect;` 
`useExpectFunctionNeeded` starts out false and is only set to true if there are expect calls. It is set to false if the use statement already exists or if the migration adds it.