### PR TITLE
Add linter to convert PHP anonymous functions to lambdas

### DIFF
--- a/src/Linters/PreferLambdasLinter.php
+++ b/src/Linters/PreferLambdasLinter.php
@@ -65,25 +65,31 @@ final class PreferLambdasLinter extends AutoFixingASTLinter<AnonymousFunction> {
 
   <<__Override>>
   public function getFixedNode(AnonymousFunction $node): ?EditableNode {
-    $attribute_spec = $node->getAttributeSpecUNTYPED();
-    $async = $node->getAsyncKeywordUNTYPED();
-    $coroutine = $node->getCoroutineKeywordUNTYPED();
+    $attribute_spec = $node->getAttributeSpec();
+    $async = $node->getAsyncKeyword();
+    $coroutine = $node->getCoroutineKeyword();
+    $parameters = $node->getParameters();
     $left_paren =
       new LeftParenToken($node->getFunctionKeyword()->getLeading(), Missing());
+    $right_paren = $node->getRightParen();
+    $colon = $node->getColon();
+    $type = $node->getType();
+
     $signature = new LambdaSignature(
       $left_paren,
-      $node->getParametersUNTYPED(),
-      $node->getRightParenUNTYPED(),
-      Missing(),
-      Missing(),
+      $parameters ?? Missing(),
+      $right_paren ?? Missing(),
+      $colon ?? Missing(),
+      $type ?? Missing(),
     );
+
     $arrow = new EqualEqualGreaterThanToken(Missing(), new WhiteSpace(' '));
-    $body = $node->getBody();
+		$body = $node->getBody();
 
     return new LambdaExpression(
-      $attribute_spec,
-      $async,
-      $coroutine,
+      $attribute_spec ?? Missing(),
+      $async ?? Missing(),
+      $coroutine ?? Missing(),
       $signature,
       $arrow,
       $body,

--- a/src/Linters/PreferLambdasLinter.php
+++ b/src/Linters/PreferLambdasLinter.php
@@ -1,0 +1,92 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\Linters;
+
+use type Facebook\HHAST\Linters\{ASTLintError, AutoFixingASTLinter};
+use type Facebook\HHAST\{
+  AmpersandToken,
+  AnonymousFunction,
+  EditableNode,
+  EqualEqualGreaterThanToken,
+  LambdaExpression,
+  LambdaSignature,
+  LeftParenToken,
+  PrefixUnaryExpression,
+  WhiteSpace,
+};
+use function Facebook\HHAST\Missing;
+use namespace HH\Lib\C;
+
+final class PreferLambdasLinter extends AutoFixingASTLinter<AnonymousFunction> {
+  <<__Override>>
+  protected static function getTargetType(): classname<AnonymousFunction> {
+    return AnonymousFunction::class;
+  }
+
+  <<__Override>>
+  protected function getTitleForFix(LintError $_): string {
+    return 'Convert to lambda';
+  }
+
+  <<__Override>>
+  public function getLintErrorForNode(
+    AnonymousFunction $node,
+    vec<EditableNode> $parents,
+  ): ?ASTLintError<AnonymousFunction> {
+
+    $use_expr = $node->getUse();
+
+    $uses_references = $use_expr is nonnull &&
+      !C\is_empty(
+        $use_expr->getDescendantsWhere(
+          ($node, $_) ==> $node is PrefixUnaryExpression &&
+            $node->getOperator() is AmpersandToken,
+        ),
+      );
+
+    if ($uses_references) {
+      return null;
+    } else {
+      return new ASTLintError(
+        $this,
+        'Use lambdas instead of PHP anonymous functions',
+        $node,
+      );
+    }
+  }
+
+  <<__Override>>
+  public function getFixedNode(AnonymousFunction $node): ?EditableNode {
+    $attribute_spec = $node->getAttributeSpecUNTYPED();
+    $async = $node->getAsyncKeywordUNTYPED();
+    $coroutine = $node->getCoroutineKeywordUNTYPED();
+    $left_paren =
+      new LeftParenToken($node->getFunctionKeyword()->getLeading(), Missing());
+    $signature = new LambdaSignature(
+      $left_paren,
+      $node->getParametersUNTYPED(),
+      $node->getRightParenUNTYPED(),
+      Missing(),
+      Missing(),
+    );
+    $arrow = new EqualEqualGreaterThanToken(Missing(), new WhiteSpace(' '));
+    $body = $node->getBody();
+
+    return new LambdaExpression(
+      $attribute_spec,
+      $async,
+      $coroutine,
+      $signature,
+      $arrow,
+      $body,
+    );
+  }
+}

--- a/src/Linters/PreferLambdasLinter.php
+++ b/src/Linters/PreferLambdasLinter.php
@@ -39,7 +39,7 @@ final class PreferLambdasLinter extends AutoFixingASTLinter<AnonymousFunction> {
   <<__Override>>
   public function getLintErrorForNode(
     AnonymousFunction $node,
-    vec<EditableNode> $parents,
+    vec<EditableNode> $_parents,
   ): ?ASTLintError<AnonymousFunction> {
 
     $use_expr = $node->getUse();
@@ -54,13 +54,13 @@ final class PreferLambdasLinter extends AutoFixingASTLinter<AnonymousFunction> {
 
     if ($uses_references) {
       return null;
-    } else {
-      return new ASTLintError(
-        $this,
-        'Use lambdas instead of PHP anonymous functions',
-        $node,
-      );
     }
+
+    return new ASTLintError(
+      $this,
+      'Use lambdas instead of PHP anonymous functions',
+      $node,
+    );
   }
 
   <<__Override>>
@@ -84,7 +84,7 @@ final class PreferLambdasLinter extends AutoFixingASTLinter<AnonymousFunction> {
     );
 
     $arrow = new EqualEqualGreaterThanToken(Missing(), new WhiteSpace(' '));
-		$body = $node->getBody();
+    $body = $node->getBody();
 
     return new LambdaExpression(
       $attribute_spec ?? Missing(),

--- a/tests/PreferLambdasLinterTest.php
+++ b/tests/PreferLambdasLinterTest.php
@@ -1,0 +1,20 @@
+<?hh // strict
+
+namespace Facebook\HHAST;
+
+use type Facebook\HHAST\AnonymousFunction;
+
+final class PreferLambdasLinterTest extends TestCase {
+  use AutoFixingLinterTestTrait<Linters\ASTLintError<AnonymousFunction>>;
+
+  protected function getLinter(string $file): Linters\PreferLambdasLinter {
+    return Linters\PreferLambdasLinter::fromPath($file);
+  }
+
+  public function getCleanExamples(): array<array<string>> {
+    return [
+      ['<?hh $fn = () ==> 5; '],
+      ['<?hh $fn = ($a, $b) ==> { return $a === $b; }'],
+    ];
+  }
+}

--- a/tests/PreferLambdasLinterTest.php
+++ b/tests/PreferLambdasLinterTest.php
@@ -1,4 +1,13 @@
 <?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
 
 namespace Facebook\HHAST;
 

--- a/tests/fixtures/PreferLambdasLinter/prefer_lambdas.php.autofix.expect
+++ b/tests/fixtures/PreferLambdasLinter/prefer_lambdas.php.autofix.expect
@@ -16,7 +16,9 @@ function test_anon(): void {
 		do_something();
 	};
 
-	$f4 = ($a, $b) ==> {
+	$f4 = (int $a): int ==> { return $a * $a; };
+
+	$f5 = ($a, $b) ==> {
 		do_something();
 	};
 

--- a/tests/fixtures/PreferLambdasLinter/prefer_lambdas.php.autofix.expect
+++ b/tests/fixtures/PreferLambdasLinter/prefer_lambdas.php.autofix.expect
@@ -1,0 +1,29 @@
+<?hh
+
+function test_anon(): void {
+
+	$outer = [];
+
+	$f1 = ($a, $b) ==> {
+		do_something();
+	};
+
+	$f2 = ($a, $b) ==> {
+		do_something();
+	};
+
+	$f3 = function($a, $b) use (&$outer) {
+		do_something();
+	};
+
+	$f4 = ($a, $b) ==> {
+		do_something();
+	};
+
+  it(
+    'formats numbers as strings',
+        () ==> {
+          do_something();
+        }
+  );
+}

--- a/tests/fixtures/PreferLambdasLinter/prefer_lambdas.php.expect
+++ b/tests/fixtures/PreferLambdasLinter/prefer_lambdas.php.expect
@@ -1,0 +1,17 @@
+[
+    {
+        "blame": "function($a, $b) {\n\t\tdo_something();\n\t}",
+        "blame_pretty": "function($a, $b) {\n\t\tdo_something();\n\t}",
+        "description": "Use lambdas instead of PHP anonymous functions"
+    },
+    {
+        "blame": "function($a, $b) use ($outer) {\n\t\tdo_something();\n\t}",
+        "blame_pretty": "function($a, $b) use ($outer) {\n\t\tdo_something();\n\t}",
+        "description": "Use lambdas instead of PHP anonymous functions"
+    },
+    {
+        "blame": "        function() {\n          do_something();\n        }\n",
+        "blame_pretty": "        function() {\n          do_something();\n        }\n",
+        "description": "Use lambdas instead of PHP anonymous functions"
+    }
+]

--- a/tests/fixtures/PreferLambdasLinter/prefer_lambdas.php.expect
+++ b/tests/fixtures/PreferLambdasLinter/prefer_lambdas.php.expect
@@ -10,6 +10,11 @@
         "description": "Use lambdas instead of PHP anonymous functions"
     },
     {
+        "blame": "function(int $a): int { return $a * $a; }",
+        "blame_pretty": "function(int $a): int { return $a * $a; }",
+        "description": "Use lambdas instead of PHP anonymous functions"
+    },
+    {
         "blame": "        function() {\n          do_something();\n        }\n",
         "blame_pretty": "        function() {\n          do_something();\n        }\n",
         "description": "Use lambdas instead of PHP anonymous functions"

--- a/tests/fixtures/PreferLambdasLinter/prefer_lambdas.php.in
+++ b/tests/fixtures/PreferLambdasLinter/prefer_lambdas.php.in
@@ -16,7 +16,9 @@ function test_anon(): void {
 		do_something();
 	};
 
-	$f4 = ($a, $b) ==> {
+	$f4 = function(int $a): int { return $a * $a; };
+
+	$f5 = ($a, $b) ==> {
 		do_something();
 	};
 

--- a/tests/fixtures/PreferLambdasLinter/prefer_lambdas.php.in
+++ b/tests/fixtures/PreferLambdasLinter/prefer_lambdas.php.in
@@ -1,0 +1,29 @@
+<?hh
+
+function test_anon(): void {
+
+	$outer = [];
+
+	$f1 = function($a, $b) {
+		do_something();
+	};
+
+	$f2 = function($a, $b) use ($outer) {
+		do_something();
+	};
+
+	$f3 = function($a, $b) use (&$outer) {
+		do_something();
+	};
+
+	$f4 = ($a, $b) ==> {
+		do_something();
+	};
+
+  it(
+    'formats numbers as strings',
+        function() {
+          do_something();
+        }
+  );
+}


### PR DESCRIPTION
This change adds an autofixing linter that converts [PHP anonymous functions](http://php.net/manual/en/functions.anonymous.php) to [Hack lambdas](https://docs.hhvm.com/hack/lambdas/introduction). It does not fix anonymous functions that use variables by reference which have no equivalent lambda.

In my implementation of `getFixedNode` I am not sure if there is a better approach to copying the child nodes from the anonymous function to the lambda expression. I use `?? Missing()` extensively; any suggestions for a better approach are very welcome.

A future improvement which I did not implement here would be to examine the body of the anonymous function and, if it returns the result of a single expression, rewrite body to drop the curly braces, return keyword, and semicolon.

Specifically:

```Hack
$fn = function($i) { return $i * $i; };

// currently becomes
$fn = ($i) ==> { return $i * $i; };

// an improvement would be
$fn = ($i) ==> $i * $i;
```