### PR TITLE
Add linter banning empty statements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,8 @@ We actively welcome your pull requests.
 1. Fork the repo and create your branch from `master`.
 2. If you've added code that should be tested, add tests
 3. Ensure that:
- - the test suite passes
- - all linters pass
+ - the test suite passes (run `vendor/bin/hacktest tests`)
+ - all linters pass (run `bin/hhast-lint`)
  - the codegen regenerates with no changes
 4. If you haven't already, complete the Contributor License Agreement ("CLA").
 

--- a/src/Linters/NoEmptyStatementsLinter.php
+++ b/src/Linters/NoEmptyStatementsLinter.php
@@ -10,11 +10,7 @@
 
 namespace Facebook\HHAST\Linters;
 
-use type Facebook\HHAST\{
-  ExpressionStatement,
-  EditableNode,
-  EditableList,
-};
+use type Facebook\HHAST\{ExpressionStatement, EditableNode, EditableList};
 
 final class NoEmptyStatementsLinter
   extends AutoFixingASTLinter<ExpressionStatement> {
@@ -36,11 +32,7 @@ final class NoEmptyStatementsLinter
 
     $expr = $stmt->getExpression();
     if ($expr === null) {
-          return new ASTLintError(
-      $this,
-      'This statement is empty',
-      $stmt,
-    );
+      return new ASTLintError($this, 'This statement is empty', $stmt);
     }
 
     return null;
@@ -52,6 +44,7 @@ final class NoEmptyStatementsLinter
     $leading = $semicolon->getLeading();
     $trailing = $semicolon->getTrailing();
 
-    return EditableList::concat($semicolon->getLeading(), $semicolon->getTrailing());
+    return
+      EditableList::concat($semicolon->getLeading(), $semicolon->getTrailing());
   }
 }

--- a/src/Linters/NoEmptyStatementsLinter.php
+++ b/src/Linters/NoEmptyStatementsLinter.php
@@ -42,8 +42,8 @@ final class NoEmptyStatementsLinter
   }
 
   <<__Override>>
-  public function getFixedNode(ExpressionStatement $expr): EditableNode {
-    $semicolon = $expr->getSemicolonx();
+  public function getFixedNode(ExpressionStatement $stmt): EditableNode {
+    $semicolon = $stmt->getSemicolonx();
     $leading = $semicolon->getLeading();
     $trailing = $semicolon->getTrailing();
 

--- a/src/Linters/NoEmptyStatementsLinter.php
+++ b/src/Linters/NoEmptyStatementsLinter.php
@@ -1,0 +1,54 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\Linters;
+
+use type Facebook\HHAST\{
+  ExpressionStatement,
+  EditableNode,
+  EqualEqualToken,
+  EqualEqualEqualToken,
+  ExclamationEqualToken,
+  ExclamationEqualEqualToken,
+  LessThanGreaterThanToken,
+};
+use function Facebook\HHAST\Missing;
+use namespace HH\Lib\Str;
+
+final class NoEmptyStatementsLinter
+  extends AutoFixingASTLinter<ExpressionStatement> {
+  <<__Override>>
+  protected static function getTargetType(): classname<ExpressionStatement> {
+    return ExpressionStatement::class;
+  }
+
+  <<__Override>>
+  public function getLintErrorForNode(
+    ExpressionStatement $stmt,
+    vec<EditableNode> $_parents,
+  ): ?ASTLintError<ExpressionStatement> {
+
+    $expr = $stmt->getExpression();
+    if ($expr === null) {
+          return new ASTLintError(
+      $this,
+      'Delete this empty statement',
+      $stmt,
+    );
+    }
+
+    return null;
+  }
+
+  <<__Override>>
+  public function getFixedNode(ExpressionStatement $_expr): EditableNode {
+    return Missing();
+  }
+}

--- a/src/Linters/NoEmptyStatementsLinter.php
+++ b/src/Linters/NoEmptyStatementsLinter.php
@@ -33,7 +33,7 @@ final class NoEmptyStatementsLinter
     if ($expr === null) {
           return new ASTLintError(
       $this,
-      'Delete this empty statement',
+      'This statement is empty',
       $stmt,
     );
     }

--- a/src/Linters/NoEmptyStatementsLinter.php
+++ b/src/Linters/NoEmptyStatementsLinter.php
@@ -24,6 +24,11 @@ final class NoEmptyStatementsLinter
   }
 
   <<__Override>>
+  public function getTitleForFix(LintError $_): string {
+    return 'Remove statement';
+  }
+
+  <<__Override>>
   public function getLintErrorForNode(
     ExpressionStatement $stmt,
     vec<EditableNode> $_parents,

--- a/src/Linters/NoEmptyStatementsLinter.php
+++ b/src/Linters/NoEmptyStatementsLinter.php
@@ -13,14 +13,8 @@ namespace Facebook\HHAST\Linters;
 use type Facebook\HHAST\{
   ExpressionStatement,
   EditableNode,
-  EqualEqualToken,
-  EqualEqualEqualToken,
-  ExclamationEqualToken,
-  ExclamationEqualEqualToken,
-  LessThanGreaterThanToken,
+  EditableList,
 };
-use function Facebook\HHAST\Missing;
-use namespace HH\Lib\Str;
 
 final class NoEmptyStatementsLinter
   extends AutoFixingASTLinter<ExpressionStatement> {
@@ -48,7 +42,11 @@ final class NoEmptyStatementsLinter
   }
 
   <<__Override>>
-  public function getFixedNode(ExpressionStatement $_expr): EditableNode {
-    return Missing();
+  public function getFixedNode(ExpressionStatement $expr): EditableNode {
+    $semicolon = $expr->getSemicolonx();
+    $leading = $semicolon->getLeading();
+    $trailing = $semicolon->getTrailing();
+
+    return EditableList::concat($semicolon->getLeading(), $semicolon->getTrailing());
   }
 }

--- a/tests/NoEmptyStatementsLinterTest.php
+++ b/tests/NoEmptyStatementsLinterTest.php
@@ -1,0 +1,28 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class NoEmptyStatementsLinterTest extends TestCase {
+  use AutoFixingLinterTestTrait<Linters\ASTLintError<ExpressionStatement>>;
+
+  protected function getLinter(
+    string $file,
+  ): Linters\NoEmptyStatementsLinter{
+    return Linters\NoEmptyStatementsLinter::fromPath($file);
+  }
+
+  public function getCleanExamples(): array<array<string>> {
+    return [
+      ['<?hh fn_call(); '],
+      ['<?hh for(;;) { }'],
+    ];
+  }
+}

--- a/tests/NoEmptyStatementsLinterTest.php
+++ b/tests/NoEmptyStatementsLinterTest.php
@@ -13,16 +13,11 @@ namespace Facebook\HHAST;
 final class NoEmptyStatementsLinterTest extends TestCase {
   use AutoFixingLinterTestTrait<Linters\ASTLintError<ExpressionStatement>>;
 
-  protected function getLinter(
-    string $file,
-  ): Linters\NoEmptyStatementsLinter{
+  protected function getLinter(string $file): Linters\NoEmptyStatementsLinter {
     return Linters\NoEmptyStatementsLinter::fromPath($file);
   }
 
   public function getCleanExamples(): array<array<string>> {
-    return [
-      ['<?hh fn_call(); '],
-      ['<?hh for(;;) { }'],
-    ];
+    return [['<?hh fn_call(); '], ['<?hh for(;;) { }']];
   }
 }

--- a/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.autofix.expect
+++ b/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.autofix.expect
@@ -10,7 +10,15 @@
 
 function foo(): void {
   some_function();
-  
+
+
+  // leading comment
+
+
+   // trailing comment
+
+  // leading
+  /* kinda sorta looks like a statement */
 }
 
 function bar(): void {

--- a/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.autofix.expect
+++ b/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.autofix.expect
@@ -10,9 +10,8 @@
 
 function foo(): void {
   some_function();
-
+  
 }
 
 function bar(): void {
-
 }

--- a/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.autofix.expect
+++ b/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.autofix.expect
@@ -9,6 +9,10 @@
  */
 
 function foo(): void {
-  some_function();;
-  ;
+  some_function();
+
+}
+
+function bar(): void {
+
 }

--- a/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.autofix.expect
+++ b/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.autofix.expect
@@ -10,15 +10,15 @@
 
 function foo(): void {
   some_function();
-
+  
 
   // leading comment
-
+  
 
    // trailing comment
 
   // leading
-  /* kinda sorta looks like a statement */
+  /* kinda sorta looks like a statement */ 
 }
 
 function bar(): void {

--- a/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.autofix.expect
+++ b/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.autofix.expect
@@ -1,0 +1,14 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+function foo(): void {
+  some_function();;
+  ;
+}

--- a/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.expect
+++ b/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.expect
@@ -1,0 +1,12 @@
+[
+    {
+        "blame": ";\n",
+        "blame_pretty": ";\n",
+        "description": "Delete this empty statement"
+    },
+    {
+        "blame": "  ;\n",
+        "blame_pretty": "  ;\n",
+        "description": "Delete this empty statement"
+    }
+]

--- a/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.expect
+++ b/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.expect
@@ -2,16 +2,31 @@
     {
         "blame": ";\n",
         "blame_pretty": ";\n",
-        "description": "Delete this empty statement"
+        "description": "This statement is empty"
     },
     {
         "blame": "  ;\n",
         "blame_pretty": "  ;\n",
-        "description": "Delete this empty statement"
+        "description": "This statement is empty"
+    },
+    {
+        "blame": "\n  \/\/ leading comment\n  ;\n",
+        "blame_pretty": "\n  \/\/ leading comment\n  ;\n",
+        "description": "This statement is empty"
+    },
+    {
+        "blame": "\n  ; \/\/ trailing comment\n",
+        "blame_pretty": "\n  ; \/\/ trailing comment\n",
+        "description": "This statement is empty"
+    },
+    {
+        "blame": "\n  \/\/ leading\n  \/* kinda sorta looks like a statement *\/ ;\n",
+        "blame_pretty": "\n  \/\/ leading\n  \/* kinda sorta looks like a statement *\/ ;\n",
+        "description": "This statement is empty"
     },
     {
         "blame": ";\n",
         "blame_pretty": ";\n",
-        "description": "Delete this empty statement"
+        "description": "This statement is empty"
     }
 ]

--- a/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.expect
+++ b/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.expect
@@ -8,5 +8,10 @@
         "blame": "  ;\n",
         "blame_pretty": "  ;\n",
         "description": "Delete this empty statement"
+    },
+    {
+        "blame": ";\n",
+        "blame_pretty": ";\n",
+        "description": "Delete this empty statement"
     }
 ]

--- a/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.in
+++ b/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.in
@@ -1,0 +1,18 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+function foo(): void {
+  some_function();;
+  ;
+};
+
+function bar(): void {
+
+};

--- a/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.in
+++ b/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.in
@@ -14,5 +14,4 @@ function foo(): void {
 };
 
 function bar(): void {
-
-};
+}

--- a/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.in
+++ b/tests/fixtures/NoEmptyStatementsLinter/empty_statements.php.in
@@ -11,6 +11,14 @@
 function foo(): void {
   some_function();;
   ;
+
+  // leading comment
+  ;
+
+  ; // trailing comment
+
+  // leading
+  /* kinda sorta looks like a statement */ ;
 };
 
 function bar(): void {


### PR DESCRIPTION
This linter addresses #110.

I'd like input on two areas in particular:

1. The language of the error. Is there something more helpful/friendly to say than "Delete this empty statement"?
2. Whitespace management

I was unsure how much whitespace management to do in this particular linter. I think there are a few options:

- Do nothing (remove the entire expression, including leading and trailing whitespace)
- Retain all whitespace (just remove the semicolon, current implementation)
- Retain only newline whitespace

I started with do nothing. My thinking was to punt and let `hackfmt` handle reformatting. But the autofix output looked pretty bad, so I tried to retain all the leading/trailing whitespace. It looks fine but can cause other errors (e.g. trailing whitespace). Retaining only newlines feels like it _might_ be a good compromise but it might just be more finicky.

As noted in #110 this linter permits use of semicolons in `for` loops like `for (;;)`.