### PR TITLE
Make LSP message flushing async, complete, and chunk in-order

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -35,16 +35,16 @@
         },
         {
             "name": "facebook/hh-clilib",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hhvm/hh-clilib.git",
-                "reference": "d8d19b4f230b6f02c6fc2be16ec1fb19c3fcbc0e"
+                "reference": "12542c339972c6fd77b2037a41b8f9b53212adcf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/d8d19b4f230b6f02c6fc2be16ec1fb19c3fcbc0e",
-                "reference": "d8d19b4f230b6f02c6fc2be16ec1fb19c3fcbc0e",
+                "url": "https://api.github.com/repos/hhvm/hh-clilib/zipball/12542c339972c6fd77b2037a41b8f9b53212adcf",
+                "reference": "12542c339972c6fd77b2037a41b8f9b53212adcf",
                 "shasum": ""
             },
             "require": {
@@ -52,17 +52,21 @@
                 "hhvm/type-assert": "^3.2"
             },
             "require-dev": {
-                "91carriage/phpunit-hhi": "^5.7",
-                "facebook/fbexpect": "^1.1.0",
-                "hhvm/hhast": "^3.27.0",
-                "phpunit/phpunit": "^5.7"
+                "facebook/fbexpect": "^2.1.0",
+                "hhvm/hacktest": "^0.2.0",
+                "hhvm/hhast": "~3.28.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "time": "2018-08-27T20:03:09+00:00"
+            "time": "2018-09-14T20:36:22+00:00"
         },
         {
             "name": "hhvm/hhvm-autoload",

--- a/src/__Private/LSPImpl/DidCloseTextDocumentNotification.php
+++ b/src/__Private/LSPImpl/DidCloseTextDocumentNotification.php
@@ -35,12 +35,14 @@ final class DidCloseTextDocumentNotification
       return;
     }
 
-    (
-      new LSPLib\PublishDiagnosticsNotification(shape(
-        'uri' => $uri,
-        'diagnostics' => vec[],
-      ))
-    )->asMessage()
-      |> $this->client->sendNotificationMessage($$);
+    await $this->client
+      ->sendNotificationMessageAsync(
+        (
+          new LSPLib\PublishDiagnosticsNotification(shape(
+            'uri' => $uri,
+            'diagnostics' => vec[],
+          ))
+        )->asMessage(),
+      );
   }
 }

--- a/src/__Private/LSPImpl/ExecuteCommandCommand.php
+++ b/src/__Private/LSPImpl/ExecuteCommandCommand.php
@@ -34,9 +34,17 @@ final class ExecuteCommandCommand extends LSPLib\ExecuteCommandCommand {
           type_structure(self::class, 'THHAST_ApplyWorkspaceEditParams'),
           $p['arguments'] ?? vec[],
         );
-        (new LSPLib\ApplyWorkspaceEditCommand(self::generateID(), shape(
-          'edit' => $args[0],
-        )))->asMessage() |> $this->client->sendRequestMessage($$);
+        await $this->client
+          ->sendRequestMessageAsync(
+            (
+              new LSPLib\ApplyWorkspaceEditCommand(
+                self::generateID(),
+                shape(
+                  'edit' => $args[0],
+                ),
+              )
+            )->asMessage(),
+          );
         return self::success(null);
     }
     return self::error(0, 'Unsupported command: '.$command, null);

--- a/src/__Private/LSPImpl/InitializedNotification.php
+++ b/src/__Private/LSPImpl/InitializedNotification.php
@@ -43,7 +43,7 @@ final class InitializedNotification
         ),
       )
     )->asMessage();
-    $this->client->sendRequestMessage($message);
+    await $this->client->sendRequestMessageAsync($message);
     await parent::executeAsync($p);
   }
 }

--- a/src/__Private/LSPLib/Client.php
+++ b/src/__Private/LSPLib/Client.php
@@ -15,21 +15,21 @@ use namespace Facebook\HHAST\__Private\LSP;
 
 abstract class Client {
 
-  abstract protected function sendMessage(LSP\Message $message): void;
+  abstract protected function sendMessageAsync(LSP\Message $message): Awaitable<void>;
 
-  final public function sendRequestMessage(LSP\RequestMessage $message): void {
-    $this->sendMessage($message);
+  final public async function sendRequestMessageAsync(LSP\RequestMessage $message): Awaitable<void> {
+    await $this->sendMessageAsync($message);
   }
 
-  final public function sendResponseMessage(
+  final public async function sendResponseMessageAsync(
     LSP\ResponseMessage $message,
-  ): void {
-    $this->sendMessage($message);
+  ): Awaitable<void> {
+    await $this->sendMessageAsync($message);
   }
 
-  final public function sendNotificationMessage(
+  final public async function sendNotificationMessageAsync(
     LSP\NotificationMessage $message,
-  ): void {
-    $this->sendMessage($message);
+  ): Awaitable<void> {
+    await $this->sendMessageAsync($message);
   }
 }

--- a/src/__Private/LintRun.php
+++ b/src/__Private/LintRun.php
@@ -58,7 +58,7 @@ final class LintRun {
       },
     );
     $result = self::worstResult(...$results);
-    $this->handler->finishedRun($result);
+    await $this->handler->finishedRunAsync($result);
     return $result;
   }
 
@@ -81,7 +81,7 @@ final class LintRun {
         throw new LinterException($class, $file->getPath(), $t->getMessage(), null, $t);
       }
     }
-    $this->handler->finishedFile($file->getPath(), $result);
+    await $this->handler->finishedFileAsync($file->getPath(), $result);
     return $result;
   }
 

--- a/src/__Private/LintRunEventHandler.php
+++ b/src/__Private/LintRunEventHandler.php
@@ -29,7 +29,7 @@ interface LintRunEventHandler {
     Traversable<Linters\LintError> $errors,
   ): LintAutoFixResult;
 
-  public function finishedFile(string $path, LintRunResult $result): void;
+  public function finishedFileAsync(string $path, LintRunResult $result): Awaitable<void>;
 
-  public function finishedRun(LintRunResult $result): void;
+  public function finishedRunAsync(LintRunResult $result): Awaitable<void>;
 }

--- a/src/__Private/LintRunJSONEventHandler.php
+++ b/src/__Private/LintRunJSONEventHandler.php
@@ -39,9 +39,7 @@ final class LintRunJSONEventHandler implements LintRunEventHandler {
 
   private vec<self::TOutputError> $errors = vec[];
 
-  public function __construct(
-    private ITerminal $terminal,
-  ) {
+  public function __construct(private ITerminal $terminal) {
   }
 
 
@@ -55,11 +53,16 @@ final class LintRunJSONEventHandler implements LintRunEventHandler {
     return LintAutoFixResult::SOME_UNFIXED;
   }
 
-  public function finishedFile(string $_, LintRunResult $_): void {
+  public async function finishedFileAsync(
+    string $_,
+    LintRunResult $_,
+  ): Awaitable<void> {
   }
 
-  public function finishedRun(LintRunResult $_): void {
-    $this->terminal->getStdout()->write(\json_encode($this->getOutput()));
+  public async function finishedRunAsync(LintRunResult $_): Awaitable<void> {
+    await $this->terminal
+      ->getStdout()
+      ->writeAsync(\json_encode($this->getOutput()));
   }
 
   private function getOutput(): self::TOutput {

--- a/src/__Private/LintRunLSPPublishDiagnosticsEventHandler.php
+++ b/src/__Private/LintRunLSPPublishDiagnosticsEventHandler.php
@@ -60,10 +60,10 @@ final class LintRunLSPPublishDiagnosticsEventHandler
     );
   }
 
-  private function publishDiagnostics(
+  private async function publishDiagnosticsAsync(
     string $file,
     vec<Linters\LintError> $errors,
-  ): void {
+  ): Awaitable<void> {
     $uri = 'file://'.$file;
     $this->state->lintErrors[$uri] = $errors;
     $message = (
@@ -72,10 +72,13 @@ final class LintRunLSPPublishDiagnosticsEventHandler
         'diagnostics' => Vec\map($errors, $e ==> $this->asDiagnostic($e)),
       ))
     )->asMessage();
-    $this->client->sendNotificationMessage($message);
+    await $this->client->sendNotificationMessageAsync($message);
   }
 
-  public function finishedFile(string $path, LintRunResult $result): void {
+  public async function finishedFileAsync(
+    string $path,
+    LintRunResult $result,
+  ): Awaitable<void> {
     $path = \realpath($path);
     invariant(
       $this->file === null || $this->file === $path,
@@ -96,11 +99,11 @@ final class LintRunLSPPublishDiagnosticsEventHandler
       );
     }
 
-    $this->publishDiagnostics($path, $errors);
+    await $this->publishDiagnosticsAsync($path, $errors);
     $this->file = null;
     $this->errors = vec[];
   }
 
-  public function finishedRun(LintRunResult $_): void {
+  public async function finishedRunAsync(LintRunResult $_): Awaitable<void> {
   }
 }


### PR DESCRIPTION
fixes #130

`write()` might only write part of the data (it returns number of bytes written). `writeAsync()` (new) does the whole lot, but can interleave.

1. Convert all the client => server methods to async
2. Use writeAsync
3. Build a queue so that we don't get a chunk from one message
interleaved with a chunk from another