### PR TITLE
Add real diff implementation (Myers algorithm), use it to display previews

### DIFF
--- a/src/Linters/FixableASTLintError.php
+++ b/src/Linters/FixableASTLintError.php
@@ -38,15 +38,9 @@ class FixableASTLintError<
       $linter instanceof AutoFixingASTLinter,
       "Can't render fix for unfixable lint error",
     );
-    $node = $this->fixed;
-    invariant(
-      $node !== null,
-      'shouldnt attempt to fix without a fixed version',
-    );
-    return tuple(
-      $this->getPrettyBlame(),
-      $linter->getPrettyTextForNode($node, $this->context),
-    );
+    $fixed = $linter->getFixedFile(vec[$this]);
+    invariant($fixed !== null, 'could not get fixed file');
+    return tuple($this->getFile()->getContents(), $fixed->getContents());
   }
 
   final public function shouldRenderBlameAndFixAsDiff(): bool {

--- a/src/__Private/Diff/Diff.php
+++ b/src/__Private/Diff/Diff.php
@@ -1,0 +1,173 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+
+namespace Facebook\HHAST\__Private\Diff;
+
+use namespace HH\Lib\{C, Dict, Vec};
+
+/** An implementation of Myer's diff algorithm.
+ *
+ * @See Myers (1986) An O(ND) difference algorithm and its variations.
+ * Algorithmica, 1(1-4), p251-266. doi: 10.1007/BF01840446
+ *
+ * In short:
+ * - think of the problem as an edit graph: the X axis is the original sequence
+ *   and the Y axis is the desired sequence
+ * - increasing X is deleting an item (cost 1)
+ * - increasing Y is inserting an item from the target sequence (cost 1)
+ * - where the items are the same, increase both X and Y simultanously (cost 0)
+ * - diffing is now graph traversal problem: find the path with the lowest cost
+ *   path from (0, 0) to (max(x), max(y))
+ */
+abstract class Diff {
+  abstract const type TContent;
+  const type TElem = shape('content' => this::TContent, 'pos' => int);
+  const type TMove = ((int, int), (int, int));
+
+  private vec<this::TElem> $a;
+  private vec<this::TElem> $b;
+
+  public function __construct(vec<this::TContent> $a, vec<this::TContent> $b) {
+    $this->a =
+      Vec\map_with_key($a, ($k, $v) ==> shape('content' => $v, 'pos' => $k));
+    $this->b =
+      Vec\map_with_key($b, ($k, $v) ==> shape('content' => $v, 'pos' => $k));
+  }
+
+  protected function areSame(this::TContent $a, this::TContent $b): bool {
+    return $a === $b;
+  }
+
+  <<__Memoize>>
+  final public function getDiff(): vec<(DiffOp, ?this::TElem, ?this::TElem)> {
+    $a = $this->a;
+    $b = $this->b;
+
+    $path = Vec\reverse($this->getPath());
+    $diff = vec[];
+
+    $prev = tuple(0, 0);
+    foreach ($path as list($from, $to)) {
+      invariant($from === $prev, "Missed a step");
+      list($x, $y) = $from;
+      $prev = $to;
+      if ($to === tuple($x + 1, $y + 1)) {
+        $diff[] = tuple(DiffOp::KEEP, $a[$x], $b[$y]);
+        continue;
+      }
+
+      if ($to === tuple($x + 1, $y)) {
+        $diff[] = tuple(DiffOp::DELETE, $a[$x], null);
+        continue;
+      }
+
+      if ($to === tuple($x, $y + 1)) {
+        $diff[] = tuple(DiffOp::INSERT, null, $b[$y]);
+        continue;
+      }
+
+      invariant_violation(
+        'invalid move: (%d, %d) => (%d, %d)',
+        $from[0],
+        $from[1],
+        $to[0],
+        $to[1],
+      );
+    }
+    return $diff;
+  }
+
+  /** Implementation as in the paper */
+  protected function getPath(): vec<this::TMove> {
+    // Variable names match the paper
+    $n = C\count($this->a);
+    $m = C\count($this->b);
+    $max = $m + $n;
+    $v = dict[1 => 0];
+    $vd = vec[];
+
+    // $d: depth a.k.a cost
+    // $x: index into $a
+    // $y: index into $b
+    // $k = $x - $y
+    // $v: map from $k, to best possible $x
+    // $vd: trace of $v at each depth
+    for ($d = 0; $d <= $max; $d++) {
+      $vd[] = $v;
+      for ($k = -$d; $k <= $d; $k += 2) {
+        if ($k === -$d || ($k !== $d && $v[$k - 1] < $v[$k + 1])) {
+          $x = $v[$k + 1];
+        } else {
+          $x = $v[$k - 1] + 1;
+        }
+        $y = $x - $k;
+
+        // diagonal moves
+        while (
+          $x < $n &&
+          $y < $m &&
+          $this->areSame($this->a[$x]['content'], $this->b[$y]['content'])
+        ) {
+          $x++;
+          $y++;
+        }
+        $v[$k] = $x;
+        if ($x >= $n && $y >= $m) {
+          return $this->backtrackPath($vd);
+        }
+      }
+    }
+    invariant_violation(
+      'Shortest path is greater than the maximum possible length',
+    );
+  }
+
+  /** Backtracking algorithm in the paper.
+   *
+   * Returns a reversed list of moves.
+   */
+  private function backtrackPath(vec<dict<int, int>> $vd): vec<this::TMove> {
+    $moves = vec[];
+    // Start at the final position, and backtrack to (0, 0)
+    $to_x = C\count($this->a);
+    $to_y = C\count($this->b);
+
+    foreach (Dict\reverse($vd) as $d => $v) {
+      $k = $to_x - $to_y;
+
+      if ($k === -$d || ($k !== $d && $v[$k - 1] < $v[$k + 1])) {
+        $k = $k + 1;
+      } else {
+        $k = $k - 1;
+      }
+      $from_x = $v[$k];
+      $from_y = $from_x - $k;
+
+      // diagonal moves
+      while ($to_x > $from_x && $to_y > $from_y) {
+        $moves[] = tuple(tuple($to_x - 1, $to_y - 1), tuple($to_x, $to_y));
+        $to_x--;
+        $to_y--;
+      }
+
+      if ($d === 0) {
+        // if cost is 0, any remaining moves had to be diagonal
+        return $moves;
+      }
+
+      $moves[] = tuple(tuple($from_x, $from_y), tuple($to_x, $to_y));
+
+      $to_x = $from_x;
+      $to_y = $from_y;
+    }
+    invariant_violation('unreachable');
+  }
+}

--- a/src/__Private/Diff/DiffOp.php
+++ b/src/__Private/Diff/DiffOp.php
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+
+namespace Facebook\HHAST\__Private\Diff;
+
+enum DiffOp: int {
+  KEEP = 0;
+  DELETE = -1;
+  INSERT = 1;
+}

--- a/src/__Private/Diff/StringDiff.php
+++ b/src/__Private/Diff/StringDiff.php
@@ -1,0 +1,121 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+
+namespace Facebook\HHAST\__Private\Diff;
+
+use namespace HH\Lib\{C, Str, Vec};
+
+final class StringDiff extends Diff {
+  const type TContent = string;
+
+  public static function lines(string $a, string $b): this {
+    return new self(Str\split($a, "\n"), Str\split($b, "\n"));
+  }
+
+  public static function characters(string $a, string $b): this {
+    return new self(Str\split($a, ''), Str\split($b, ''));
+  }
+
+  public function getUnifiedDiff(int $context = 3): string {
+    $hunks = vec[];
+
+    $remaining = $this->getDiff();
+    while (!C\is_empty($remaining)) {
+      $not_keep = C\find_key($remaining, $row ==> $row[0] !== DiffOp::KEEP);
+      if ($not_keep === null) {
+        break;
+      }
+      $start = ($not_keep > $context) ? ($not_keep - $context) : 0;
+
+      $remaining = Vec\drop($remaining, $start);
+      $count = C\count($remaining);
+
+      $end = $count;
+      $run_start = null;
+      for ($i = $context; $i < $count; ++$i) {
+        if ($remaining[$i][0] === DiffOp::KEEP) {
+          $run_start = $run_start ?? $i;
+          continue;
+        }
+
+        if ($run_start === null) {
+          continue;
+        }
+
+        if ($i >= $run_start + (2 * $context)) {
+          $end = $run_start + $context;
+          break;
+        }
+      }
+      if ($run_start !== null) {
+        $end = $run_start + $context;
+      }
+      $hunks[] = Vec\take($remaining, $end);
+      $remaining = Vec\drop($remaining, $end);
+    }
+
+    return Vec\map($hunks, $hunk ==> $this->getUnifiedDiffHunk($hunk))
+      |> Vec\filter_nulls($$)
+      |> Str\join($$, "");
+  }
+
+  private function getUnifiedDiffHunk(
+    vec<(DiffOp, ?this::TElem, ?this::TElem)> $hunk,
+  ): ?string {
+    if (C\is_empty($hunk)) {
+      return null;
+    }
+    $old_start = null;
+    $new_start = null;
+    $old_lines = 0;
+    $new_lines = 0;
+
+    $lines = vec[];
+
+    foreach ($hunk as list($op, $old, $new)) {
+      switch ($op) {
+        case DiffOp::KEEP:
+          invariant($old !== null, 'must have old for keep');
+          invariant($new !== null, 'must have new for keep');
+          $lines[] = ' '.$old['content'];
+          $old_start = $old_start ?? $old['pos'];
+          $new_start = $new_start ?? $new['pos'];
+          ++$old_lines;
+          ++$new_lines;
+          break;
+        case DiffOp::DELETE:
+          invariant($old !== null, 'must have old for delete');
+          $lines[] = '-'.$old['content'];
+          $old_start = $old_start ?? $old['pos'];
+          $new_start = $new_start ?? $old['pos'];
+          ++$old_lines;
+          break;
+        case DiffOp::INSERT:
+          invariant($new !== null, 'must have new for insert');
+          $lines[] = '+'.$new['content'];
+          $old_start = $old_start ?? $new['pos'];
+          $new_start = $new_start ?? $new['pos'];
+          ++$new_lines;
+          break;
+      }
+    }
+    invariant($old_start !== null, 'failed to find an old pos');
+    invariant($new_start !== null, 'failed to find a new pos');
+
+    return Str\format(
+      "@@ -%d,%d +%d,%d @@\n",
+      $old_start + 1,
+      $old_lines,
+      $new_start + 1,
+      $new_lines,
+    ).Str\join($lines, "\n")."\n";
+  }
+}


### PR DESCRIPTION
This PR depends on (and includes) the LSP as-you-type changes

 This is pretty slow if running it with the jit on with just a few files, mostly due to having to flatten the AST to a file, bu tfine with the jit off, or when running across a few files.

I'm hoping to use this to:
- implement LSP support for all fixable lint errors (i.e. file changes => document textEdit structs)
- drastically simplify the linter/lint error class hierarchy - if we have `getFixedFile`, we can render a diff.