### PR TITLE
Add <> to != migration

### DIFF
--- a/src/Migrations/PHPLessThanGreaterThanOperatorMigration.php
+++ b/src/Migrations/PHPLessThanGreaterThanOperatorMigration.php
@@ -1,0 +1,39 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\Migrations;
+
+use namespace Facebook\HHAST;
+
+final class PHPLessThanGreaterThanOperatorMigration extends StepBasedMigration {
+  final private function replaceOperator(
+    HHAST\BinaryExpression $in,
+  ): HHAST\BinaryExpression {
+    $op = $in->getOperator();
+    if (!$op is HHAST\LessThanGreaterThanToken) {
+      return $in;
+    }
+    return $in->withOperator(
+      new HHAST\ExclamationEqualToken($op->getLeading(), $op->getTrailing())
+    );
+  }
+
+  <<__Override>>
+  final public function getSteps(): Traversable<IMigrationStep> {
+    return vec[
+      new TypedMigrationStep(
+        'replace the `<>` operator with `!=`',
+        HHAST\BinaryExpression::class,
+        HHAST\BinaryExpression::class,
+        $node ==> $this->replaceOperator($node),
+      ),
+    ];
+  }
+}

--- a/src/__Private/MigrationCLI.php
+++ b/src/__Private/MigrationCLI.php
@@ -22,6 +22,7 @@ use type Facebook\HHAST\Migrations\{
   ImplicitShapeSubtypesMigration,
   OptionalShapeFieldsMigration,
   NamespaceFallbackMigration,
+  PHPLessThanGreaterThanOperatorMigration,
   PHPUnitToHackTestMigration,
 };
 
@@ -90,6 +91,20 @@ class MigrationCLI extends CLIWithRequiredArguments {
         },
         'Apply all migrations for moving from 3.23 to 3.24',
         '--hhvm-3.23-to-3.24',
+      ),
+      CLIOptions\flag(
+        () ==> {
+          $this->migrations[] = PHPLessThanGreaterThanOperatorMigration::class;
+        },
+        'Replace <> with != (no semantic change',
+        '--ltgt-to-ne',
+      ),
+      CLIOptions\flag(
+        () ==> {
+          $this->migrations[] = PHPLessThanGreaterThanOperatorMigration::class;
+        },
+        'Apply all migrations for moving from 3.28 to 3.29',
+        '--hhvm-3.28-to-3.29',
       ),
       CLIOptions\flag(
         () ==> {

--- a/tests/MigrationsTest.php
+++ b/tests/MigrationsTest.php
@@ -77,6 +77,10 @@ final class MigrationsTest extends TestCase {
         Migrations\PHPUnitToHackTestMigration::class,
         'migrations/PHPUnitToHackTest/old_name_ns_with_use.php',
       ),
+      tuple(
+        Migrations\PHPLessThanGreaterThanOperatorMigration::class,
+        'migrations/ltgt.php',
+      ),
     ];
 
     return $migrations;

--- a/tests/fixtures/migrations/ltgt.php.expect
+++ b/tests/fixtures/migrations/ltgt.php.expect
@@ -1,0 +1,20 @@
+<?hh // strict
+
+/**
+ * Copyright (c) 2016, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional
+ * grant of patent rights can be found in the PATENTS file in the same
+ * directory.
+ *
+ */
+
+if ($a != $b) {
+}
+
+if (/* a */ $foo /* b */ != /* c */ $bar /* d */) {
+}
+
+/* This comment contains `<>` which should remain less-than-greater-than */

--- a/tests/fixtures/migrations/ltgt.php.in
+++ b/tests/fixtures/migrations/ltgt.php.in
@@ -1,0 +1,20 @@
+<?hh // strict
+
+/**
+ * Copyright (c) 2016, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional
+ * grant of patent rights can be found in the PATENTS file in the same
+ * directory.
+ *
+ */
+
+if ($a <> $b) {
+}
+
+if (/* a */ $foo /* b */ <> /* c */ $bar /* d */) {
+}
+
+/* This comment contains `<>` which should remain less-than-greater-than */


### PR DESCRIPTION
There's already a PHP inequality /linter/ but that's more ambitious:
that converts to `!==`.

The migration does the safe change.