### PR TITLE
Fix generated @return docblock

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ We develop HHAST purely on GitHub, and welcome pull requests.
    correctly implemented in the hand-written base classes. If you need to
    extend any of these, **do not modify them directly** - instead, edit the
    code that generates them in `src/__Private/codegen/`, and run
-   `bin/update-codegen.php`.
+   `bin/update-codegen`.
  - the linter framework
  - the migration framework
 

--- a/codegen/syntax/AliasDeclaration.php
+++ b/codegen/syntax/AliasDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<085f2f59dc3f208a6e641ee96cb2698e>>
+ * @generated SignedSource<<a1f0b89a8b0fbc1763cacfe591e2c18a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -194,7 +194,7 @@ final class AliasDeclaration extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification | Missing
+   * @return AttributeSpecification | null
    */
   public function getAttributeSpec(): ?AttributeSpecification {
     if ($this->_attribute_spec->isMissing()) {
@@ -207,7 +207,7 @@ final class AliasDeclaration extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification
+   * @return AttributeSpecification
    */
   public function getAttributeSpecx(): AttributeSpecification {
     return TypeAssert\instance_of(
@@ -241,14 +241,14 @@ final class AliasDeclaration extends EditableNode {
   }
 
   /**
-   * @returns NewtypeToken | TypeToken
+   * @return NewtypeToken | TypeToken
    */
   public function getKeyword(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_keyword);
   }
 
   /**
-   * @returns NewtypeToken | TypeToken
+   * @return NewtypeToken | TypeToken
    */
   public function getKeywordx(): EditableToken {
     return $this->getKeyword();
@@ -279,14 +279,14 @@ final class AliasDeclaration extends EditableNode {
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getNamex(): NameToken {
     return $this->getName();
@@ -317,7 +317,7 @@ final class AliasDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | TypeParameters
+   * @return null | TypeParameters
    */
   public function getGenericParameter(): ?TypeParameters {
     if ($this->_generic_parameter->isMissing()) {
@@ -328,7 +328,7 @@ final class AliasDeclaration extends EditableNode {
   }
 
   /**
-   * @returns TypeParameters
+   * @return TypeParameters
    */
   public function getGenericParameterx(): TypeParameters {
     return
@@ -360,7 +360,7 @@ final class AliasDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | TypeConstraint
+   * @return null | TypeConstraint
    */
   public function getConstraint(): ?TypeConstraint {
     if ($this->_constraint->isMissing()) {
@@ -370,7 +370,7 @@ final class AliasDeclaration extends EditableNode {
   }
 
   /**
-   * @returns TypeConstraint
+   * @return TypeConstraint
    */
   public function getConstraintx(): TypeConstraint {
     return TypeAssert\instance_of(TypeConstraint::class, $this->_constraint);
@@ -401,14 +401,14 @@ final class AliasDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EqualToken
+   * @return EqualToken
    */
   public function getEqual(): EqualToken {
     return TypeAssert\instance_of(EqualToken::class, $this->_equal);
   }
 
   /**
-   * @returns EqualToken
+   * @return EqualToken
    */
   public function getEqualx(): EqualToken {
     return $this->getEqual();
@@ -439,7 +439,7 @@ final class AliasDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | DictionaryTypeSpecifier |
+   * @return ClosureTypeSpecifier | DictionaryTypeSpecifier |
    * GenericTypeSpecifier | KeysetTypeSpecifier | MapArrayTypeSpecifier |
    * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
    * TupleTypeSpecifier | VectorArrayTypeSpecifier | VectorTypeSpecifier
@@ -449,7 +449,7 @@ final class AliasDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | DictionaryTypeSpecifier |
+   * @return ClosureTypeSpecifier | DictionaryTypeSpecifier |
    * GenericTypeSpecifier | KeysetTypeSpecifier | MapArrayTypeSpecifier |
    * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
    * TupleTypeSpecifier | VectorArrayTypeSpecifier | VectorTypeSpecifier
@@ -483,14 +483,14 @@ final class AliasDeclaration extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/AlternateElseClause.php
+++ b/codegen/syntax/AlternateElseClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<846f33fdb6dcb443eb58237a067ff5b9>>
+ * @generated SignedSource<<0584a02f7feae8f1c89b78af82cf0f93>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -103,14 +103,14 @@ final class AlternateElseClause
   }
 
   /**
-   * @returns ElseToken
+   * @return ElseToken
    */
   public function getKeyword(): ElseToken {
     return TypeAssert\instance_of(ElseToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ElseToken
+   * @return ElseToken
    */
   public function getKeywordx(): ElseToken {
     return $this->getKeyword();
@@ -132,14 +132,14 @@ final class AlternateElseClause
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColon(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColonx(): ColonToken {
     return $this->getColon();
@@ -161,14 +161,14 @@ final class AlternateElseClause
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getStatement(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_statement);
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getStatementx(): EditableList<EditableNode> {
     return $this->getStatement();

--- a/codegen/syntax/AlternateElseifClause.php
+++ b/codegen/syntax/AlternateElseifClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<08f603ed0afa963da9ea3e5dbcd7f9dd>>
+ * @generated SignedSource<<51c625f0a4f326cb519cbe6810d2fac0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -163,14 +163,14 @@ final class AlternateElseifClause
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getKeyword(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_keyword);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getKeywordx(): EditableNode {
     return $this->getKeyword();
@@ -199,14 +199,14 @@ final class AlternateElseifClause
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getLeftParen(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_paren);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getLeftParenx(): EditableNode {
     return $this->getLeftParen();
@@ -235,14 +235,14 @@ final class AlternateElseifClause
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getCondition(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_condition);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getConditionx(): EditableNode {
     return $this->getCondition();
@@ -271,14 +271,14 @@ final class AlternateElseifClause
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getRightParen(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_paren);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getRightParenx(): EditableNode {
     return $this->getRightParen();
@@ -307,14 +307,14 @@ final class AlternateElseifClause
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getColon(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_colon);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getColonx(): EditableNode {
     return $this->getColon();
@@ -343,14 +343,14 @@ final class AlternateElseifClause
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getStatement(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_statement);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getStatementx(): EditableNode {
     return $this->getStatement();

--- a/codegen/syntax/AlternateIfStatement.php
+++ b/codegen/syntax/AlternateIfStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5e3a2a17d865e8210130a9a5525fd2fd>>
+ * @generated SignedSource<<98a6c2f20c31e8729507c3524979c3f4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -225,14 +225,14 @@ final class AlternateIfStatement extends EditableNode {
   }
 
   /**
-   * @returns IfToken
+   * @return IfToken
    */
   public function getKeyword(): IfToken {
     return TypeAssert\instance_of(IfToken::class, $this->_keyword);
   }
 
   /**
-   * @returns IfToken
+   * @return IfToken
    */
   public function getKeywordx(): IfToken {
     return $this->getKeyword();
@@ -265,14 +265,14 @@ final class AlternateIfStatement extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -305,14 +305,14 @@ final class AlternateIfStatement extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression | LiteralExpression | VariableExpression
+   * @return BinaryExpression | LiteralExpression | VariableExpression
    */
   public function getCondition(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_condition);
   }
 
   /**
-   * @returns BinaryExpression | LiteralExpression | VariableExpression
+   * @return BinaryExpression | LiteralExpression | VariableExpression
    */
   public function getConditionx(): EditableNode {
     return $this->getCondition();
@@ -345,14 +345,14 @@ final class AlternateIfStatement extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -385,14 +385,14 @@ final class AlternateIfStatement extends EditableNode {
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColon(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColonx(): ColonToken {
     return $this->getColon();
@@ -425,14 +425,14 @@ final class AlternateIfStatement extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getStatement(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_statement);
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getStatementx(): EditableList<EditableNode> {
     return $this->getStatement();
@@ -465,7 +465,7 @@ final class AlternateIfStatement extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getElseifClauses(): ?EditableNode {
     if ($this->_elseif_clauses->isMissing()) {
@@ -475,7 +475,7 @@ final class AlternateIfStatement extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getElseifClausesx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_elseif_clauses);
@@ -508,7 +508,7 @@ final class AlternateIfStatement extends EditableNode {
   }
 
   /**
-   * @returns AlternateElseClause | Missing
+   * @return AlternateElseClause | null
    */
   public function getElseClause(): ?AlternateElseClause {
     if ($this->_else_clause->isMissing()) {
@@ -519,7 +519,7 @@ final class AlternateIfStatement extends EditableNode {
   }
 
   /**
-   * @returns AlternateElseClause
+   * @return AlternateElseClause
    */
   public function getElseClausex(): AlternateElseClause {
     return
@@ -553,14 +553,14 @@ final class AlternateIfStatement extends EditableNode {
   }
 
   /**
-   * @returns EndifToken
+   * @return EndifToken
    */
   public function getEndifKeyword(): EndifToken {
     return TypeAssert\instance_of(EndifToken::class, $this->_endif_keyword);
   }
 
   /**
-   * @returns EndifToken
+   * @return EndifToken
    */
   public function getEndifKeywordx(): EndifToken {
     return $this->getEndifKeyword();
@@ -593,14 +593,14 @@ final class AlternateIfStatement extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/AlternateLoopStatement.php
+++ b/codegen/syntax/AlternateLoopStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1821d54b9310e323be7d5b5ed47f6a28>>
+ * @generated SignedSource<<835fecc817f2f53f05449eb8fd15fb3f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -132,14 +132,14 @@ abstract class AlternateLoopStatementGeneratedBase
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getOpeningColon(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_opening_colon);
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getOpeningColonx(): ColonToken {
     return $this->getOpeningColon();
@@ -166,14 +166,14 @@ abstract class AlternateLoopStatementGeneratedBase
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getStatements(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_statements);
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getStatementsx(): EditableList<EditableNode> {
     return $this->getStatements();
@@ -200,7 +200,7 @@ abstract class AlternateLoopStatementGeneratedBase
   }
 
   /**
-   * @returns EnddeclareToken | EndforToken | EndforeachToken | EndwhileToken
+   * @return EnddeclareToken | EndforToken | EndforeachToken | EndwhileToken
    */
   public function getClosingKeyword(): EditableToken {
     return
@@ -208,7 +208,7 @@ abstract class AlternateLoopStatementGeneratedBase
   }
 
   /**
-   * @returns EnddeclareToken | EndforToken | EndforeachToken | EndwhileToken
+   * @return EnddeclareToken | EndforToken | EndforeachToken | EndwhileToken
    */
   public function getClosingKeywordx(): EditableToken {
     return $this->getClosingKeyword();
@@ -235,7 +235,7 @@ abstract class AlternateLoopStatementGeneratedBase
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getClosingSemicolon(): SemicolonToken {
     return
@@ -243,7 +243,7 @@ abstract class AlternateLoopStatementGeneratedBase
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getClosingSemicolonx(): SemicolonToken {
     return $this->getClosingSemicolon();

--- a/codegen/syntax/AlternateSwitchStatement.php
+++ b/codegen/syntax/AlternateSwitchStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a073e58fc9be4ce9ad1d168407923894>>
+ * @generated SignedSource<<d9227437a1e57dd1601da1e476d2a91a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -197,14 +197,14 @@ final class AlternateSwitchStatement
   }
 
   /**
-   * @returns SwitchToken
+   * @return SwitchToken
    */
   public function getKeyword(): SwitchToken {
     return TypeAssert\instance_of(SwitchToken::class, $this->_keyword);
   }
 
   /**
-   * @returns SwitchToken
+   * @return SwitchToken
    */
   public function getKeywordx(): SwitchToken {
     return $this->getKeyword();
@@ -235,14 +235,14 @@ final class AlternateSwitchStatement
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -273,14 +273,14 @@ final class AlternateSwitchStatement
   }
 
   /**
-   * @returns LiteralExpression | VariableExpression
+   * @return LiteralExpression | VariableExpression
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
   /**
-   * @returns LiteralExpression | VariableExpression
+   * @return LiteralExpression | VariableExpression
    */
   public function getExpressionx(): EditableNode {
     return $this->getExpression();
@@ -311,14 +311,14 @@ final class AlternateSwitchStatement
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -349,14 +349,14 @@ final class AlternateSwitchStatement
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getOpeningColon(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_opening_colon);
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getOpeningColonx(): ColonToken {
     return $this->getOpeningColon();
@@ -387,14 +387,14 @@ final class AlternateSwitchStatement
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getSections(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_sections);
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getSectionsx(): EditableList<EditableNode> {
     return $this->getSections();
@@ -425,7 +425,7 @@ final class AlternateSwitchStatement
   }
 
   /**
-   * @returns EndswitchToken
+   * @return EndswitchToken
    */
   public function getClosingEndswitch(): EndswitchToken {
     return
@@ -433,7 +433,7 @@ final class AlternateSwitchStatement
   }
 
   /**
-   * @returns EndswitchToken
+   * @return EndswitchToken
    */
   public function getClosingEndswitchx(): EndswitchToken {
     return $this->getClosingEndswitch();
@@ -464,7 +464,7 @@ final class AlternateSwitchStatement
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getClosingSemicolon(): SemicolonToken {
     return
@@ -472,7 +472,7 @@ final class AlternateSwitchStatement
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getClosingSemicolonx(): SemicolonToken {
     return $this->getClosingSemicolon();

--- a/codegen/syntax/AnonymousClass.php
+++ b/codegen/syntax/AnonymousClass.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e23cd1006b2aa3976bc1adb4e6171895>>
+ * @generated SignedSource<<533a10eaae1a3979d443a0b51fc556ee>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -210,14 +210,14 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns ClassToken
+   * @return ClassToken
    */
   public function getClassKeyword(): ClassToken {
     return TypeAssert\instance_of(ClassToken::class, $this->_class_keyword);
   }
 
   /**
-   * @returns ClassToken
+   * @return ClassToken
    */
   public function getClassKeywordx(): ClassToken {
     return $this->getClassKeyword();
@@ -249,7 +249,7 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns Missing | LeftParenToken
+   * @return null | LeftParenToken
    */
   public function getLeftParen(): ?LeftParenToken {
     if ($this->_left_paren->isMissing()) {
@@ -259,7 +259,7 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
@@ -291,9 +291,9 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns EditableList<AnonymousFunction> | EditableList<LiteralExpression>
+   * @return EditableList<AnonymousFunction> | EditableList<LiteralExpression>
    * | EditableList<MemberSelectionExpression> |
-   * EditableList<VariableExpression> | Missing
+   * EditableList<VariableExpression> | null
    */
   public function getArgumentList(): ?EditableList<EditableNode> {
     if ($this->_argument_list->isMissing()) {
@@ -303,7 +303,7 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns EditableList<AnonymousFunction> | EditableList<LiteralExpression>
+   * @return EditableList<AnonymousFunction> | EditableList<LiteralExpression>
    * | EditableList<MemberSelectionExpression> |
    * EditableList<VariableExpression>
    */
@@ -337,7 +337,7 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns Missing | RightParenToken
+   * @return null | RightParenToken
    */
   public function getRightParen(): ?RightParenToken {
     if ($this->_right_paren->isMissing()) {
@@ -347,7 +347,7 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
@@ -379,7 +379,7 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns Missing | ExtendsToken
+   * @return null | ExtendsToken
    */
   public function getExtendsKeyword(): ?ExtendsToken {
     if ($this->_extends_keyword->isMissing()) {
@@ -389,7 +389,7 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns ExtendsToken
+   * @return ExtendsToken
    */
   public function getExtendsKeywordx(): ExtendsToken {
     return TypeAssert\instance_of(ExtendsToken::class, $this->_extends_keyword);
@@ -421,7 +421,7 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns EditableList<SimpleTypeSpecifier> | Missing
+   * @return EditableList<SimpleTypeSpecifier> | null
    */
   public function getExtendsList(): ?EditableList<SimpleTypeSpecifier> {
     if ($this->_extends_list->isMissing()) {
@@ -431,7 +431,7 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns EditableList<SimpleTypeSpecifier>
+   * @return EditableList<SimpleTypeSpecifier>
    */
   public function getExtendsListx(): EditableList<SimpleTypeSpecifier> {
     return TypeAssert\instance_of(EditableList::class, $this->_extends_list);
@@ -463,7 +463,7 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns Missing | ImplementsToken
+   * @return null | ImplementsToken
    */
   public function getImplementsKeyword(): ?ImplementsToken {
     if ($this->_implements_keyword->isMissing()) {
@@ -476,7 +476,7 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns ImplementsToken
+   * @return ImplementsToken
    */
   public function getImplementsKeywordx(): ImplementsToken {
     return TypeAssert\instance_of(
@@ -511,7 +511,7 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns EditableList<SimpleTypeSpecifier> | Missing
+   * @return EditableList<SimpleTypeSpecifier> | null
    */
   public function getImplementsList(): ?EditableList<SimpleTypeSpecifier> {
     if ($this->_implements_list->isMissing()) {
@@ -521,7 +521,7 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns EditableList<SimpleTypeSpecifier>
+   * @return EditableList<SimpleTypeSpecifier>
    */
   public function getImplementsListx(): EditableList<SimpleTypeSpecifier> {
     return TypeAssert\instance_of(EditableList::class, $this->_implements_list);
@@ -553,14 +553,14 @@ final class AnonymousClass extends EditableNode {
   }
 
   /**
-   * @returns ClassishBody
+   * @return ClassishBody
    */
   public function getBody(): ClassishBody {
     return TypeAssert\instance_of(ClassishBody::class, $this->_body);
   }
 
   /**
-   * @returns ClassishBody
+   * @return ClassishBody
    */
   public function getBodyx(): ClassishBody {
     return $this->getBody();

--- a/codegen/syntax/AnonymousFunction.php
+++ b/codegen/syntax/AnonymousFunction.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<33a0af6e527da45e1c245749475abf4c>>
+ * @generated SignedSource<<41fd2b5beef4da0fd89c3e7fd9c7a93a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -274,7 +274,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification | Missing
+   * @return AttributeSpecification | null
    */
   public function getAttributeSpec(): ?AttributeSpecification {
     if ($this->_attribute_spec->isMissing()) {
@@ -287,7 +287,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification
+   * @return AttributeSpecification
    */
   public function getAttributeSpecx(): AttributeSpecification {
     return TypeAssert\instance_of(
@@ -326,7 +326,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing | StaticToken
+   * @return null | StaticToken
    */
   public function getStaticKeyword(): ?StaticToken {
     if ($this->_static_keyword->isMissing()) {
@@ -336,7 +336,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns StaticToken
+   * @return StaticToken
    */
   public function getStaticKeywordx(): StaticToken {
     return TypeAssert\instance_of(StaticToken::class, $this->_static_keyword);
@@ -372,7 +372,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing | AsyncToken
+   * @return null | AsyncToken
    */
   public function getAsyncKeyword(): ?AsyncToken {
     if ($this->_async_keyword->isMissing()) {
@@ -382,7 +382,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns AsyncToken
+   * @return AsyncToken
    */
   public function getAsyncKeywordx(): AsyncToken {
     return TypeAssert\instance_of(AsyncToken::class, $this->_async_keyword);
@@ -418,7 +418,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing | CoroutineToken
+   * @return null | CoroutineToken
    */
   public function getCoroutineKeyword(): ?CoroutineToken {
     if ($this->_coroutine_keyword->isMissing()) {
@@ -429,7 +429,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns CoroutineToken
+   * @return CoroutineToken
    */
   public function getCoroutineKeywordx(): CoroutineToken {
     return
@@ -466,7 +466,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns FunctionToken
+   * @return FunctionToken
    */
   public function getFunctionKeyword(): FunctionToken {
     return
@@ -474,7 +474,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns FunctionToken
+   * @return FunctionToken
    */
   public function getFunctionKeywordx(): FunctionToken {
     return $this->getFunctionKeyword();
@@ -510,7 +510,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing | AmpersandToken
+   * @return null | AmpersandToken
    */
   public function getAmpersand(): ?AmpersandToken {
     if ($this->_ampersand->isMissing()) {
@@ -520,7 +520,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns AmpersandToken
+   * @return AmpersandToken
    */
   public function getAmpersandx(): AmpersandToken {
     return TypeAssert\instance_of(AmpersandToken::class, $this->_ampersand);
@@ -556,7 +556,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing | LeftParenToken
+   * @return null | LeftParenToken
    */
   public function getLeftParen(): ?LeftParenToken {
     if ($this->_left_paren->isMissing()) {
@@ -566,7 +566,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
@@ -602,8 +602,8 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ParameterDeclaration> |
-   * EditableList<VariadicParameter> | Missing
+   * @return EditableList<ParameterDeclaration> |
+   * EditableList<VariadicParameter> | null
    */
   public function getParameters(): ?EditableList<EditableNode> {
     if ($this->_parameters->isMissing()) {
@@ -613,7 +613,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ParameterDeclaration> |
+   * @return EditableList<ParameterDeclaration> |
    * EditableList<VariadicParameter>
    */
   public function getParametersx(): EditableList<EditableNode> {
@@ -650,7 +650,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing | RightParenToken
+   * @return null | RightParenToken
    */
   public function getRightParen(): ?RightParenToken {
     if ($this->_right_paren->isMissing()) {
@@ -660,7 +660,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
@@ -696,7 +696,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing | ColonToken
+   * @return null | ColonToken
    */
   public function getColon(): ?ColonToken {
     if ($this->_colon->isMissing()) {
@@ -706,7 +706,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColonx(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
@@ -742,10 +742,9 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | GenericTypeSpecifier |
-   * MapArrayTypeSpecifier | Missing | NullableTypeSpecifier |
-   * SimpleTypeSpecifier | SoftTypeSpecifier | TupleTypeSpecifier |
-   * VectorArrayTypeSpecifier
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier |
+   * MapArrayTypeSpecifier | null | NullableTypeSpecifier | SimpleTypeSpecifier
+   * | SoftTypeSpecifier | TupleTypeSpecifier | VectorArrayTypeSpecifier
    */
   public function getType(): ?EditableNode {
     if ($this->_type->isMissing()) {
@@ -755,7 +754,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | GenericTypeSpecifier |
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier |
    * MapArrayTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier |
    * SoftTypeSpecifier | TupleTypeSpecifier | VectorArrayTypeSpecifier
    */
@@ -793,7 +792,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunctionUseClause | Missing
+   * @return AnonymousFunctionUseClause | null
    */
   public function getUse(): ?AnonymousFunctionUseClause {
     if ($this->_use->isMissing()) {
@@ -804,7 +803,7 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunctionUseClause
+   * @return AnonymousFunctionUseClause
    */
   public function getUsex(): AnonymousFunctionUseClause {
     return
@@ -841,14 +840,14 @@ final class AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getBody(): CompoundStatement {
     return TypeAssert\instance_of(CompoundStatement::class, $this->_body);
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getBodyx(): CompoundStatement {
     return $this->getBody();

--- a/codegen/syntax/AnonymousFunctionUseClause.php
+++ b/codegen/syntax/AnonymousFunctionUseClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fa070672841864ae51658fb9a864e620>>
+ * @generated SignedSource<<ba18fb829b459e0c5b2cd42c2aab4c35>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class AnonymousFunctionUseClause extends EditableNode {
   }
 
   /**
-   * @returns UseToken
+   * @return UseToken
    */
   public function getKeyword(): UseToken {
     return TypeAssert\instance_of(UseToken::class, $this->_keyword);
   }
 
   /**
-   * @returns UseToken
+   * @return UseToken
    */
   public function getKeywordx(): UseToken {
     return $this->getKeyword();
@@ -153,14 +153,14 @@ final class AnonymousFunctionUseClause extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -187,18 +187,16 @@ final class AnonymousFunctionUseClause extends EditableNode {
   }
 
   /**
-   * @returns EditableList<?VariableToken> |
-   * EditableList<PrefixUnaryExpression> | EditableList<EditableNode> |
-   * EditableList<VariableToken>
+   * @return EditableList<?VariableToken> | EditableList<PrefixUnaryExpression>
+   * | EditableList<EditableNode> | EditableList<VariableToken>
    */
   public function getVariables(): EditableList<?EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_variables);
   }
 
   /**
-   * @returns EditableList<?VariableToken> |
-   * EditableList<PrefixUnaryExpression> | EditableList<EditableNode> |
-   * EditableList<VariableToken>
+   * @return EditableList<?VariableToken> | EditableList<PrefixUnaryExpression>
+   * | EditableList<EditableNode> | EditableList<VariableToken>
    */
   public function getVariablesx(): EditableList<?EditableNode> {
     return $this->getVariables();
@@ -225,14 +223,14 @@ final class AnonymousFunctionUseClause extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();

--- a/codegen/syntax/ArrayCreationExpression.php
+++ b/codegen/syntax/ArrayCreationExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e6bae27989fc692c92fea69759970a1f>>
+ * @generated SignedSource<<f5fb0079b4d56dfa30164e7c65a0d39e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,7 +101,7 @@ final class ArrayCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBracketToken
+   * @return LeftBracketToken
    */
   public function getLeftBracket(): LeftBracketToken {
     return
@@ -109,7 +109,7 @@ final class ArrayCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBracketToken
+   * @return LeftBracketToken
    */
   public function getLeftBracketx(): LeftBracketToken {
     return $this->getLeftBracket();
@@ -131,10 +131,9 @@ final class ArrayCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> |
-   * EditableList<ArrayCreationExpression> |
-   * EditableList<ArrayIntrinsicExpression> | EditableList<BinaryExpression> |
-   * EditableList<ConditionalExpression> |
+   * @return EditableList<EditableNode> | EditableList<ArrayCreationExpression>
+   * | EditableList<ArrayIntrinsicExpression> | EditableList<BinaryExpression>
+   * | EditableList<ConditionalExpression> |
    * EditableList<DictionaryIntrinsicExpression> |
    * EditableList<ElementInitializer> | EditableList<FunctionCallExpression> |
    * EditableList<KeysetIntrinsicExpression> | EditableList<LiteralExpression>
@@ -143,7 +142,7 @@ final class ArrayCreationExpression extends EditableNode {
    * EditableList<ScopeResolutionExpression> |
    * EditableList<SubscriptExpression> | EditableList<NameToken> |
    * EditableList<VariableExpression> | EditableList<VarrayIntrinsicExpression>
-   * | EditableList<VectorIntrinsicExpression> | Missing
+   * | EditableList<VectorIntrinsicExpression> | null
    */
   public function getMembers(): ?EditableList<EditableNode> {
     if ($this->_members->isMissing()) {
@@ -153,10 +152,9 @@ final class ArrayCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> |
-   * EditableList<ArrayCreationExpression> |
-   * EditableList<ArrayIntrinsicExpression> | EditableList<BinaryExpression> |
-   * EditableList<ConditionalExpression> |
+   * @return EditableList<EditableNode> | EditableList<ArrayCreationExpression>
+   * | EditableList<ArrayIntrinsicExpression> | EditableList<BinaryExpression>
+   * | EditableList<ConditionalExpression> |
    * EditableList<DictionaryIntrinsicExpression> |
    * EditableList<ElementInitializer> | EditableList<FunctionCallExpression> |
    * EditableList<KeysetIntrinsicExpression> | EditableList<LiteralExpression>
@@ -187,7 +185,7 @@ final class ArrayCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBracketToken
+   * @return RightBracketToken
    */
   public function getRightBracket(): RightBracketToken {
     return
@@ -195,7 +193,7 @@ final class ArrayCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBracketToken
+   * @return RightBracketToken
    */
   public function getRightBracketx(): RightBracketToken {
     return $this->getRightBracket();

--- a/codegen/syntax/ArrayIntrinsicExpression.php
+++ b/codegen/syntax/ArrayIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<88837a7a4fe65ff619ac7df60ef13a6c>>
+ * @generated SignedSource<<0ee682553a15543d8b54011a4ec58008>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class ArrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayToken
+   * @return ArrayToken
    */
   public function getKeyword(): ArrayToken {
     return TypeAssert\instance_of(ArrayToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ArrayToken
+   * @return ArrayToken
    */
   public function getKeywordx(): ArrayToken {
     return $this->getKeyword();
@@ -149,14 +149,14 @@ final class ArrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -183,7 +183,7 @@ final class ArrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<AnonymousFunction> | EditableList<EditableNode> |
+   * @return EditableList<AnonymousFunction> | EditableList<EditableNode> |
    * EditableList<ArrayCreationExpression> |
    * EditableList<ArrayIntrinsicExpression> |
    * EditableList<AwaitableCreationExpression> | EditableList<BinaryExpression>
@@ -196,7 +196,7 @@ final class ArrayIntrinsicExpression extends EditableNode {
    * EditableList<ScopeResolutionExpression> |
    * EditableList<SubscriptExpression> | EditableList<NameToken> |
    * EditableList<TupleExpression> | EditableList<VariableExpression> |
-   * EditableList<VectorIntrinsicExpression> | Missing
+   * EditableList<VectorIntrinsicExpression> | null
    */
   public function getMembers(): ?EditableList<EditableNode> {
     if ($this->_members->isMissing()) {
@@ -206,7 +206,7 @@ final class ArrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<AnonymousFunction> | EditableList<EditableNode> |
+   * @return EditableList<AnonymousFunction> | EditableList<EditableNode> |
    * EditableList<ArrayCreationExpression> |
    * EditableList<ArrayIntrinsicExpression> |
    * EditableList<AwaitableCreationExpression> | EditableList<BinaryExpression>
@@ -242,14 +242,14 @@ final class ArrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();

--- a/codegen/syntax/AsExpression.php
+++ b/codegen/syntax/AsExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e05d4226981212e53431ec93caf6b83b>>
+ * @generated SignedSource<<9ac68ca67791f161dec5ac97480099ec>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,7 +101,7 @@ final class AsExpression extends EditableNode {
   }
 
   /**
-   * @returns CollectionLiteralExpression | LiteralExpression |
+   * @return CollectionLiteralExpression | LiteralExpression |
    * MemberSelectionExpression | ParenthesizedExpression | TupleExpression |
    * VariableExpression
    */
@@ -110,7 +110,7 @@ final class AsExpression extends EditableNode {
   }
 
   /**
-   * @returns CollectionLiteralExpression | LiteralExpression |
+   * @return CollectionLiteralExpression | LiteralExpression |
    * MemberSelectionExpression | ParenthesizedExpression | TupleExpression |
    * VariableExpression
    */
@@ -134,14 +134,14 @@ final class AsExpression extends EditableNode {
   }
 
   /**
-   * @returns AsToken
+   * @return AsToken
    */
   public function getOperator(): AsToken {
     return TypeAssert\instance_of(AsToken::class, $this->_operator);
   }
 
   /**
-   * @returns AsToken
+   * @return AsToken
    */
   public function getOperatorx(): AsToken {
     return $this->getOperator();
@@ -163,7 +163,7 @@ final class AsExpression extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | NullableTypeSpecifier | ShapeTypeSpecifier
+   * @return ClosureTypeSpecifier | NullableTypeSpecifier | ShapeTypeSpecifier
    * | SimpleTypeSpecifier | SoftTypeSpecifier | TupleTypeSpecifier
    */
   public function getRightOperand(): EditableNode {
@@ -171,7 +171,7 @@ final class AsExpression extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | NullableTypeSpecifier | ShapeTypeSpecifier
+   * @return ClosureTypeSpecifier | NullableTypeSpecifier | ShapeTypeSpecifier
    * | SimpleTypeSpecifier | SoftTypeSpecifier | TupleTypeSpecifier
    */
   public function getRightOperandx(): EditableNode {

--- a/codegen/syntax/AttributeSpecification.php
+++ b/codegen/syntax/AttributeSpecification.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<788e028220e7bc547187924bad033165>>
+ * @generated SignedSource<<214db37529f9031cb77d1df3f215aad3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -103,7 +103,7 @@ final class AttributeSpecification extends EditableNode {
   }
 
   /**
-   * @returns LessThanLessThanToken
+   * @return LessThanLessThanToken
    */
   public function getLeftDoubleAngle(): LessThanLessThanToken {
     return TypeAssert\instance_of(
@@ -113,7 +113,7 @@ final class AttributeSpecification extends EditableNode {
   }
 
   /**
-   * @returns LessThanLessThanToken
+   * @return LessThanLessThanToken
    */
   public function getLeftDoubleAnglex(): LessThanLessThanToken {
     return $this->getLeftDoubleAngle();
@@ -136,14 +136,14 @@ final class AttributeSpecification extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ConstructorCall>
+   * @return EditableList<ConstructorCall>
    */
   public function getAttributes(): EditableList<ConstructorCall> {
     return TypeAssert\instance_of(EditableList::class, $this->_attributes);
   }
 
   /**
-   * @returns EditableList<ConstructorCall>
+   * @return EditableList<ConstructorCall>
    */
   public function getAttributesx(): EditableList<ConstructorCall> {
     return $this->getAttributes();
@@ -165,7 +165,7 @@ final class AttributeSpecification extends EditableNode {
   }
 
   /**
-   * @returns GreaterThanGreaterThanToken
+   * @return GreaterThanGreaterThanToken
    */
   public function getRightDoubleAngle(): GreaterThanGreaterThanToken {
     return TypeAssert\instance_of(
@@ -175,7 +175,7 @@ final class AttributeSpecification extends EditableNode {
   }
 
   /**
-   * @returns GreaterThanGreaterThanToken
+   * @return GreaterThanGreaterThanToken
    */
   public function getRightDoubleAnglex(): GreaterThanGreaterThanToken {
     return $this->getRightDoubleAngle();

--- a/codegen/syntax/AwaitableCreationExpression.php
+++ b/codegen/syntax/AwaitableCreationExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<953198e3455abc447403ead911f5ebf5>>
+ * @generated SignedSource<<7c7e5c101c44d4c7fc7745f31f60384d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -120,7 +120,7 @@ final class AwaitableCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification | Missing
+   * @return AttributeSpecification | null
    */
   public function getAttributeSpec(): ?AttributeSpecification {
     if ($this->_attribute_spec->isMissing()) {
@@ -133,7 +133,7 @@ final class AwaitableCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification
+   * @return AttributeSpecification
    */
   public function getAttributeSpecx(): AttributeSpecification {
     return TypeAssert\instance_of(
@@ -163,14 +163,14 @@ final class AwaitableCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns AsyncToken
+   * @return AsyncToken
    */
   public function getAsync(): AsyncToken {
     return TypeAssert\instance_of(AsyncToken::class, $this->_async);
   }
 
   /**
-   * @returns AsyncToken
+   * @return AsyncToken
    */
   public function getAsyncx(): AsyncToken {
     return $this->getAsync();
@@ -197,7 +197,7 @@ final class AwaitableCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getCoroutine(): ?EditableNode {
     if ($this->_coroutine->isMissing()) {
@@ -207,7 +207,7 @@ final class AwaitableCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getCoroutinex(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_coroutine);
@@ -234,7 +234,7 @@ final class AwaitableCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getCompoundStatement(): CompoundStatement {
     return TypeAssert\instance_of(
@@ -244,7 +244,7 @@ final class AwaitableCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getCompoundStatementx(): CompoundStatement {
     return $this->getCompoundStatement();

--- a/codegen/syntax/BinaryExpression.php
+++ b/codegen/syntax/BinaryExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4b64b7c045c3c5337ac53972b559cff1>>
+ * @generated SignedSource<<10101db005d6ba65bd0f3d62a89e5a68>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,7 +101,7 @@ final class BinaryExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
    * CollectionLiteralExpression | DarrayIntrinsicExpression |
    * DictionaryIntrinsicExpression | EmptyExpression | FunctionCallExpression |
@@ -118,7 +118,7 @@ final class BinaryExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
    * CollectionLiteralExpression | DarrayIntrinsicExpression |
    * DictionaryIntrinsicExpression | EmptyExpression | FunctionCallExpression |
@@ -150,7 +150,7 @@ final class BinaryExpression extends EditableNode {
   }
 
   /**
-   * @returns ExclamationEqualToken | ExclamationEqualEqualToken | PercentToken
+   * @return ExclamationEqualToken | ExclamationEqualEqualToken | PercentToken
    * | PercentEqualToken | AmpersandToken | AmpersandAmpersandToken |
    * AmpersandEqualToken | StarToken | StarStarToken | StarStarEqualToken |
    * StarEqualToken | PlusToken | PlusEqualToken | MinusToken | MinusEqualToken
@@ -169,7 +169,7 @@ final class BinaryExpression extends EditableNode {
   }
 
   /**
-   * @returns ExclamationEqualToken | ExclamationEqualEqualToken | PercentToken
+   * @return ExclamationEqualToken | ExclamationEqualEqualToken | PercentToken
    * | PercentEqualToken | AmpersandToken | AmpersandAmpersandToken |
    * AmpersandEqualToken | StarToken | StarStarToken | StarStarEqualToken |
    * StarEqualToken | PlusToken | PlusEqualToken | MinusToken | MinusEqualToken
@@ -203,7 +203,7 @@ final class BinaryExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | AsExpression | AwaitableCreationExpression |
    * BinaryExpression | CastExpression | CollectionLiteralExpression |
    * ConditionalExpression | DarrayIntrinsicExpression |
@@ -211,7 +211,7 @@ final class BinaryExpression extends EditableNode {
    * FunctionCallExpression | FunctionCallWithTypeArgumentsExpression |
    * InclusionExpression | InstanceofExpression | IssetExpression |
    * KeysetIntrinsicExpression | LambdaExpression | LiteralExpression |
-   * MemberSelectionExpression | Missing | NullableAsExpression |
+   * MemberSelectionExpression | null | NullableAsExpression |
    * ObjectCreationExpression | ParenthesizedExpression | Php7AnonymousFunction
    * | PipeVariableExpression | PostfixUnaryExpression | PrefixUnaryExpression
    * | PrefixedStringExpression | QualifiedName | SafeMemberSelectionExpression
@@ -229,7 +229,7 @@ final class BinaryExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | AsExpression | AwaitableCreationExpression |
    * BinaryExpression | CastExpression | CollectionLiteralExpression |
    * ConditionalExpression | DarrayIntrinsicExpression |

--- a/codegen/syntax/BracedExpression.php
+++ b/codegen/syntax/BracedExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d721cf3e9f35390d6bc895256e6b0fd8>>
+ * @generated SignedSource<<5c20de49a506c79e0807dede9d644310>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class BracedExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBracex(): LeftBraceToken {
     return $this->getLeftBrace();
@@ -130,7 +130,7 @@ final class BracedExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayIntrinsicExpression | BinaryExpression |
+   * @return ArrayIntrinsicExpression | BinaryExpression |
    * CollectionLiteralExpression | FunctionCallExpression | LiteralExpression |
    * MemberSelectionExpression | ObjectCreationExpression |
    * PrefixUnaryExpression | SubscriptExpression | NameToken |
@@ -141,7 +141,7 @@ final class BracedExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayIntrinsicExpression | BinaryExpression |
+   * @return ArrayIntrinsicExpression | BinaryExpression |
    * CollectionLiteralExpression | FunctionCallExpression | LiteralExpression |
    * MemberSelectionExpression | ObjectCreationExpression |
    * PrefixUnaryExpression | SubscriptExpression | NameToken |
@@ -167,14 +167,14 @@ final class BracedExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBrace(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBracex(): RightBraceToken {
     return $this->getRightBrace();

--- a/codegen/syntax/BreakStatement.php
+++ b/codegen/syntax/BreakStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b061253e00bf5cad5fd6f6e1da4e0a38>>
+ * @generated SignedSource<<773041621a96ba09d56ab30f584c764b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class BreakStatement extends EditableNode {
   }
 
   /**
-   * @returns BreakToken
+   * @return BreakToken
    */
   public function getKeyword(): BreakToken {
     return TypeAssert\instance_of(BreakToken::class, $this->_keyword);
   }
 
   /**
-   * @returns BreakToken
+   * @return BreakToken
    */
   public function getKeywordx(): BreakToken {
     return $this->getKeyword();
@@ -130,7 +130,7 @@ final class BreakStatement extends EditableNode {
   }
 
   /**
-   * @returns LiteralExpression | Missing | VariableExpression
+   * @return LiteralExpression | null | VariableExpression
    */
   public function getLevel(): ?EditableNode {
     if ($this->_level->isMissing()) {
@@ -140,7 +140,7 @@ final class BreakStatement extends EditableNode {
   }
 
   /**
-   * @returns LiteralExpression | VariableExpression
+   * @return LiteralExpression | VariableExpression
    */
   public function getLevelx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_level);
@@ -162,14 +162,14 @@ final class BreakStatement extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/CaseLabel.php
+++ b/codegen/syntax/CaseLabel.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<95ba351dd1e2416868685f615e77dcfc>>
+ * @generated SignedSource<<d6429e2d2e4ea340d943df67da267e02>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class CaseLabel extends EditableNode {
   }
 
   /**
-   * @returns CaseToken
+   * @return CaseToken
    */
   public function getKeyword(): CaseToken {
     return TypeAssert\instance_of(CaseToken::class, $this->_keyword);
   }
 
   /**
-   * @returns CaseToken
+   * @return CaseToken
    */
   public function getKeywordx(): CaseToken {
     return $this->getKeyword();
@@ -130,7 +130,7 @@ final class CaseLabel extends EditableNode {
   }
 
   /**
-   * @returns ArrayIntrinsicExpression | FunctionCallExpression |
+   * @return ArrayIntrinsicExpression | FunctionCallExpression |
    * InstanceofExpression | LiteralExpression | PrefixUnaryExpression |
    * ScopeResolutionExpression | NameToken | VariableExpression
    */
@@ -139,7 +139,7 @@ final class CaseLabel extends EditableNode {
   }
 
   /**
-   * @returns ArrayIntrinsicExpression | FunctionCallExpression |
+   * @return ArrayIntrinsicExpression | FunctionCallExpression |
    * InstanceofExpression | LiteralExpression | PrefixUnaryExpression |
    * ScopeResolutionExpression | NameToken | VariableExpression
    */
@@ -163,14 +163,14 @@ final class CaseLabel extends EditableNode {
   }
 
   /**
-   * @returns ColonToken | SemicolonToken
+   * @return ColonToken | SemicolonToken
    */
   public function getColon(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_colon);
   }
 
   /**
-   * @returns ColonToken | SemicolonToken
+   * @return ColonToken | SemicolonToken
    */
   public function getColonx(): EditableToken {
     return $this->getColon();

--- a/codegen/syntax/CastExpression.php
+++ b/codegen/syntax/CastExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8dd5f2ff611b1a1199460338933e50e7>>
+ * @generated SignedSource<<0ed095491a801c76fe51654bc971303a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -115,14 +115,14 @@ final class CastExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -149,7 +149,7 @@ final class CastExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayToken | BinaryToken | BoolToken | BooleanToken | DoubleToken
+   * @return ArrayToken | BinaryToken | BoolToken | BooleanToken | DoubleToken
    * | FloatToken | IntToken | IntegerToken | ObjectToken | RealToken |
    * StringToken | UnsetToken
    */
@@ -158,7 +158,7 @@ final class CastExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayToken | BinaryToken | BoolToken | BooleanToken | DoubleToken
+   * @return ArrayToken | BinaryToken | BoolToken | BooleanToken | DoubleToken
    * | FloatToken | IntToken | IntegerToken | ObjectToken | RealToken |
    * StringToken | UnsetToken
    */
@@ -183,14 +183,14 @@ final class CastExpression extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -213,7 +213,7 @@ final class CastExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | CastExpression | CollectionLiteralExpression |
    * DictionaryIntrinsicExpression | FunctionCallExpression |
    * KeysetIntrinsicExpression | LiteralExpression | MemberSelectionExpression
@@ -227,7 +227,7 @@ final class CastExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | CastExpression | CollectionLiteralExpression |
    * DictionaryIntrinsicExpression | FunctionCallExpression |
    * KeysetIntrinsicExpression | LiteralExpression | MemberSelectionExpression

--- a/codegen/syntax/CatchClause.php
+++ b/codegen/syntax/CatchClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ae1d40e2b7663fe4182e53b402438c36>>
+ * @generated SignedSource<<d8b43da312eac551c768266e1e7f94f0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -149,14 +149,14 @@ final class CatchClause extends EditableNode {
   }
 
   /**
-   * @returns CatchToken
+   * @return CatchToken
    */
   public function getKeyword(): CatchToken {
     return TypeAssert\instance_of(CatchToken::class, $this->_keyword);
   }
 
   /**
-   * @returns CatchToken
+   * @return CatchToken
    */
   public function getKeywordx(): CatchToken {
     return $this->getKeyword();
@@ -185,14 +185,14 @@ final class CatchClause extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -221,14 +221,14 @@ final class CatchClause extends EditableNode {
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getType(): SimpleTypeSpecifier {
     return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_type);
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getTypex(): SimpleTypeSpecifier {
     return $this->getType();
@@ -257,14 +257,14 @@ final class CatchClause extends EditableNode {
   }
 
   /**
-   * @returns NameToken | VariableToken
+   * @return NameToken | VariableToken
    */
   public function getVariable(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_variable);
   }
 
   /**
-   * @returns NameToken | VariableToken
+   * @return NameToken | VariableToken
    */
   public function getVariablex(): EditableToken {
     return $this->getVariable();
@@ -293,14 +293,14 @@ final class CatchClause extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -329,14 +329,14 @@ final class CatchClause extends EditableNode {
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getBody(): CompoundStatement {
     return TypeAssert\instance_of(CompoundStatement::class, $this->_body);
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getBodyx(): CompoundStatement {
     return $this->getBody();

--- a/codegen/syntax/ClassishBody.php
+++ b/codegen/syntax/ClassishBody.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<68219344482a251921750b67ce37dc97>>
+ * @generated SignedSource<<0be4e52e4b826ddb71272eff78086ccc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class ClassishBody extends EditableNode {
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBracex(): LeftBraceToken {
     return $this->getLeftBrace();
@@ -130,7 +130,7 @@ final class ClassishBody extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getElements(): ?EditableList<EditableNode> {
     if ($this->_elements->isMissing()) {
@@ -140,7 +140,7 @@ final class ClassishBody extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getElementsx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_elements);
@@ -162,7 +162,7 @@ final class ClassishBody extends EditableNode {
   }
 
   /**
-   * @returns Missing | RightBraceToken
+   * @return null | RightBraceToken
    */
   public function getRightBrace(): ?RightBraceToken {
     if ($this->_right_brace->isMissing()) {
@@ -172,7 +172,7 @@ final class ClassishBody extends EditableNode {
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBracex(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);

--- a/codegen/syntax/ClassishDeclaration.php
+++ b/codegen/syntax/ClassishDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bcde4a847b5a6e1b449fa0f938891284>>
+ * @generated SignedSource<<901c107bc071d13812c4d72218a26804>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -226,7 +226,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification | Missing
+   * @return AttributeSpecification | null
    */
   public function getAttribute(): ?AttributeSpecification {
     if ($this->_attribute->isMissing()) {
@@ -237,7 +237,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification
+   * @return AttributeSpecification
    */
   public function getAttributex(): AttributeSpecification {
     return
@@ -271,7 +271,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getModifiers(): ?EditableList<EditableNode> {
     if ($this->_modifiers->isMissing()) {
@@ -281,7 +281,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getModifiersx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_modifiers);
@@ -314,14 +314,14 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ClassToken | InterfaceToken | TraitToken
+   * @return ClassToken | InterfaceToken | TraitToken
    */
   public function getKeyword(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ClassToken | InterfaceToken | TraitToken
+   * @return ClassToken | InterfaceToken | TraitToken
    */
   public function getKeywordx(): EditableToken {
     return $this->getKeyword();
@@ -354,7 +354,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | XHPClassNameToken | NameToken
+   * @return null | XHPClassNameToken | NameToken
    */
   public function getName(): ?EditableToken {
     if ($this->_name->isMissing()) {
@@ -364,7 +364,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns XHPClassNameToken | NameToken
+   * @return XHPClassNameToken | NameToken
    */
   public function getNamex(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_name);
@@ -397,7 +397,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | TypeParameters
+   * @return null | TypeParameters
    */
   public function getTypeParameters(): ?TypeParameters {
     if ($this->_type_parameters->isMissing()) {
@@ -408,7 +408,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns TypeParameters
+   * @return TypeParameters
    */
   public function getTypeParametersx(): TypeParameters {
     return
@@ -442,7 +442,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | ExtendsToken
+   * @return null | ExtendsToken
    */
   public function getExtendsKeyword(): ?ExtendsToken {
     if ($this->_extends_keyword->isMissing()) {
@@ -452,7 +452,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ExtendsToken
+   * @return ExtendsToken
    */
   public function getExtendsKeywordx(): ExtendsToken {
     return TypeAssert\instance_of(ExtendsToken::class, $this->_extends_keyword);
@@ -485,8 +485,8 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
-   * EditableList<?EditableNode> | EditableList<SimpleTypeSpecifier> | Missing
+   * @return EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
+   * EditableList<?EditableNode> | EditableList<SimpleTypeSpecifier> | null
    */
   public function getExtendsList(): ?EditableList<?EditableNode> {
     if ($this->_extends_list->isMissing()) {
@@ -496,7 +496,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
+   * @return EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
    * EditableList<?EditableNode> | EditableList<SimpleTypeSpecifier>
    */
   public function getExtendsListx(): EditableList<?EditableNode> {
@@ -530,7 +530,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | ImplementsToken
+   * @return null | ImplementsToken
    */
   public function getImplementsKeyword(): ?ImplementsToken {
     if ($this->_implements_keyword->isMissing()) {
@@ -543,7 +543,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ImplementsToken
+   * @return ImplementsToken
    */
   public function getImplementsKeywordx(): ImplementsToken {
     return TypeAssert\instance_of(
@@ -579,8 +579,8 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
-   * EditableList<?EditableNode> | EditableList<SimpleTypeSpecifier> | Missing
+   * @return EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
+   * EditableList<?EditableNode> | EditableList<SimpleTypeSpecifier> | null
    */
   public function getImplementsList(): ?EditableList<?EditableNode> {
     if ($this->_implements_list->isMissing()) {
@@ -590,7 +590,7 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
+   * @return EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
    * EditableList<?EditableNode> | EditableList<SimpleTypeSpecifier>
    */
   public function getImplementsListx(): EditableList<?EditableNode> {
@@ -624,14 +624,14 @@ final class ClassishDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ClassishBody
+   * @return ClassishBody
    */
   public function getBody(): ClassishBody {
     return TypeAssert\instance_of(ClassishBody::class, $this->_body);
   }
 
   /**
-   * @returns ClassishBody
+   * @return ClassishBody
    */
   public function getBodyx(): ClassishBody {
     return $this->getBody();

--- a/codegen/syntax/ClassnameTypeSpecifier.php
+++ b/codegen/syntax/ClassnameTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<08bafd7156dbde9c1d1dba0412da4800>>
+ * @generated SignedSource<<83303bc03f7ceb53bc99a3144833d0e1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -135,14 +135,14 @@ final class ClassnameTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ClassnameToken
+   * @return ClassnameToken
    */
   public function getKeyword(): ClassnameToken {
     return TypeAssert\instance_of(ClassnameToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ClassnameToken
+   * @return ClassnameToken
    */
   public function getKeywordx(): ClassnameToken {
     return $this->getKeyword();
@@ -170,7 +170,7 @@ final class ClassnameTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns Missing | LessThanToken
+   * @return null | LessThanToken
    */
   public function getLeftAngle(): ?LessThanToken {
     if ($this->_left_angle->isMissing()) {
@@ -180,7 +180,7 @@ final class ClassnameTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAnglex(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
@@ -208,7 +208,7 @@ final class ClassnameTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns Missing | SimpleTypeSpecifier | TypeConstant
+   * @return null | SimpleTypeSpecifier | TypeConstant
    */
   public function getType(): ?EditableNode {
     if ($this->_type->isMissing()) {
@@ -218,7 +218,7 @@ final class ClassnameTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns SimpleTypeSpecifier | TypeConstant
+   * @return SimpleTypeSpecifier | TypeConstant
    */
   public function getTypex(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
@@ -246,7 +246,7 @@ final class ClassnameTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getTrailingComma(): ?EditableNode {
     if ($this->_trailing_comma->isMissing()) {
@@ -256,7 +256,7 @@ final class ClassnameTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getTrailingCommax(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_trailing_comma);
@@ -284,7 +284,7 @@ final class ClassnameTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns Missing | GreaterThanToken
+   * @return null | GreaterThanToken
    */
   public function getRightAngle(): ?GreaterThanToken {
     if ($this->_right_angle->isMissing()) {
@@ -294,7 +294,7 @@ final class ClassnameTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAnglex(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);

--- a/codegen/syntax/ClosureParameterTypeSpecifier.php
+++ b/codegen/syntax/ClosureParameterTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a4ab78d71700014e147c44ec6c1d44ee>>
+ * @generated SignedSource<<6ec29544b823cff8da2fcf41b8d5f5cf>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -87,7 +87,7 @@ final class ClosureParameterTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns Missing | InoutToken
+   * @return null | InoutToken
    */
   public function getCallConvention(): ?InoutToken {
     if ($this->_call_convention->isMissing()) {
@@ -97,7 +97,7 @@ final class ClosureParameterTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns InoutToken
+   * @return InoutToken
    */
   public function getCallConventionx(): InoutToken {
     return TypeAssert\instance_of(InoutToken::class, $this->_call_convention);
@@ -119,16 +119,16 @@ final class ClosureParameterTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns GenericTypeSpecifier | NullableTypeSpecifier |
-   * SimpleTypeSpecifier | SoftTypeSpecifier | TupleTypeSpecifier | TypeConstant
+   * @return GenericTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier
+   * | SoftTypeSpecifier | TupleTypeSpecifier | TypeConstant
    */
   public function getType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
   }
 
   /**
-   * @returns GenericTypeSpecifier | NullableTypeSpecifier |
-   * SimpleTypeSpecifier | SoftTypeSpecifier | TupleTypeSpecifier | TypeConstant
+   * @return GenericTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier
+   * | SoftTypeSpecifier | TupleTypeSpecifier | TypeConstant
    */
   public function getTypex(): EditableNode {
     return $this->getType();

--- a/codegen/syntax/ClosureTypeSpecifier.php
+++ b/codegen/syntax/ClosureTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<da7ced607a32ed2292d73594362d2d70>>
+ * @generated SignedSource<<576bd85595d21d1fa0126c1c7678178b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -211,7 +211,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getOuterLeftParen(): LeftParenToken {
     return
@@ -219,7 +219,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getOuterLeftParenx(): LeftParenToken {
     return $this->getOuterLeftParen();
@@ -251,7 +251,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns Missing | CoroutineToken
+   * @return null | CoroutineToken
    */
   public function getCoroutine(): ?CoroutineToken {
     if ($this->_coroutine->isMissing()) {
@@ -261,7 +261,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns CoroutineToken
+   * @return CoroutineToken
    */
   public function getCoroutinex(): CoroutineToken {
     return TypeAssert\instance_of(CoroutineToken::class, $this->_coroutine);
@@ -293,7 +293,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns FunctionToken
+   * @return FunctionToken
    */
   public function getFunctionKeyword(): FunctionToken {
     return
@@ -301,7 +301,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns FunctionToken
+   * @return FunctionToken
    */
   public function getFunctionKeywordx(): FunctionToken {
     return $this->getFunctionKeyword();
@@ -333,7 +333,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getInnerLeftParen(): LeftParenToken {
     return
@@ -341,7 +341,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getInnerLeftParenx(): LeftParenToken {
     return $this->getInnerLeftParen();
@@ -373,8 +373,8 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ClosureParameterTypeSpecifier> |
-   * EditableList<EditableNode> | EditableList<VariadicParameter> | Missing
+   * @return EditableList<ClosureParameterTypeSpecifier> |
+   * EditableList<EditableNode> | EditableList<VariadicParameter> | null
    */
   public function getParameterList(): ?EditableList<EditableNode> {
     if ($this->_parameter_list->isMissing()) {
@@ -384,7 +384,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ClosureParameterTypeSpecifier> |
+   * @return EditableList<ClosureParameterTypeSpecifier> |
    * EditableList<EditableNode> | EditableList<VariadicParameter>
    */
   public function getParameterListx(): EditableList<EditableNode> {
@@ -417,7 +417,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getInnerRightParen(): RightParenToken {
     return
@@ -425,7 +425,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getInnerRightParenx(): RightParenToken {
     return $this->getInnerRightParen();
@@ -457,14 +457,14 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColon(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColonx(): ColonToken {
     return $this->getColon();
@@ -496,7 +496,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | GenericTypeSpecifier |
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier |
    * NullableTypeSpecifier | SimpleTypeSpecifier
    */
   public function getReturnType(): EditableNode {
@@ -504,7 +504,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | GenericTypeSpecifier |
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier |
    * NullableTypeSpecifier | SimpleTypeSpecifier
    */
   public function getReturnTypex(): EditableNode {
@@ -537,7 +537,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getOuterRightParen(): RightParenToken {
     return
@@ -545,7 +545,7 @@ final class ClosureTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getOuterRightParenx(): RightParenToken {
     return $this->getOuterRightParen();

--- a/codegen/syntax/CollectionLiteralExpression.php
+++ b/codegen/syntax/CollectionLiteralExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bc0120c7c77717491e53d4ec6ab0febb>>
+ * @generated SignedSource<<94062507b53eb88fc5914b3afaa162a5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class CollectionLiteralExpression extends EditableNode {
   }
 
   /**
-   * @returns GenericTypeSpecifier | SimpleTypeSpecifier
+   * @return GenericTypeSpecifier | SimpleTypeSpecifier
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
   }
 
   /**
-   * @returns GenericTypeSpecifier | SimpleTypeSpecifier
+   * @return GenericTypeSpecifier | SimpleTypeSpecifier
    */
   public function getNamex(): EditableNode {
     return $this->getName();
@@ -153,14 +153,14 @@ final class CollectionLiteralExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBracex(): LeftBraceToken {
     return $this->getLeftBrace();
@@ -183,7 +183,7 @@ final class CollectionLiteralExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<AnonymousFunction> |
+   * @return EditableList<AnonymousFunction> |
    * EditableList<ArrayCreationExpression> |
    * EditableList<ArrayIntrinsicExpression> | EditableList<EditableNode> |
    * EditableList<CastExpression> | EditableList<CollectionLiteralExpression> |
@@ -194,7 +194,7 @@ final class CollectionLiteralExpression extends EditableNode {
    * EditableList<SubscriptExpression> | EditableList<EditableToken> |
    * EditableList<NameToken> | EditableList<ReturnToken> |
    * EditableList<TupleExpression> | EditableList<VariableExpression> |
-   * EditableList<VarrayIntrinsicExpression> | Missing
+   * EditableList<VarrayIntrinsicExpression> | null
    */
   public function getInitializers(): ?EditableList<EditableNode> {
     if ($this->_initializers->isMissing()) {
@@ -204,7 +204,7 @@ final class CollectionLiteralExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<AnonymousFunction> |
+   * @return EditableList<AnonymousFunction> |
    * EditableList<ArrayCreationExpression> |
    * EditableList<ArrayIntrinsicExpression> | EditableList<EditableNode> |
    * EditableList<CastExpression> | EditableList<CollectionLiteralExpression> |
@@ -242,7 +242,7 @@ final class CollectionLiteralExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing | RightBraceToken
+   * @return null | RightBraceToken
    */
   public function getRightBrace(): ?RightBraceToken {
     if ($this->_right_brace->isMissing()) {
@@ -252,7 +252,7 @@ final class CollectionLiteralExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBracex(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);

--- a/codegen/syntax/CompoundStatement.php
+++ b/codegen/syntax/CompoundStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4caceb0289c9b4de2b2b2eff836686ee>>
+ * @generated SignedSource<<c8db016422db3175f719df37e9cd4cb2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,7 +101,7 @@ final class CompoundStatement extends EditableNode {
   }
 
   /**
-   * @returns Missing | LeftBraceToken
+   * @return null | LeftBraceToken
    */
   public function getLeftBrace(): ?LeftBraceToken {
     if ($this->_left_brace->isMissing()) {
@@ -111,7 +111,7 @@ final class CompoundStatement extends EditableNode {
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBracex(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
@@ -133,7 +133,7 @@ final class CompoundStatement extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getStatements(): ?EditableList<EditableNode> {
     if ($this->_statements->isMissing()) {
@@ -143,7 +143,7 @@ final class CompoundStatement extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getStatementsx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_statements);
@@ -165,7 +165,7 @@ final class CompoundStatement extends EditableNode {
   }
 
   /**
-   * @returns Missing | RightBraceToken
+   * @return null | RightBraceToken
    */
   public function getRightBrace(): ?RightBraceToken {
     if ($this->_right_brace->isMissing()) {
@@ -175,7 +175,7 @@ final class CompoundStatement extends EditableNode {
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBracex(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);

--- a/codegen/syntax/ConditionalExpression.php
+++ b/codegen/syntax/ConditionalExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e1a664961e0c7f2a0a56f83257c46396>>
+ * @generated SignedSource<<067757043b4fa6bccf306ea5268184c2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -133,7 +133,7 @@ final class ConditionalExpression extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression | ConditionalExpression | EmptyExpression |
+   * @return BinaryExpression | ConditionalExpression | EmptyExpression |
    * FunctionCallExpression | InstanceofExpression | IsExpression |
    * IssetExpression | LiteralExpression | MemberSelectionExpression |
    * ParenthesizedExpression | PipeVariableExpression | PrefixUnaryExpression |
@@ -145,7 +145,7 @@ final class ConditionalExpression extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression | ConditionalExpression | EmptyExpression |
+   * @return BinaryExpression | ConditionalExpression | EmptyExpression |
    * FunctionCallExpression | InstanceofExpression | IsExpression |
    * IssetExpression | LiteralExpression | MemberSelectionExpression |
    * ParenthesizedExpression | PipeVariableExpression | PrefixUnaryExpression |
@@ -178,14 +178,14 @@ final class ConditionalExpression extends EditableNode {
   }
 
   /**
-   * @returns QuestionToken
+   * @return QuestionToken
    */
   public function getQuestion(): QuestionToken {
     return TypeAssert\instance_of(QuestionToken::class, $this->_question);
   }
 
   /**
-   * @returns QuestionToken
+   * @return QuestionToken
    */
   public function getQuestionx(): QuestionToken {
     return $this->getQuestion();
@@ -213,10 +213,10 @@ final class ConditionalExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayCreationExpression | ArrayIntrinsicExpression |
+   * @return ArrayCreationExpression | ArrayIntrinsicExpression |
    * BinaryExpression | CastExpression | CollectionLiteralExpression |
    * FunctionCallExpression | LambdaExpression | LiteralExpression |
-   * MemberSelectionExpression | Missing | ObjectCreationExpression |
+   * MemberSelectionExpression | null | ObjectCreationExpression |
    * ParenthesizedExpression | PrefixUnaryExpression |
    * ScopeResolutionExpression | SubscriptExpression | NameToken |
    * VariableExpression
@@ -229,7 +229,7 @@ final class ConditionalExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayCreationExpression | ArrayIntrinsicExpression |
+   * @return ArrayCreationExpression | ArrayIntrinsicExpression |
    * BinaryExpression | CastExpression | CollectionLiteralExpression |
    * FunctionCallExpression | LambdaExpression | LiteralExpression |
    * MemberSelectionExpression | ObjectCreationExpression |
@@ -263,7 +263,7 @@ final class ConditionalExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing | ColonToken
+   * @return null | ColonToken
    */
   public function getColon(): ?ColonToken {
     if ($this->_colon->isMissing()) {
@@ -273,7 +273,7 @@ final class ConditionalExpression extends EditableNode {
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColonx(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
@@ -301,13 +301,13 @@ final class ConditionalExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
    * CollectionLiteralExpression | FunctionCallExpression | IssetExpression |
-   * LambdaExpression | LiteralExpression | MemberSelectionExpression | Missing
-   * | ObjectCreationExpression | ParenthesizedExpression |
-   * PrefixUnaryExpression | ScopeResolutionExpression | SubscriptExpression |
-   * NameToken | UseToken | TupleExpression | VariableExpression
+   * LambdaExpression | LiteralExpression | MemberSelectionExpression | null |
+   * ObjectCreationExpression | ParenthesizedExpression | PrefixUnaryExpression
+   * | ScopeResolutionExpression | SubscriptExpression | NameToken | UseToken |
+   * TupleExpression | VariableExpression
    */
   public function getAlternative(): ?EditableNode {
     if ($this->_alternative->isMissing()) {
@@ -317,7 +317,7 @@ final class ConditionalExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
    * CollectionLiteralExpression | FunctionCallExpression | IssetExpression |
    * LambdaExpression | LiteralExpression | MemberSelectionExpression |

--- a/codegen/syntax/ConstDeclaration.php
+++ b/codegen/syntax/ConstDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7bac61816aedcf7555487832714eea69>>
+ * @generated SignedSource<<61fe992e6c4737e61515503ff70bb915>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -161,7 +161,7 @@ final class ConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | ProtectedToken | PublicToken
+   * @return null | ProtectedToken | PublicToken
    */
   public function getVisibility(): ?EditableToken {
     if ($this->_visibility->isMissing()) {
@@ -171,7 +171,7 @@ final class ConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ProtectedToken | PublicToken
+   * @return ProtectedToken | PublicToken
    */
   public function getVisibilityx(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_visibility);
@@ -200,7 +200,7 @@ final class ConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | AbstractToken
+   * @return null | AbstractToken
    */
   public function getAbstract(): ?AbstractToken {
     if ($this->_abstract->isMissing()) {
@@ -210,7 +210,7 @@ final class ConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns AbstractToken
+   * @return AbstractToken
    */
   public function getAbstractx(): AbstractToken {
     return TypeAssert\instance_of(AbstractToken::class, $this->_abstract);
@@ -239,14 +239,14 @@ final class ConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ConstToken
+   * @return ConstToken
    */
   public function getKeyword(): ConstToken {
     return TypeAssert\instance_of(ConstToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ConstToken
+   * @return ConstToken
    */
   public function getKeywordx(): ConstToken {
     return $this->getKeyword();
@@ -275,10 +275,9 @@ final class ConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ClassnameTypeSpecifier | GenericTypeSpecifier |
-   * KeysetTypeSpecifier | Missing | NullableTypeSpecifier |
-   * SimpleTypeSpecifier | TypeConstant | VarrayTypeSpecifier |
-   * VectorTypeSpecifier
+   * @return ClassnameTypeSpecifier | GenericTypeSpecifier |
+   * KeysetTypeSpecifier | null | NullableTypeSpecifier | SimpleTypeSpecifier |
+   * TypeConstant | VarrayTypeSpecifier | VectorTypeSpecifier
    */
   public function getTypeSpecifier(): ?EditableNode {
     if ($this->_type_specifier->isMissing()) {
@@ -288,7 +287,7 @@ final class ConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ClassnameTypeSpecifier | GenericTypeSpecifier |
+   * @return ClassnameTypeSpecifier | GenericTypeSpecifier |
    * KeysetTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier |
    * TypeConstant | VarrayTypeSpecifier | VectorTypeSpecifier
    */
@@ -319,14 +318,14 @@ final class ConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ConstantDeclarator>
+   * @return EditableList<ConstantDeclarator>
    */
   public function getDeclarators(): EditableList<ConstantDeclarator> {
     return TypeAssert\instance_of(EditableList::class, $this->_declarators);
   }
 
   /**
-   * @returns EditableList<ConstantDeclarator>
+   * @return EditableList<ConstantDeclarator>
    */
   public function getDeclaratorsx(): EditableList<ConstantDeclarator> {
     return $this->getDeclarators();
@@ -355,14 +354,14 @@ final class ConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/ConstantDeclarator.php
+++ b/codegen/syntax/ConstantDeclarator.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5f75ffe89b07fe5e63803feda803e31f>>
+ * @generated SignedSource<<14ae5900dfd1358ea7df542d39835215>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class ConstantDeclarator extends EditableNode {
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getNamex(): NameToken {
     return $this->getName();
@@ -111,7 +111,7 @@ final class ConstantDeclarator extends EditableNode {
   }
 
   /**
-   * @returns Missing | SimpleInitializer
+   * @return null | SimpleInitializer
    */
   public function getInitializer(): ?SimpleInitializer {
     if ($this->_initializer->isMissing()) {
@@ -122,7 +122,7 @@ final class ConstantDeclarator extends EditableNode {
   }
 
   /**
-   * @returns SimpleInitializer
+   * @return SimpleInitializer
    */
   public function getInitializerx(): SimpleInitializer {
     return

--- a/codegen/syntax/ConstructorCall.php
+++ b/codegen/syntax/ConstructorCall.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4d70e562c08eb59778b5e961bbc66401>>
+ * @generated SignedSource<<0f8206b046a4d60f946a55e776facb75>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,7 +119,7 @@ final class ConstructorCall extends EditableNode {
   }
 
   /**
-   * @returns GenericTypeSpecifier | MemberSelectionExpression |
+   * @return GenericTypeSpecifier | MemberSelectionExpression |
    * ParenthesizedExpression | QualifiedName | ScopeResolutionExpression |
    * SimpleTypeSpecifier | SubscriptExpression | NameToken | ParentToken |
    * SelfToken | StaticToken | VariableExpression
@@ -129,7 +129,7 @@ final class ConstructorCall extends EditableNode {
   }
 
   /**
-   * @returns GenericTypeSpecifier | MemberSelectionExpression |
+   * @return GenericTypeSpecifier | MemberSelectionExpression |
    * ParenthesizedExpression | QualifiedName | ScopeResolutionExpression |
    * SimpleTypeSpecifier | SubscriptExpression | NameToken | ParentToken |
    * SelfToken | StaticToken | VariableExpression
@@ -159,7 +159,7 @@ final class ConstructorCall extends EditableNode {
   }
 
   /**
-   * @returns Missing | LeftParenToken
+   * @return null | LeftParenToken
    */
   public function getLeftParen(): ?LeftParenToken {
     if ($this->_left_paren->isMissing()) {
@@ -169,7 +169,7 @@ final class ConstructorCall extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
@@ -192,7 +192,7 @@ final class ConstructorCall extends EditableNode {
   }
 
   /**
-   * @returns EditableList<AnonymousFunction> | EditableList<EditableNode> |
+   * @return EditableList<AnonymousFunction> | EditableList<EditableNode> |
    * EditableList<ArrayCreationExpression> |
    * EditableList<ArrayIntrinsicExpression> | EditableList<BinaryExpression> |
    * EditableList<CastExpression> | EditableList<CollectionLiteralExpression> |
@@ -209,7 +209,7 @@ final class ConstructorCall extends EditableNode {
    * EditableList<ScopeResolutionExpression> | EditableList<ShapeExpression> |
    * EditableList<SubscriptExpression> | EditableList<NameToken> |
    * EditableList<VariableExpression> | EditableList<VarrayIntrinsicExpression>
-   * | EditableList<VectorIntrinsicExpression> | Missing
+   * | EditableList<VectorIntrinsicExpression> | null
    */
   public function getArgumentList(): ?EditableList<EditableNode> {
     if ($this->_argument_list->isMissing()) {
@@ -219,7 +219,7 @@ final class ConstructorCall extends EditableNode {
   }
 
   /**
-   * @returns EditableList<AnonymousFunction> | EditableList<EditableNode> |
+   * @return EditableList<AnonymousFunction> | EditableList<EditableNode> |
    * EditableList<ArrayCreationExpression> |
    * EditableList<ArrayIntrinsicExpression> | EditableList<BinaryExpression> |
    * EditableList<CastExpression> | EditableList<CollectionLiteralExpression> |
@@ -263,7 +263,7 @@ final class ConstructorCall extends EditableNode {
   }
 
   /**
-   * @returns Missing | RightParenToken
+   * @return null | RightParenToken
    */
   public function getRightParen(): ?RightParenToken {
     if ($this->_right_paren->isMissing()) {
@@ -273,7 +273,7 @@ final class ConstructorCall extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);

--- a/codegen/syntax/ContinueStatement.php
+++ b/codegen/syntax/ContinueStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<875a1adc2ac3f6ef3a5d04fc1da4156d>>
+ * @generated SignedSource<<c9b9fff377bba2e6f3c7e00acbdfdd32>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class ContinueStatement extends EditableNode {
   }
 
   /**
-   * @returns ContinueToken
+   * @return ContinueToken
    */
   public function getKeyword(): ContinueToken {
     return TypeAssert\instance_of(ContinueToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ContinueToken
+   * @return ContinueToken
    */
   public function getKeywordx(): ContinueToken {
     return $this->getKeyword();
@@ -130,7 +130,7 @@ final class ContinueStatement extends EditableNode {
   }
 
   /**
-   * @returns LiteralExpression | Missing | VariableExpression
+   * @return LiteralExpression | null | VariableExpression
    */
   public function getLevel(): ?EditableNode {
     if ($this->_level->isMissing()) {
@@ -140,7 +140,7 @@ final class ContinueStatement extends EditableNode {
   }
 
   /**
-   * @returns LiteralExpression | VariableExpression
+   * @return LiteralExpression | VariableExpression
    */
   public function getLevelx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_level);
@@ -162,14 +162,14 @@ final class ContinueStatement extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/DarrayIntrinsicExpression.php
+++ b/codegen/syntax/DarrayIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a94b5a6994b8d7360fcd5d2b9f6edd6c>>
+ * @generated SignedSource<<020ebd61cc100c087d36c280537e04d6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -145,14 +145,14 @@ final class DarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns DarrayToken
+   * @return DarrayToken
    */
   public function getKeyword(): DarrayToken {
     return TypeAssert\instance_of(DarrayToken::class, $this->_keyword);
   }
 
   /**
-   * @returns DarrayToken
+   * @return DarrayToken
    */
   public function getKeywordx(): DarrayToken {
     return $this->getKeyword();
@@ -180,7 +180,7 @@ final class DarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getExplicitType(): ?EditableNode {
     if ($this->_explicit_type->isMissing()) {
@@ -190,7 +190,7 @@ final class DarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getExplicitTypex(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_explicit_type);
@@ -218,7 +218,7 @@ final class DarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBracketToken
+   * @return LeftBracketToken
    */
   public function getLeftBracket(): LeftBracketToken {
     return
@@ -226,7 +226,7 @@ final class DarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBracketToken
+   * @return LeftBracketToken
    */
   public function getLeftBracketx(): LeftBracketToken {
     return $this->getLeftBracket();
@@ -254,7 +254,7 @@ final class DarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ElementInitializer> | Missing
+   * @return EditableList<ElementInitializer> | null
    */
   public function getMembers(): ?EditableList<ElementInitializer> {
     if ($this->_members->isMissing()) {
@@ -264,7 +264,7 @@ final class DarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ElementInitializer>
+   * @return EditableList<ElementInitializer>
    */
   public function getMembersx(): EditableList<ElementInitializer> {
     return TypeAssert\instance_of(EditableList::class, $this->_members);
@@ -292,7 +292,7 @@ final class DarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBracketToken
+   * @return RightBracketToken
    */
   public function getRightBracket(): RightBracketToken {
     return
@@ -300,7 +300,7 @@ final class DarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBracketToken
+   * @return RightBracketToken
    */
   public function getRightBracketx(): RightBracketToken {
     return $this->getRightBracket();

--- a/codegen/syntax/DarrayTypeSpecifier.php
+++ b/codegen/syntax/DarrayTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b622e43ad9a2d10c498478e5e9685001>>
+ * @generated SignedSource<<e71768a6e90f5df5c450449d023a98aa>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -177,14 +177,14 @@ final class DarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns DarrayToken
+   * @return DarrayToken
    */
   public function getKeyword(): DarrayToken {
     return TypeAssert\instance_of(DarrayToken::class, $this->_keyword);
   }
 
   /**
-   * @returns DarrayToken
+   * @return DarrayToken
    */
   public function getKeywordx(): DarrayToken {
     return $this->getKeyword();
@@ -214,14 +214,14 @@ final class DarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAnglex(): LessThanToken {
     return $this->getLeftAngle();
@@ -251,14 +251,14 @@ final class DarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getKey(): SimpleTypeSpecifier {
     return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_key);
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getKeyx(): SimpleTypeSpecifier {
     return $this->getKey();
@@ -288,14 +288,14 @@ final class DarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns CommaToken
+   * @return CommaToken
    */
   public function getComma(): CommaToken {
     return TypeAssert\instance_of(CommaToken::class, $this->_comma);
   }
 
   /**
-   * @returns CommaToken
+   * @return CommaToken
    */
   public function getCommax(): CommaToken {
     return $this->getComma();
@@ -325,7 +325,7 @@ final class DarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns DarrayTypeSpecifier | SimpleTypeSpecifier | VarrayTypeSpecifier |
+   * @return DarrayTypeSpecifier | SimpleTypeSpecifier | VarrayTypeSpecifier |
    * VectorArrayTypeSpecifier
    */
   public function getValue(): EditableNode {
@@ -333,7 +333,7 @@ final class DarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns DarrayTypeSpecifier | SimpleTypeSpecifier | VarrayTypeSpecifier |
+   * @return DarrayTypeSpecifier | SimpleTypeSpecifier | VarrayTypeSpecifier |
    * VectorArrayTypeSpecifier
    */
   public function getValuex(): EditableNode {
@@ -364,7 +364,7 @@ final class DarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getTrailingComma(): ?EditableNode {
     if ($this->_trailing_comma->isMissing()) {
@@ -374,7 +374,7 @@ final class DarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getTrailingCommax(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_trailing_comma);
@@ -404,14 +404,14 @@ final class DarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAnglex(): GreaterThanToken {
     return $this->getRightAngle();

--- a/codegen/syntax/DeclareBlockStatement.php
+++ b/codegen/syntax/DeclareBlockStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3349405ffb9eb9d60befa607625b5239>>
+ * @generated SignedSource<<f038e57acc431b7997b3a9c26a7ae55e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -133,14 +133,14 @@ final class DeclareBlockStatement extends EditableNode {
   }
 
   /**
-   * @returns DeclareToken
+   * @return DeclareToken
    */
   public function getKeyword(): DeclareToken {
     return TypeAssert\instance_of(DeclareToken::class, $this->_keyword);
   }
 
   /**
-   * @returns DeclareToken
+   * @return DeclareToken
    */
   public function getKeywordx(): DeclareToken {
     return $this->getKeyword();
@@ -168,14 +168,14 @@ final class DeclareBlockStatement extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -203,14 +203,14 @@ final class DeclareBlockStatement extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression
+   * @return BinaryExpression
    */
   public function getExpression(): BinaryExpression {
     return TypeAssert\instance_of(BinaryExpression::class, $this->_expression);
   }
 
   /**
-   * @returns BinaryExpression
+   * @return BinaryExpression
    */
   public function getExpressionx(): BinaryExpression {
     return $this->getExpression();
@@ -238,14 +238,14 @@ final class DeclareBlockStatement extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -273,14 +273,14 @@ final class DeclareBlockStatement extends EditableNode {
   }
 
   /**
-   * @returns AlternateLoopStatement | CompoundStatement
+   * @return AlternateLoopStatement | CompoundStatement
    */
   public function getBody(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_body);
   }
 
   /**
-   * @returns AlternateLoopStatement | CompoundStatement
+   * @return AlternateLoopStatement | CompoundStatement
    */
   public function getBodyx(): EditableNode {
     return $this->getBody();

--- a/codegen/syntax/DeclareDirectiveStatement.php
+++ b/codegen/syntax/DeclareDirectiveStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7d8c2c9395b8ed9305920fb0503663f7>>
+ * @generated SignedSource<<14561a120170d58830d8362bd62fd1ef>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -135,14 +135,14 @@ final class DeclareDirectiveStatement extends EditableNode {
   }
 
   /**
-   * @returns DeclareToken
+   * @return DeclareToken
    */
   public function getKeyword(): DeclareToken {
     return TypeAssert\instance_of(DeclareToken::class, $this->_keyword);
   }
 
   /**
-   * @returns DeclareToken
+   * @return DeclareToken
    */
   public function getKeywordx(): DeclareToken {
     return $this->getKeyword();
@@ -170,14 +170,14 @@ final class DeclareDirectiveStatement extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -205,14 +205,14 @@ final class DeclareDirectiveStatement extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression
+   * @return BinaryExpression
    */
   public function getExpression(): BinaryExpression {
     return TypeAssert\instance_of(BinaryExpression::class, $this->_expression);
   }
 
   /**
-   * @returns BinaryExpression
+   * @return BinaryExpression
    */
   public function getExpressionx(): BinaryExpression {
     return $this->getExpression();
@@ -240,14 +240,14 @@ final class DeclareDirectiveStatement extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -275,14 +275,14 @@ final class DeclareDirectiveStatement extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/DecoratedExpression.php
+++ b/codegen/syntax/DecoratedExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4631f5bb8f95d42c329389474931b0f3>>
+ * @generated SignedSource<<60ad2f5e844e0bde1accddb49597e116>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -87,14 +87,14 @@ final class DecoratedExpression extends EditableNode {
   }
 
   /**
-   * @returns AmpersandToken | DotDotDotToken | InoutToken
+   * @return AmpersandToken | DotDotDotToken | InoutToken
    */
   public function getDecorator(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_decorator);
   }
 
   /**
-   * @returns AmpersandToken | DotDotDotToken | InoutToken
+   * @return AmpersandToken | DotDotDotToken | InoutToken
    */
   public function getDecoratorx(): EditableToken {
     return $this->getDecorator();
@@ -116,7 +116,7 @@ final class DecoratedExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayCreationExpression | ArrayIntrinsicExpression |
+   * @return ArrayCreationExpression | ArrayIntrinsicExpression |
    * DecoratedExpression | FunctionCallExpression | ScopeResolutionExpression |
    * SubscriptExpression | VariableToken | VariableExpression
    */
@@ -125,7 +125,7 @@ final class DecoratedExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayCreationExpression | ArrayIntrinsicExpression |
+   * @return ArrayCreationExpression | ArrayIntrinsicExpression |
    * DecoratedExpression | FunctionCallExpression | ScopeResolutionExpression |
    * SubscriptExpression | VariableToken | VariableExpression
    */

--- a/codegen/syntax/DefaultLabel.php
+++ b/codegen/syntax/DefaultLabel.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d9bac9601f00d81a1848e52e1c61111a>>
+ * @generated SignedSource<<26b10d3d5da8efae924119e0164209f7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class DefaultLabel extends EditableNode {
   }
 
   /**
-   * @returns DefaultToken
+   * @return DefaultToken
    */
   public function getKeyword(): DefaultToken {
     return TypeAssert\instance_of(DefaultToken::class, $this->_keyword);
   }
 
   /**
-   * @returns DefaultToken
+   * @return DefaultToken
    */
   public function getKeywordx(): DefaultToken {
     return $this->getKeyword();
@@ -111,14 +111,14 @@ final class DefaultLabel extends EditableNode {
   }
 
   /**
-   * @returns ColonToken | SemicolonToken
+   * @return ColonToken | SemicolonToken
    */
   public function getColon(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_colon);
   }
 
   /**
-   * @returns ColonToken | SemicolonToken
+   * @return ColonToken | SemicolonToken
    */
   public function getColonx(): EditableToken {
     return $this->getColon();

--- a/codegen/syntax/DefineExpression.php
+++ b/codegen/syntax/DefineExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1afdd5fcea4316ebfc84050d96a1780c>>
+ * @generated SignedSource<<a206f0d48d023573d4912ada22ff2101>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class DefineExpression extends EditableNode {
   }
 
   /**
-   * @returns DefineToken
+   * @return DefineToken
    */
   public function getKeyword(): DefineToken {
     return TypeAssert\instance_of(DefineToken::class, $this->_keyword);
   }
 
   /**
-   * @returns DefineToken
+   * @return DefineToken
    */
   public function getKeywordx(): DefineToken {
     return $this->getKeyword();
@@ -153,14 +153,14 @@ final class DefineExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -187,8 +187,7 @@ final class DefineExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | EditableList<LiteralExpression> |
-   * Missing
+   * @return EditableList<EditableNode> | EditableList<LiteralExpression> | null
    */
   public function getArgumentList(): ?EditableList<EditableNode> {
     if ($this->_argument_list->isMissing()) {
@@ -198,7 +197,7 @@ final class DefineExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | EditableList<LiteralExpression>
+   * @return EditableList<EditableNode> | EditableList<LiteralExpression>
    */
   public function getArgumentListx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_argument_list);
@@ -225,14 +224,14 @@ final class DefineExpression extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();

--- a/codegen/syntax/DictionaryIntrinsicExpression.php
+++ b/codegen/syntax/DictionaryIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<57d0293a56e6bb183a148a4c4a8b5468>>
+ * @generated SignedSource<<2f93db371fa8b2ca847c176c8ac817e7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -145,14 +145,14 @@ final class DictionaryIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns DictToken
+   * @return DictToken
    */
   public function getKeyword(): DictToken {
     return TypeAssert\instance_of(DictToken::class, $this->_keyword);
   }
 
   /**
-   * @returns DictToken
+   * @return DictToken
    */
   public function getKeywordx(): DictToken {
     return $this->getKeyword();
@@ -180,7 +180,7 @@ final class DictionaryIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getExplicitType(): ?EditableNode {
     if ($this->_explicit_type->isMissing()) {
@@ -190,7 +190,7 @@ final class DictionaryIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getExplicitTypex(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_explicit_type);
@@ -218,7 +218,7 @@ final class DictionaryIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBracketToken
+   * @return LeftBracketToken
    */
   public function getLeftBracket(): LeftBracketToken {
     return
@@ -226,7 +226,7 @@ final class DictionaryIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBracketToken
+   * @return LeftBracketToken
    */
   public function getLeftBracketx(): LeftBracketToken {
     return $this->getLeftBracket();
@@ -254,7 +254,7 @@ final class DictionaryIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ElementInitializer> | Missing
+   * @return EditableList<ElementInitializer> | null
    */
   public function getMembers(): ?EditableList<ElementInitializer> {
     if ($this->_members->isMissing()) {
@@ -264,7 +264,7 @@ final class DictionaryIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ElementInitializer>
+   * @return EditableList<ElementInitializer>
    */
   public function getMembersx(): EditableList<ElementInitializer> {
     return TypeAssert\instance_of(EditableList::class, $this->_members);
@@ -292,7 +292,7 @@ final class DictionaryIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBracketToken
+   * @return RightBracketToken
    */
   public function getRightBracket(): RightBracketToken {
     return
@@ -300,7 +300,7 @@ final class DictionaryIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBracketToken
+   * @return RightBracketToken
    */
   public function getRightBracketx(): RightBracketToken {
     return $this->getRightBracket();

--- a/codegen/syntax/DictionaryTypeSpecifier.php
+++ b/codegen/syntax/DictionaryTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<15257798cec262aae7022dae37566f98>>
+ * @generated SignedSource<<3a49fd643b95b441259ebc8c30034aef>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class DictionaryTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns DictToken
+   * @return DictToken
    */
   public function getKeyword(): DictToken {
     return TypeAssert\instance_of(DictToken::class, $this->_keyword);
   }
 
   /**
-   * @returns DictToken
+   * @return DictToken
    */
   public function getKeywordx(): DictToken {
     return $this->getKeyword();
@@ -149,14 +149,14 @@ final class DictionaryTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAnglex(): LessThanToken {
     return $this->getLeftAngle();
@@ -183,14 +183,14 @@ final class DictionaryTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | EditableList<SimpleTypeSpecifier>
+   * @return EditableList<EditableNode> | EditableList<SimpleTypeSpecifier>
    */
   public function getMembers(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_members);
   }
 
   /**
-   * @returns EditableList<EditableNode> | EditableList<SimpleTypeSpecifier>
+   * @return EditableList<EditableNode> | EditableList<SimpleTypeSpecifier>
    */
   public function getMembersx(): EditableList<EditableNode> {
     return $this->getMembers();
@@ -213,14 +213,14 @@ final class DictionaryTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAnglex(): GreaterThanToken {
     return $this->getRightAngle();

--- a/codegen/syntax/DoStatement.php
+++ b/codegen/syntax/DoStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<210cc98a634bbd2f1b95432e25adab1b>>
+ * @generated SignedSource<<4c8b60669b284b2eb04e4a0a7af10440>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -179,14 +179,14 @@ final class DoStatement
   }
 
   /**
-   * @returns DoToken
+   * @return DoToken
    */
   public function getKeyword(): DoToken {
     return TypeAssert\instance_of(DoToken::class, $this->_keyword);
   }
 
   /**
-   * @returns DoToken
+   * @return DoToken
    */
   public function getKeywordx(): DoToken {
     return $this->getKeyword();
@@ -216,14 +216,14 @@ final class DoStatement
   }
 
   /**
-   * @returns CompoundStatement | ExpressionStatement
+   * @return CompoundStatement | ExpressionStatement
    */
   public function getBody(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_body);
   }
 
   /**
-   * @returns CompoundStatement | ExpressionStatement
+   * @return CompoundStatement | ExpressionStatement
    */
   public function getBodyx(): EditableNode {
     return $this->getBody();
@@ -253,14 +253,14 @@ final class DoStatement
   }
 
   /**
-   * @returns WhileToken
+   * @return WhileToken
    */
   public function getWhileKeyword(): WhileToken {
     return TypeAssert\instance_of(WhileToken::class, $this->_while_keyword);
   }
 
   /**
-   * @returns WhileToken
+   * @return WhileToken
    */
   public function getWhileKeywordx(): WhileToken {
     return $this->getWhileKeyword();
@@ -290,14 +290,14 @@ final class DoStatement
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -327,7 +327,7 @@ final class DoStatement
   }
 
   /**
-   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * @return BinaryExpression | FunctionCallExpression | LiteralExpression |
    * PrefixUnaryExpression | SubscriptExpression | VariableExpression
    */
   public function getCondition(): EditableNode {
@@ -335,7 +335,7 @@ final class DoStatement
   }
 
   /**
-   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * @return BinaryExpression | FunctionCallExpression | LiteralExpression |
    * PrefixUnaryExpression | SubscriptExpression | VariableExpression
    */
   public function getConditionx(): EditableNode {
@@ -366,14 +366,14 @@ final class DoStatement
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -403,14 +403,14 @@ final class DoStatement
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/EchoStatement.php
+++ b/codegen/syntax/EchoStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5db90c37c54b28f972cc134d02229d5f>>
+ * @generated SignedSource<<242454fd47152a7f4ed0d64591a427dc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class EchoStatement extends EditableNode {
   }
 
   /**
-   * @returns EchoToken
+   * @return EchoToken
    */
   public function getKeyword(): EchoToken {
     return TypeAssert\instance_of(EchoToken::class, $this->_keyword);
   }
 
   /**
-   * @returns EchoToken
+   * @return EchoToken
    */
   public function getKeywordx(): EchoToken {
     return $this->getKeyword();
@@ -130,7 +130,7 @@ final class EchoStatement extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | EditableList<BinaryExpression> |
+   * @return EditableList<EditableNode> | EditableList<BinaryExpression> |
    * EditableList<CastExpression> | EditableList<ConditionalExpression> |
    * EditableList<EmptyExpression> | EditableList<FunctionCallExpression> |
    * EditableList<IssetExpression> | EditableList<LiteralExpression> |
@@ -148,7 +148,7 @@ final class EchoStatement extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | EditableList<BinaryExpression> |
+   * @return EditableList<EditableNode> | EditableList<BinaryExpression> |
    * EditableList<CastExpression> | EditableList<ConditionalExpression> |
    * EditableList<EmptyExpression> | EditableList<FunctionCallExpression> |
    * EditableList<IssetExpression> | EditableList<LiteralExpression> |
@@ -181,7 +181,7 @@ final class EchoStatement extends EditableNode {
   }
 
   /**
-   * @returns Missing | SemicolonToken
+   * @return null | SemicolonToken
    */
   public function getSemicolon(): ?SemicolonToken {
     if ($this->_semicolon->isMissing()) {
@@ -191,7 +191,7 @@ final class EchoStatement extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);

--- a/codegen/syntax/ElementInitializer.php
+++ b/codegen/syntax/ElementInitializer.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<23b0ec3cd1d7b9ae07b8ce5b25dfad83>>
+ * @generated SignedSource<<df5559d353cd7251d215d44f79bcb073>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,7 +101,7 @@ final class ElementInitializer extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
    * CollectionLiteralExpression | DictionaryIntrinsicExpression |
    * FunctionCallExpression | KeysetIntrinsicExpression | LiteralExpression |
@@ -114,7 +114,7 @@ final class ElementInitializer extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
    * CollectionLiteralExpression | DictionaryIntrinsicExpression |
    * FunctionCallExpression | KeysetIntrinsicExpression | LiteralExpression |
@@ -142,14 +142,14 @@ final class ElementInitializer extends EditableNode {
   }
 
   /**
-   * @returns EqualGreaterThanToken
+   * @return EqualGreaterThanToken
    */
   public function getArrow(): EqualGreaterThanToken {
     return TypeAssert\instance_of(EqualGreaterThanToken::class, $this->_arrow);
   }
 
   /**
-   * @returns EqualGreaterThanToken
+   * @return EqualGreaterThanToken
    */
   public function getArrowx(): EqualGreaterThanToken {
     return $this->getArrow();
@@ -171,7 +171,7 @@ final class ElementInitializer extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
    * CollectionLiteralExpression | ConditionalExpression |
    * DarrayIntrinsicExpression | DictionaryIntrinsicExpression |
@@ -187,7 +187,7 @@ final class ElementInitializer extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
    * CollectionLiteralExpression | ConditionalExpression |
    * DarrayIntrinsicExpression | DictionaryIntrinsicExpression |

--- a/codegen/syntax/ElseClause.php
+++ b/codegen/syntax/ElseClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9699fd92dfc4cc119a4ba5aa0ce70091>>
+ * @generated SignedSource<<b012cdc9ece422a269624cecf9ce9a05>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class ElseClause extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns ElseToken
+   * @return ElseToken
    */
   public function getKeyword(): ElseToken {
     return TypeAssert\instance_of(ElseToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ElseToken
+   * @return ElseToken
    */
   public function getKeywordx(): ElseToken {
     return $this->getKeyword();
@@ -111,7 +111,7 @@ final class ElseClause extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns CompoundStatement | EchoStatement | ExpressionStatement |
+   * @return CompoundStatement | EchoStatement | ExpressionStatement |
    * IfStatement | ReturnStatement
    */
   public function getStatement(): EditableNode {
@@ -119,7 +119,7 @@ final class ElseClause extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns CompoundStatement | EchoStatement | ExpressionStatement |
+   * @return CompoundStatement | EchoStatement | ExpressionStatement |
    * IfStatement | ReturnStatement
    */
   public function getStatementx(): EditableNode {

--- a/codegen/syntax/ElseifClause.php
+++ b/codegen/syntax/ElseifClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<37a60033eb697cbd6a30f7c16d580d7b>>
+ * @generated SignedSource<<7db95e738d564f2922fe62010e7b66a4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -135,14 +135,14 @@ final class ElseifClause extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns ElseifToken
+   * @return ElseifToken
    */
   public function getKeyword(): ElseifToken {
     return TypeAssert\instance_of(ElseifToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ElseifToken
+   * @return ElseifToken
    */
   public function getKeywordx(): ElseifToken {
     return $this->getKeyword();
@@ -170,14 +170,14 @@ final class ElseifClause extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -205,7 +205,7 @@ final class ElseifClause extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * @return BinaryExpression | FunctionCallExpression | LiteralExpression |
    * VariableExpression
    */
   public function getCondition(): EditableNode {
@@ -213,7 +213,7 @@ final class ElseifClause extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * @return BinaryExpression | FunctionCallExpression | LiteralExpression |
    * VariableExpression
    */
   public function getConditionx(): EditableNode {
@@ -242,14 +242,14 @@ final class ElseifClause extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -277,14 +277,14 @@ final class ElseifClause extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns CompoundStatement | ExpressionStatement
+   * @return CompoundStatement | ExpressionStatement
    */
   public function getStatement(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_statement);
   }
 
   /**
-   * @returns CompoundStatement | ExpressionStatement
+   * @return CompoundStatement | ExpressionStatement
    */
   public function getStatementx(): EditableNode {
     return $this->getStatement();

--- a/codegen/syntax/EmbeddedBracedExpression.php
+++ b/codegen/syntax/EmbeddedBracedExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6aedcde9623d7eef999d29547c7e8136>>
+ * @generated SignedSource<<a4d6dbd92c4ad63db081be9180667b28>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class EmbeddedBracedExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getLeftBrace(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_brace);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getLeftBracex(): EditableNode {
     return $this->getLeftBrace();
@@ -130,14 +130,14 @@ final class EmbeddedBracedExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getExpressionx(): EditableNode {
     return $this->getExpression();
@@ -159,14 +159,14 @@ final class EmbeddedBracedExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getRightBrace(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_brace);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getRightBracex(): EditableNode {
     return $this->getRightBrace();

--- a/codegen/syntax/EmbeddedMemberSelectionExpression.php
+++ b/codegen/syntax/EmbeddedMemberSelectionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b52c96f6a540d86e8fdcc65b7bee57d8>>
+ * @generated SignedSource<<3364589efdbe86c48ae7d56d4e274ae3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class EmbeddedMemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getObject(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_object);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getObjectx(): EditableNode {
     return $this->getObject();
@@ -130,14 +130,14 @@ final class EmbeddedMemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getOperator(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_operator);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getOperatorx(): EditableNode {
     return $this->getOperator();
@@ -159,14 +159,14 @@ final class EmbeddedMemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getNamex(): EditableNode {
     return $this->getName();

--- a/codegen/syntax/EmbeddedSubscriptExpression.php
+++ b/codegen/syntax/EmbeddedSubscriptExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<eb64c2d5fe88012704c27434f0a4dead>>
+ * @generated SignedSource<<51a4fdf793f67d129148f0fe15756f81>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class EmbeddedSubscriptExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getReceiver(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_receiver);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getReceiverx(): EditableNode {
     return $this->getReceiver();
@@ -153,14 +153,14 @@ final class EmbeddedSubscriptExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getLeftBracket(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_bracket);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getLeftBracketx(): EditableNode {
     return $this->getLeftBracket();
@@ -187,14 +187,14 @@ final class EmbeddedSubscriptExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getIndex(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_index);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getIndexx(): EditableNode {
     return $this->getIndex();
@@ -217,14 +217,14 @@ final class EmbeddedSubscriptExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getRightBracket(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_bracket);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getRightBracketx(): EditableNode {
     return $this->getRightBracket();

--- a/codegen/syntax/EmptyExpression.php
+++ b/codegen/syntax/EmptyExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<30c83cc9eb68ecdf52c6425ea4e80397>>
+ * @generated SignedSource<<e526a6c11c65b25902b83d0d207e042d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class EmptyExpression extends EditableNode {
   }
 
   /**
-   * @returns EmptyToken
+   * @return EmptyToken
    */
   public function getKeyword(): EmptyToken {
     return TypeAssert\instance_of(EmptyToken::class, $this->_keyword);
   }
 
   /**
-   * @returns EmptyToken
+   * @return EmptyToken
    */
   public function getKeywordx(): EmptyToken {
     return $this->getKeyword();
@@ -153,14 +153,14 @@ final class EmptyExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -187,7 +187,7 @@ final class EmptyExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayCreationExpression | ArrayIntrinsicExpression |
+   * @return ArrayCreationExpression | ArrayIntrinsicExpression |
    * BinaryExpression | CollectionLiteralExpression | FunctionCallExpression |
    * LiteralExpression | MemberSelectionExpression | ObjectCreationExpression |
    * ParenthesizedExpression | PrefixUnaryExpression |
@@ -199,7 +199,7 @@ final class EmptyExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayCreationExpression | ArrayIntrinsicExpression |
+   * @return ArrayCreationExpression | ArrayIntrinsicExpression |
    * BinaryExpression | CollectionLiteralExpression | FunctionCallExpression |
    * LiteralExpression | MemberSelectionExpression | ObjectCreationExpression |
    * ParenthesizedExpression | PrefixUnaryExpression |
@@ -227,14 +227,14 @@ final class EmptyExpression extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();

--- a/codegen/syntax/EndOfFile.php
+++ b/codegen/syntax/EndOfFile.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3df2e3b3b1510e2b52c2cb05407af0b0>>
+ * @generated SignedSource<<f7c9d9ab6d269b1ca25ef4d051464d8c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -71,14 +71,14 @@ final class EndOfFile extends EditableNode {
   }
 
   /**
-   * @returns EndOfFileToken
+   * @return EndOfFileToken
    */
   public function getToken(): EndOfFileToken {
     return TypeAssert\instance_of(EndOfFileToken::class, $this->_token);
   }
 
   /**
-   * @returns EndOfFileToken
+   * @return EndOfFileToken
    */
   public function getTokenx(): EndOfFileToken {
     return $this->getToken();

--- a/codegen/syntax/EnumDeclaration.php
+++ b/codegen/syntax/EnumDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cf9a32d0fefc3b47e139b1e21b3afc5a>>
+ * @generated SignedSource<<85dbc279f341f783da0c7a1ab3fb9e7d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -209,7 +209,7 @@ final class EnumDeclaration extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification | Missing
+   * @return AttributeSpecification | null
    */
   public function getAttributeSpec(): ?AttributeSpecification {
     if ($this->_attribute_spec->isMissing()) {
@@ -222,7 +222,7 @@ final class EnumDeclaration extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification
+   * @return AttributeSpecification
    */
   public function getAttributeSpecx(): AttributeSpecification {
     return TypeAssert\instance_of(
@@ -257,14 +257,14 @@ final class EnumDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EnumToken
+   * @return EnumToken
    */
   public function getKeyword(): EnumToken {
     return TypeAssert\instance_of(EnumToken::class, $this->_keyword);
   }
 
   /**
-   * @returns EnumToken
+   * @return EnumToken
    */
   public function getKeywordx(): EnumToken {
     return $this->getKeyword();
@@ -296,14 +296,14 @@ final class EnumDeclaration extends EditableNode {
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getNamex(): NameToken {
     return $this->getName();
@@ -335,14 +335,14 @@ final class EnumDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColon(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColonx(): ColonToken {
     return $this->getColon();
@@ -374,16 +374,14 @@ final class EnumDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ClassnameTypeSpecifier | GenericTypeSpecifier |
-   * SimpleTypeSpecifier
+   * @return ClassnameTypeSpecifier | GenericTypeSpecifier | SimpleTypeSpecifier
    */
   public function getBase(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_base);
   }
 
   /**
-   * @returns ClassnameTypeSpecifier | GenericTypeSpecifier |
-   * SimpleTypeSpecifier
+   * @return ClassnameTypeSpecifier | GenericTypeSpecifier | SimpleTypeSpecifier
    */
   public function getBasex(): EditableNode {
     return $this->getBase();
@@ -415,7 +413,7 @@ final class EnumDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | TypeConstraint
+   * @return null | TypeConstraint
    */
   public function getType(): ?TypeConstraint {
     if ($this->_type->isMissing()) {
@@ -425,7 +423,7 @@ final class EnumDeclaration extends EditableNode {
   }
 
   /**
-   * @returns TypeConstraint
+   * @return TypeConstraint
    */
   public function getTypex(): TypeConstraint {
     return TypeAssert\instance_of(TypeConstraint::class, $this->_type);
@@ -457,14 +455,14 @@ final class EnumDeclaration extends EditableNode {
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBracex(): LeftBraceToken {
     return $this->getLeftBrace();
@@ -496,7 +494,7 @@ final class EnumDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getEnumerators(): ?EditableList<EditableNode> {
     if ($this->_enumerators->isMissing()) {
@@ -506,7 +504,7 @@ final class EnumDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getEnumeratorsx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_enumerators);
@@ -538,14 +536,14 @@ final class EnumDeclaration extends EditableNode {
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBrace(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBracex(): RightBraceToken {
     return $this->getRightBrace();

--- a/codegen/syntax/Enumerator.php
+++ b/codegen/syntax/Enumerator.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2671fc02b823a6b6d4e4b3a79d3c1952>>
+ * @generated SignedSource<<1fada0f17fd48b97dce8783b166f94b5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -114,14 +114,14 @@ final class Enumerator extends EditableNode {
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getNamex(): NameToken {
     return $this->getName();
@@ -143,14 +143,14 @@ final class Enumerator extends EditableNode {
   }
 
   /**
-   * @returns EqualToken
+   * @return EqualToken
    */
   public function getEqual(): EqualToken {
     return TypeAssert\instance_of(EqualToken::class, $this->_equal);
   }
 
   /**
-   * @returns EqualToken
+   * @return EqualToken
    */
   public function getEqualx(): EqualToken {
     return $this->getEqual();
@@ -172,7 +172,7 @@ final class Enumerator extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * @return BinaryExpression | FunctionCallExpression | LiteralExpression |
    * ObjectCreationExpression | ScopeResolutionExpression | NameToken |
    * VariableExpression
    */
@@ -181,7 +181,7 @@ final class Enumerator extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * @return BinaryExpression | FunctionCallExpression | LiteralExpression |
    * ObjectCreationExpression | ScopeResolutionExpression | NameToken |
    * VariableExpression
    */
@@ -205,14 +205,14 @@ final class Enumerator extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/ErrorSyntax.php
+++ b/codegen/syntax/ErrorSyntax.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<aa966ea0e084eef5000ac6ca0a39353f>>
+ * @generated SignedSource<<5a5928b3f9585a4f93a67638c62d01a9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -71,7 +71,7 @@ final class ErrorSyntax extends EditableNode {
   }
 
   /**
-   * @returns CommaToken | SemicolonToken | EqualToken | DecimalLiteralToken |
+   * @return CommaToken | SemicolonToken | EqualToken | DecimalLiteralToken |
    * NameToken | SingleQuotedStringLiteralToken | VariableToken |
    * LeftBraceToken | RightBraceToken
    */
@@ -80,7 +80,7 @@ final class ErrorSyntax extends EditableNode {
   }
 
   /**
-   * @returns CommaToken | SemicolonToken | EqualToken | DecimalLiteralToken |
+   * @return CommaToken | SemicolonToken | EqualToken | DecimalLiteralToken |
    * NameToken | SingleQuotedStringLiteralToken | VariableToken |
    * LeftBraceToken | RightBraceToken
    */

--- a/codegen/syntax/EvalExpression.php
+++ b/codegen/syntax/EvalExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7ab111bb07cd23882503065a30b70382>>
+ * @generated SignedSource<<d951e3e14c2c71f718c94ad9c777a611>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class EvalExpression extends EditableNode {
   }
 
   /**
-   * @returns EvalToken
+   * @return EvalToken
    */
   public function getKeyword(): EvalToken {
     return TypeAssert\instance_of(EvalToken::class, $this->_keyword);
   }
 
   /**
-   * @returns EvalToken
+   * @return EvalToken
    */
   public function getKeywordx(): EvalToken {
     return $this->getKeyword();
@@ -153,14 +153,14 @@ final class EvalExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -187,7 +187,7 @@ final class EvalExpression extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * @return BinaryExpression | FunctionCallExpression | LiteralExpression |
    * VariableExpression
    */
   public function getArgument(): EditableNode {
@@ -195,7 +195,7 @@ final class EvalExpression extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * @return BinaryExpression | FunctionCallExpression | LiteralExpression |
    * VariableExpression
    */
   public function getArgumentx(): EditableNode {
@@ -219,14 +219,14 @@ final class EvalExpression extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();

--- a/codegen/syntax/ExpressionStatement.php
+++ b/codegen/syntax/ExpressionStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<208e9d0c980408fe7e4d96f94d6296e3>>
+ * @generated SignedSource<<34601cb602305dbe45dec2d72f463b6b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -87,14 +87,14 @@ final class ExpressionStatement extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | AsExpression | BinaryExpression |
+   * @return AnonymousFunction | AsExpression | BinaryExpression |
    * CastExpression | CollectionLiteralExpression | ConditionalExpression |
    * DarrayIntrinsicExpression | DefineExpression |
    * DictionaryIntrinsicExpression | EmptyExpression | EvalExpression |
    * FunctionCallExpression | FunctionCallWithTypeArgumentsExpression |
    * HaltCompilerExpression | InclusionExpression | InstanceofExpression |
    * IssetExpression | LambdaExpression | LiteralExpression |
-   * MemberSelectionExpression | Missing | ObjectCreationExpression |
+   * MemberSelectionExpression | null | ObjectCreationExpression |
    * ParenthesizedExpression | PostfixUnaryExpression | PrefixUnaryExpression |
    * QualifiedName | SafeMemberSelectionExpression | ScopeResolutionExpression
    * | SubscriptExpression | RightParenToken | CommaToken | ColonToken |
@@ -111,7 +111,7 @@ final class ExpressionStatement extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | AsExpression | BinaryExpression |
+   * @return AnonymousFunction | AsExpression | BinaryExpression |
    * CastExpression | CollectionLiteralExpression | ConditionalExpression |
    * DarrayIntrinsicExpression | DefineExpression |
    * DictionaryIntrinsicExpression | EmptyExpression | EvalExpression |
@@ -147,7 +147,7 @@ final class ExpressionStatement extends EditableNode {
   }
 
   /**
-   * @returns Missing | SemicolonToken
+   * @return null | SemicolonToken
    */
   public function getSemicolon(): ?SemicolonToken {
     if ($this->_semicolon->isMissing()) {
@@ -157,7 +157,7 @@ final class ExpressionStatement extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);

--- a/codegen/syntax/FieldInitializer.php
+++ b/codegen/syntax/FieldInitializer.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<663a8f5003fbcd265ea7c15dee242988>>
+ * @generated SignedSource<<c68a721cac7c0652fecc000b12104323>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,7 +101,7 @@ final class FieldInitializer extends EditableNode {
   }
 
   /**
-   * @returns LiteralExpression | ScopeResolutionExpression | QuestionToken |
+   * @return LiteralExpression | ScopeResolutionExpression | QuestionToken |
    * VariableExpression
    */
   public function getName(): EditableNode {
@@ -109,7 +109,7 @@ final class FieldInitializer extends EditableNode {
   }
 
   /**
-   * @returns LiteralExpression | ScopeResolutionExpression | QuestionToken |
+   * @return LiteralExpression | ScopeResolutionExpression | QuestionToken |
    * VariableExpression
    */
   public function getNamex(): EditableNode {
@@ -132,14 +132,14 @@ final class FieldInitializer extends EditableNode {
   }
 
   /**
-   * @returns EqualGreaterThanToken
+   * @return EqualGreaterThanToken
    */
   public function getArrow(): EqualGreaterThanToken {
     return TypeAssert\instance_of(EqualGreaterThanToken::class, $this->_arrow);
   }
 
   /**
-   * @returns EqualGreaterThanToken
+   * @return EqualGreaterThanToken
    */
   public function getArrowx(): EqualGreaterThanToken {
     return $this->getArrow();
@@ -161,7 +161,7 @@ final class FieldInitializer extends EditableNode {
   }
 
   /**
-   * @returns ArrayIntrinsicExpression | BinaryExpression | LambdaExpression |
+   * @return ArrayIntrinsicExpression | BinaryExpression | LambdaExpression |
    * LiteralExpression | ObjectCreationExpression | ScopeResolutionExpression |
    * SubscriptExpression | NameToken | VariableExpression |
    * VectorIntrinsicExpression
@@ -171,7 +171,7 @@ final class FieldInitializer extends EditableNode {
   }
 
   /**
-   * @returns ArrayIntrinsicExpression | BinaryExpression | LambdaExpression |
+   * @return ArrayIntrinsicExpression | BinaryExpression | LambdaExpression |
    * LiteralExpression | ObjectCreationExpression | ScopeResolutionExpression |
    * SubscriptExpression | NameToken | VariableExpression |
    * VectorIntrinsicExpression

--- a/codegen/syntax/FieldSpecifier.php
+++ b/codegen/syntax/FieldSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f2c23fd0a030acf19891174b52d810ab>>
+ * @generated SignedSource<<b820c0bbfaa01d1a99e9c55f1f0852aa>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -114,7 +114,7 @@ final class FieldSpecifier extends EditableNode {
   }
 
   /**
-   * @returns Missing | QuestionToken
+   * @return null | QuestionToken
    */
   public function getQuestion(): ?QuestionToken {
     if ($this->_question->isMissing()) {
@@ -124,7 +124,7 @@ final class FieldSpecifier extends EditableNode {
   }
 
   /**
-   * @returns QuestionToken
+   * @return QuestionToken
    */
   public function getQuestionx(): QuestionToken {
     return TypeAssert\instance_of(QuestionToken::class, $this->_question);
@@ -146,14 +146,14 @@ final class FieldSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LiteralExpression | ScopeResolutionExpression
+   * @return LiteralExpression | ScopeResolutionExpression
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
   }
 
   /**
-   * @returns LiteralExpression | ScopeResolutionExpression
+   * @return LiteralExpression | ScopeResolutionExpression
    */
   public function getNamex(): EditableNode {
     return $this->getName();
@@ -175,14 +175,14 @@ final class FieldSpecifier extends EditableNode {
   }
 
   /**
-   * @returns EqualGreaterThanToken
+   * @return EqualGreaterThanToken
    */
   public function getArrow(): EqualGreaterThanToken {
     return TypeAssert\instance_of(EqualGreaterThanToken::class, $this->_arrow);
   }
 
   /**
-   * @returns EqualGreaterThanToken
+   * @return EqualGreaterThanToken
    */
   public function getArrowx(): EqualGreaterThanToken {
     return $this->getArrow();
@@ -204,7 +204,7 @@ final class FieldSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | GenericTypeSpecifier |
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier |
    * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
    * TypeConstant | VectorTypeSpecifier
    */
@@ -213,7 +213,7 @@ final class FieldSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | GenericTypeSpecifier |
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier |
    * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
    * TypeConstant | VectorTypeSpecifier
    */

--- a/codegen/syntax/FinallyClause.php
+++ b/codegen/syntax/FinallyClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1cdab1a5365210762fadedd2153ced8a>>
+ * @generated SignedSource<<50b8d19fab38f862b35df1e1c35769ac>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class FinallyClause extends EditableNode {
   }
 
   /**
-   * @returns FinallyToken
+   * @return FinallyToken
    */
   public function getKeyword(): FinallyToken {
     return TypeAssert\instance_of(FinallyToken::class, $this->_keyword);
   }
 
   /**
-   * @returns FinallyToken
+   * @return FinallyToken
    */
   public function getKeywordx(): FinallyToken {
     return $this->getKeyword();
@@ -111,14 +111,14 @@ final class FinallyClause extends EditableNode {
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getBody(): CompoundStatement {
     return TypeAssert\instance_of(CompoundStatement::class, $this->_body);
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getBodyx(): CompoundStatement {
     return $this->getBody();

--- a/codegen/syntax/ForStatement.php
+++ b/codegen/syntax/ForStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c8775c91fb67f1f67434920ca4171177>>
+ * @generated SignedSource<<c90703af80def230422c602bc1703fb0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -211,14 +211,14 @@ final class ForStatement
   }
 
   /**
-   * @returns ForToken
+   * @return ForToken
    */
   public function getKeyword(): ForToken {
     return TypeAssert\instance_of(ForToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ForToken
+   * @return ForToken
    */
   public function getKeywordx(): ForToken {
     return $this->getKeyword();
@@ -250,14 +250,14 @@ final class ForStatement
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -289,9 +289,9 @@ final class ForStatement
   }
 
   /**
-   * @returns EditableList<BinaryExpression> |
+   * @return EditableList<BinaryExpression> |
    * EditableList<FunctionCallExpression> | EditableList<LiteralExpression> |
-   * Missing
+   * null
    */
   public function getInitializer(): ?EditableList<EditableNode> {
     if ($this->_initializer->isMissing()) {
@@ -301,7 +301,7 @@ final class ForStatement
   }
 
   /**
-   * @returns EditableList<BinaryExpression> |
+   * @return EditableList<BinaryExpression> |
    * EditableList<FunctionCallExpression> | EditableList<LiteralExpression>
    */
   public function getInitializerx(): EditableList<EditableNode> {
@@ -334,7 +334,7 @@ final class ForStatement
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getFirstSemicolon(): SemicolonToken {
     return
@@ -342,7 +342,7 @@ final class ForStatement
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getFirstSemicolonx(): SemicolonToken {
     return $this->getFirstSemicolon();
@@ -374,10 +374,10 @@ final class ForStatement
   }
 
   /**
-   * @returns EditableList<BinaryExpression> | EditableList<EditableNode> |
+   * @return EditableList<BinaryExpression> | EditableList<EditableNode> |
    * EditableList<ConditionalExpression> | EditableList<FunctionCallExpression>
    * | EditableList<PrefixUnaryExpression> | EditableList<VariableExpression> |
-   * Missing
+   * null
    */
   public function getControl(): ?EditableList<EditableNode> {
     if ($this->_control->isMissing()) {
@@ -387,7 +387,7 @@ final class ForStatement
   }
 
   /**
-   * @returns EditableList<BinaryExpression> | EditableList<EditableNode> |
+   * @return EditableList<BinaryExpression> | EditableList<EditableNode> |
    * EditableList<ConditionalExpression> | EditableList<FunctionCallExpression>
    * | EditableList<PrefixUnaryExpression> | EditableList<VariableExpression>
    */
@@ -421,7 +421,7 @@ final class ForStatement
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSecondSemicolon(): SemicolonToken {
     return
@@ -429,7 +429,7 @@ final class ForStatement
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSecondSemicolonx(): SemicolonToken {
     return $this->getSecondSemicolon();
@@ -461,10 +461,10 @@ final class ForStatement
   }
 
   /**
-   * @returns EditableList<BinaryExpression> |
+   * @return EditableList<BinaryExpression> |
    * EditableList<FunctionCallExpression> |
    * EditableList<PostfixUnaryExpression> | EditableList<PrefixUnaryExpression>
-   * | Missing
+   * | null
    */
   public function getEndOfLoop(): ?EditableList<EditableNode> {
     if ($this->_end_of_loop->isMissing()) {
@@ -474,7 +474,7 @@ final class ForStatement
   }
 
   /**
-   * @returns EditableList<BinaryExpression> |
+   * @return EditableList<BinaryExpression> |
    * EditableList<FunctionCallExpression> |
    * EditableList<PostfixUnaryExpression> | EditableList<PrefixUnaryExpression>
    */
@@ -508,14 +508,14 @@ final class ForStatement
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -547,7 +547,7 @@ final class ForStatement
   }
 
   /**
-   * @returns AlternateLoopStatement | CompoundStatement | EchoStatement |
+   * @return AlternateLoopStatement | CompoundStatement | EchoStatement |
    * ExpressionStatement | ForStatement | UnsetStatement
    */
   public function getBody(): EditableNode {
@@ -555,7 +555,7 @@ final class ForStatement
   }
 
   /**
-   * @returns AlternateLoopStatement | CompoundStatement | EchoStatement |
+   * @return AlternateLoopStatement | CompoundStatement | EchoStatement |
    * ExpressionStatement | ForStatement | UnsetStatement
    */
   public function getBodyx(): EditableNode {

--- a/codegen/syntax/ForeachStatement.php
+++ b/codegen/syntax/ForeachStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<543cc69b87f4df641d8ac42b36ca6233>>
+ * @generated SignedSource<<18b4afcc92607714de791479685b10f6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -227,14 +227,14 @@ final class ForeachStatement
   }
 
   /**
-   * @returns ForeachToken
+   * @return ForeachToken
    */
   public function getKeyword(): ForeachToken {
     return TypeAssert\instance_of(ForeachToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ForeachToken
+   * @return ForeachToken
    */
   public function getKeywordx(): ForeachToken {
     return $this->getKeyword();
@@ -267,14 +267,14 @@ final class ForeachStatement
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -307,7 +307,7 @@ final class ForeachStatement
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | CastExpression | CollectionLiteralExpression |
    * FunctionCallExpression | MemberSelectionExpression |
    * ObjectCreationExpression | ParenthesizedExpression | PrefixUnaryExpression
@@ -319,7 +319,7 @@ final class ForeachStatement
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | CastExpression | CollectionLiteralExpression |
    * FunctionCallExpression | MemberSelectionExpression |
    * ObjectCreationExpression | ParenthesizedExpression | PrefixUnaryExpression
@@ -357,7 +357,7 @@ final class ForeachStatement
   }
 
   /**
-   * @returns Missing | AwaitToken
+   * @return null | AwaitToken
    */
   public function getAwaitKeyword(): ?AwaitToken {
     if ($this->_await_keyword->isMissing()) {
@@ -367,7 +367,7 @@ final class ForeachStatement
   }
 
   /**
-   * @returns AwaitToken
+   * @return AwaitToken
    */
   public function getAwaitKeywordx(): AwaitToken {
     return TypeAssert\instance_of(AwaitToken::class, $this->_await_keyword);
@@ -400,14 +400,14 @@ final class ForeachStatement
   }
 
   /**
-   * @returns AsToken
+   * @return AsToken
    */
   public function getAs(): AsToken {
     return TypeAssert\instance_of(AsToken::class, $this->_as);
   }
 
   /**
-   * @returns AsToken
+   * @return AsToken
    */
   public function getAsx(): AsToken {
     return $this->getAs();
@@ -440,8 +440,8 @@ final class ForeachStatement
   }
 
   /**
-   * @returns FunctionCallExpression | ListExpression |
-   * MemberSelectionExpression | Missing | PrefixUnaryExpression |
+   * @return FunctionCallExpression | ListExpression |
+   * MemberSelectionExpression | null | PrefixUnaryExpression |
    * ScopeResolutionExpression | SubscriptExpression | NameToken |
    * VariableExpression
    */
@@ -453,7 +453,7 @@ final class ForeachStatement
   }
 
   /**
-   * @returns FunctionCallExpression | ListExpression |
+   * @return FunctionCallExpression | ListExpression |
    * MemberSelectionExpression | PrefixUnaryExpression |
    * ScopeResolutionExpression | SubscriptExpression | NameToken |
    * VariableExpression
@@ -489,7 +489,7 @@ final class ForeachStatement
   }
 
   /**
-   * @returns Missing | EqualGreaterThanToken
+   * @return null | EqualGreaterThanToken
    */
   public function getArrow(): ?EqualGreaterThanToken {
     if ($this->_arrow->isMissing()) {
@@ -499,7 +499,7 @@ final class ForeachStatement
   }
 
   /**
-   * @returns EqualGreaterThanToken
+   * @return EqualGreaterThanToken
    */
   public function getArrowx(): EqualGreaterThanToken {
     return TypeAssert\instance_of(EqualGreaterThanToken::class, $this->_arrow);
@@ -532,7 +532,7 @@ final class ForeachStatement
   }
 
   /**
-   * @returns FunctionCallExpression | ListExpression |
+   * @return FunctionCallExpression | ListExpression |
    * MemberSelectionExpression | PrefixUnaryExpression |
    * ScopeResolutionExpression | SubscriptExpression | NameToken |
    * VariableExpression
@@ -542,7 +542,7 @@ final class ForeachStatement
   }
 
   /**
-   * @returns FunctionCallExpression | ListExpression |
+   * @return FunctionCallExpression | ListExpression |
    * MemberSelectionExpression | PrefixUnaryExpression |
    * ScopeResolutionExpression | SubscriptExpression | NameToken |
    * VariableExpression
@@ -578,14 +578,14 @@ final class ForeachStatement
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -618,7 +618,7 @@ final class ForeachStatement
   }
 
   /**
-   * @returns AlternateLoopStatement | CompoundStatement | EchoStatement |
+   * @return AlternateLoopStatement | CompoundStatement | EchoStatement |
    * ExpressionStatement | ForeachStatement
    */
   public function getBody(): EditableNode {
@@ -626,7 +626,7 @@ final class ForeachStatement
   }
 
   /**
-   * @returns AlternateLoopStatement | CompoundStatement | EchoStatement |
+   * @return AlternateLoopStatement | CompoundStatement | EchoStatement |
    * ExpressionStatement | ForeachStatement
    */
   public function getBodyx(): EditableNode {

--- a/codegen/syntax/FunctionCallExpression.php
+++ b/codegen/syntax/FunctionCallExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f2861a941fcf8e88f2b4276a6de9a7bc>>
+ * @generated SignedSource<<14692f136c4081791b71b5db519f745c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,7 +119,7 @@ final class FunctionCallExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayCreationExpression | FunctionCallExpression |
+   * @return ArrayCreationExpression | FunctionCallExpression |
    * LiteralExpression | MemberSelectionExpression | ParenthesizedExpression |
    * PrefixUnaryExpression | QualifiedName | SafeMemberSelectionExpression |
    * ScopeResolutionExpression | SubscriptExpression | IfToken | NameToken |
@@ -130,7 +130,7 @@ final class FunctionCallExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayCreationExpression | FunctionCallExpression |
+   * @return ArrayCreationExpression | FunctionCallExpression |
    * LiteralExpression | MemberSelectionExpression | ParenthesizedExpression |
    * PrefixUnaryExpression | QualifiedName | SafeMemberSelectionExpression |
    * ScopeResolutionExpression | SubscriptExpression | IfToken | NameToken |
@@ -161,14 +161,14 @@ final class FunctionCallExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -195,7 +195,7 @@ final class FunctionCallExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<AnonymousFunction> | EditableList<EditableNode> |
+   * @return EditableList<AnonymousFunction> | EditableList<EditableNode> |
    * EditableList<ArrayCreationExpression> |
    * EditableList<ArrayIntrinsicExpression> | EditableList<AsExpression> |
    * EditableList<AwaitableCreationExpression> | EditableList<BinaryExpression>
@@ -221,7 +221,7 @@ final class FunctionCallExpression extends EditableNode {
    * EditableList<TupleExpression> | EditableList<VariableExpression> |
    * EditableList<VarrayIntrinsicExpression> |
    * EditableList<VectorIntrinsicExpression> | EditableList<XHPExpression> |
-   * Missing
+   * null
    */
   public function getArgumentList(): ?EditableList<?EditableNode> {
     if ($this->_argument_list->isMissing()) {
@@ -231,7 +231,7 @@ final class FunctionCallExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<AnonymousFunction> | EditableList<EditableNode> |
+   * @return EditableList<AnonymousFunction> | EditableList<EditableNode> |
    * EditableList<ArrayCreationExpression> |
    * EditableList<ArrayIntrinsicExpression> | EditableList<AsExpression> |
    * EditableList<AwaitableCreationExpression> | EditableList<BinaryExpression>
@@ -283,7 +283,7 @@ final class FunctionCallExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing | RightParenToken
+   * @return null | RightParenToken
    */
   public function getRightParen(): ?RightParenToken {
     if ($this->_right_paren->isMissing()) {
@@ -293,7 +293,7 @@ final class FunctionCallExpression extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);

--- a/codegen/syntax/FunctionCallWithTypeArgumentsExpression.php
+++ b/codegen/syntax/FunctionCallWithTypeArgumentsExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<59ad3349c3602788c4730def97da56bb>>
+ * @generated SignedSource<<5a92156479671f18b861c732f77ed7d6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -145,14 +145,14 @@ final class FunctionCallWithTypeArgumentsExpression extends EditableNode {
   }
 
   /**
-   * @returns MemberSelectionExpression | ScopeResolutionExpression | NameToken
+   * @return MemberSelectionExpression | ScopeResolutionExpression | NameToken
    */
   public function getReceiver(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_receiver);
   }
 
   /**
-   * @returns MemberSelectionExpression | ScopeResolutionExpression | NameToken
+   * @return MemberSelectionExpression | ScopeResolutionExpression | NameToken
    */
   public function getReceiverx(): EditableNode {
     return $this->getReceiver();
@@ -180,14 +180,14 @@ final class FunctionCallWithTypeArgumentsExpression extends EditableNode {
   }
 
   /**
-   * @returns TypeArguments
+   * @return TypeArguments
    */
   public function getTypeArgs(): TypeArguments {
     return TypeAssert\instance_of(TypeArguments::class, $this->_type_args);
   }
 
   /**
-   * @returns TypeArguments
+   * @return TypeArguments
    */
   public function getTypeArgsx(): TypeArguments {
     return $this->getTypeArgs();
@@ -215,14 +215,14 @@ final class FunctionCallWithTypeArgumentsExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -250,8 +250,8 @@ final class FunctionCallWithTypeArgumentsExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | EditableList<LiteralExpression> |
-   * EditableList<TupleExpression> | EditableList<VariableExpression> | Missing
+   * @return EditableList<EditableNode> | EditableList<LiteralExpression> |
+   * EditableList<TupleExpression> | EditableList<VariableExpression> | null
    */
   public function getArgumentList(): ?EditableList<EditableNode> {
     if ($this->_argument_list->isMissing()) {
@@ -261,7 +261,7 @@ final class FunctionCallWithTypeArgumentsExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | EditableList<LiteralExpression> |
+   * @return EditableList<EditableNode> | EditableList<LiteralExpression> |
    * EditableList<TupleExpression> | EditableList<VariableExpression>
    */
   public function getArgumentListx(): EditableList<EditableNode> {
@@ -290,14 +290,14 @@ final class FunctionCallWithTypeArgumentsExpression extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();

--- a/codegen/syntax/FunctionDeclaration.php
+++ b/codegen/syntax/FunctionDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<dc2428e2bc05b2151c4feaca8cb0ef4c>>
+ * @generated SignedSource<<e368d0ae1b8aed7b3e1f422098fd0fcc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -104,7 +104,7 @@ final class FunctionDeclaration
   }
 
   /**
-   * @returns AttributeSpecification | Missing
+   * @return AttributeSpecification | null
    */
   public function getAttributeSpec(): ?AttributeSpecification {
     if ($this->_attribute_spec->isMissing()) {
@@ -117,7 +117,7 @@ final class FunctionDeclaration
   }
 
   /**
-   * @returns AttributeSpecification
+   * @return AttributeSpecification
    */
   public function getAttributeSpecx(): AttributeSpecification {
     return TypeAssert\instance_of(
@@ -142,7 +142,7 @@ final class FunctionDeclaration
   }
 
   /**
-   * @returns FunctionDeclarationHeader
+   * @return FunctionDeclarationHeader
    */
   public function getDeclarationHeader(): FunctionDeclarationHeader {
     return TypeAssert\instance_of(
@@ -152,7 +152,7 @@ final class FunctionDeclaration
   }
 
   /**
-   * @returns FunctionDeclarationHeader
+   * @return FunctionDeclarationHeader
    */
   public function getDeclarationHeaderx(): FunctionDeclarationHeader {
     return $this->getDeclarationHeader();
@@ -175,14 +175,14 @@ final class FunctionDeclaration
   }
 
   /**
-   * @returns CompoundStatement | SemicolonToken
+   * @return CompoundStatement | SemicolonToken
    */
   public function getBody(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_body);
   }
 
   /**
-   * @returns CompoundStatement | SemicolonToken
+   * @return CompoundStatement | SemicolonToken
    */
   public function getBodyx(): EditableNode {
     return $this->getBody();

--- a/codegen/syntax/FunctionDeclarationHeader.php
+++ b/codegen/syntax/FunctionDeclarationHeader.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2547bcd75a637fc92376ac2c86223997>>
+ * @generated SignedSource<<bc21cb6e1412667b2c7097c41988188f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -242,7 +242,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getModifiers(): ?EditableList<EditableNode> {
     if ($this->_modifiers->isMissing()) {
@@ -252,7 +252,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getModifiersx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_modifiers);
@@ -286,7 +286,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns Missing | FunctionToken
+   * @return null | FunctionToken
    */
   public function getKeyword(): ?FunctionToken {
     if ($this->_keyword->isMissing()) {
@@ -296,7 +296,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns FunctionToken
+   * @return FunctionToken
    */
   public function getKeywordx(): FunctionToken {
     return TypeAssert\instance_of(FunctionToken::class, $this->_keyword);
@@ -330,7 +330,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns Missing | AmpersandToken
+   * @return null | AmpersandToken
    */
   public function getAmpersand(): ?AmpersandToken {
     if ($this->_ampersand->isMissing()) {
@@ -340,7 +340,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns AmpersandToken
+   * @return AmpersandToken
    */
   public function getAmpersandx(): AmpersandToken {
     return TypeAssert\instance_of(AmpersandToken::class, $this->_ampersand);
@@ -374,14 +374,14 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns ConstructToken | DestructToken | NameToken
+   * @return ConstructToken | DestructToken | NameToken
    */
   public function getName(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_name);
   }
 
   /**
-   * @returns ConstructToken | DestructToken | NameToken
+   * @return ConstructToken | DestructToken | NameToken
    */
   public function getNamex(): EditableToken {
     return $this->getName();
@@ -415,7 +415,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns Missing | TypeParameters
+   * @return null | TypeParameters
    */
   public function getTypeParameterList(): ?TypeParameters {
     if ($this->_type_parameter_list->isMissing()) {
@@ -428,7 +428,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns TypeParameters
+   * @return TypeParameters
    */
   public function getTypeParameterListx(): TypeParameters {
     return TypeAssert\instance_of(
@@ -465,7 +465,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns Missing | LeftParenToken
+   * @return null | LeftParenToken
    */
   public function getLeftParen(): ?LeftParenToken {
     if ($this->_left_paren->isMissing()) {
@@ -475,7 +475,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
@@ -509,9 +509,9 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns EditableList<?ParameterDeclaration> |
+   * @return EditableList<?ParameterDeclaration> |
    * EditableList<ParameterDeclaration> | EditableList<EditableNode> |
-   * EditableList<VariadicParameter> | Missing
+   * EditableList<VariadicParameter> | null
    */
   public function getParameterList(): ?EditableList<?EditableNode> {
     if ($this->_parameter_list->isMissing()) {
@@ -521,7 +521,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns EditableList<?ParameterDeclaration> |
+   * @return EditableList<?ParameterDeclaration> |
    * EditableList<ParameterDeclaration> | EditableList<EditableNode> |
    * EditableList<VariadicParameter>
    */
@@ -557,7 +557,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns Missing | RightParenToken
+   * @return null | RightParenToken
    */
   public function getRightParen(): ?RightParenToken {
     if ($this->_right_paren->isMissing()) {
@@ -567,7 +567,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
@@ -601,7 +601,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns Missing | ColonToken
+   * @return null | ColonToken
    */
   public function getColon(): ?ColonToken {
     if ($this->_colon->isMissing()) {
@@ -611,7 +611,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColonx(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
@@ -645,12 +645,12 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
    * DarrayTypeSpecifier | DictionaryTypeSpecifier | GenericTypeSpecifier |
-   * KeysetTypeSpecifier | MapArrayTypeSpecifier | Missing |
-   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
-   * SoftTypeSpecifier | NoreturnToken | TupleTypeSpecifier | TypeConstant |
-   * VarrayTypeSpecifier | VectorArrayTypeSpecifier | VectorTypeSpecifier
+   * KeysetTypeSpecifier | MapArrayTypeSpecifier | null | NullableTypeSpecifier
+   * | ShapeTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier |
+   * NoreturnToken | TupleTypeSpecifier | TypeConstant | VarrayTypeSpecifier |
+   * VectorArrayTypeSpecifier | VectorTypeSpecifier
    */
   public function getType(): ?EditableNode {
     if ($this->_type->isMissing()) {
@@ -660,7 +660,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
    * DarrayTypeSpecifier | DictionaryTypeSpecifier | GenericTypeSpecifier |
    * KeysetTypeSpecifier | MapArrayTypeSpecifier | NullableTypeSpecifier |
    * ShapeTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier |
@@ -699,7 +699,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns Missing | WhereClause
+   * @return null | WhereClause
    */
   public function getWhereClause(): ?WhereClause {
     if ($this->_where_clause->isMissing()) {
@@ -709,7 +709,7 @@ final class FunctionDeclarationHeader extends EditableNode {
   }
 
   /**
-   * @returns WhereClause
+   * @return WhereClause
    */
   public function getWhereClausex(): WhereClause {
     return TypeAssert\instance_of(WhereClause::class, $this->_where_clause);

--- a/codegen/syntax/FunctionStaticStatement.php
+++ b/codegen/syntax/FunctionStaticStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<52ad1657e248e81337b7f612c8f576f6>>
+ * @generated SignedSource<<0778d4161d8d42f7246d448261462a00>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class FunctionStaticStatement extends EditableNode {
   }
 
   /**
-   * @returns StaticToken
+   * @return StaticToken
    */
   public function getStaticKeyword(): StaticToken {
     return TypeAssert\instance_of(StaticToken::class, $this->_static_keyword);
   }
 
   /**
-   * @returns StaticToken
+   * @return StaticToken
    */
   public function getStaticKeywordx(): StaticToken {
     return $this->getStaticKeyword();
@@ -130,14 +130,14 @@ final class FunctionStaticStatement extends EditableNode {
   }
 
   /**
-   * @returns EditableList<StaticDeclarator>
+   * @return EditableList<StaticDeclarator>
    */
   public function getDeclarations(): EditableList<StaticDeclarator> {
     return TypeAssert\instance_of(EditableList::class, $this->_declarations);
   }
 
   /**
-   * @returns EditableList<StaticDeclarator>
+   * @return EditableList<StaticDeclarator>
    */
   public function getDeclarationsx(): EditableList<StaticDeclarator> {
     return $this->getDeclarations();
@@ -159,14 +159,14 @@ final class FunctionStaticStatement extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/GenericTypeSpecifier.php
+++ b/codegen/syntax/GenericTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cf7142ff4986e7e4130b7ec18bdd4e4c>>
+ * @generated SignedSource<<6de5ec36e6e08b97e4cbd4d3f8e0c86c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -88,14 +88,14 @@ final class GenericTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns QualifiedName | XHPClassNameToken | NameToken | StringToken
+   * @return QualifiedName | XHPClassNameToken | NameToken | StringToken
    */
   public function getClassType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_class_type);
   }
 
   /**
-   * @returns QualifiedName | XHPClassNameToken | NameToken | StringToken
+   * @return QualifiedName | XHPClassNameToken | NameToken | StringToken
    */
   public function getClassTypex(): EditableNode {
     return $this->getClassType();
@@ -117,14 +117,14 @@ final class GenericTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns TypeArguments
+   * @return TypeArguments
    */
   public function getArgumentList(): TypeArguments {
     return TypeAssert\instance_of(TypeArguments::class, $this->_argument_list);
   }
 
   /**
-   * @returns TypeArguments
+   * @return TypeArguments
    */
   public function getArgumentListx(): TypeArguments {
     return $this->getArgumentList();

--- a/codegen/syntax/GlobalStatement.php
+++ b/codegen/syntax/GlobalStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<48387d2ff5f84554544861925d4578ae>>
+ * @generated SignedSource<<975e872c87c59506997082b79c70aa96>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class GlobalStatement extends EditableNode {
   }
 
   /**
-   * @returns GlobalToken
+   * @return GlobalToken
    */
   public function getKeyword(): GlobalToken {
     return TypeAssert\instance_of(GlobalToken::class, $this->_keyword);
   }
 
   /**
-   * @returns GlobalToken
+   * @return GlobalToken
    */
   public function getKeywordx(): GlobalToken {
     return $this->getKeyword();
@@ -130,14 +130,14 @@ final class GlobalStatement extends EditableNode {
   }
 
   /**
-   * @returns EditableList<PrefixUnaryExpression> | EditableList<VariableToken>
+   * @return EditableList<PrefixUnaryExpression> | EditableList<VariableToken>
    */
   public function getVariables(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_variables);
   }
 
   /**
-   * @returns EditableList<PrefixUnaryExpression> | EditableList<VariableToken>
+   * @return EditableList<PrefixUnaryExpression> | EditableList<VariableToken>
    */
   public function getVariablesx(): EditableList<EditableNode> {
     return $this->getVariables();
@@ -159,14 +159,14 @@ final class GlobalStatement extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/GotoLabel.php
+++ b/codegen/syntax/GotoLabel.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8a0298be636102197b9fb4147f982ad6>>
+ * @generated SignedSource<<e95b5d63c2ac17dbedbee736c5c8b2d5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class GotoLabel extends EditableNode {
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getNamex(): NameToken {
     return $this->getName();
@@ -111,14 +111,14 @@ final class GotoLabel extends EditableNode {
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColon(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColonx(): ColonToken {
     return $this->getColon();

--- a/codegen/syntax/GotoStatement.php
+++ b/codegen/syntax/GotoStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<86aed5631ecd41c48b6514aee44a2cc1>>
+ * @generated SignedSource<<6359e6876f3cbf0f6b2bee6c055385dd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class GotoStatement extends EditableNode {
   }
 
   /**
-   * @returns GotoToken
+   * @return GotoToken
    */
   public function getKeyword(): GotoToken {
     return TypeAssert\instance_of(GotoToken::class, $this->_keyword);
   }
 
   /**
-   * @returns GotoToken
+   * @return GotoToken
    */
   public function getKeywordx(): GotoToken {
     return $this->getKeyword();
@@ -130,14 +130,14 @@ final class GotoStatement extends EditableNode {
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getLabelName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_label_name);
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getLabelNamex(): NameToken {
     return $this->getLabelName();
@@ -159,14 +159,14 @@ final class GotoStatement extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/HaltCompilerExpression.php
+++ b/codegen/syntax/HaltCompilerExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e197cab58cb484f5f67851e264ebb629>>
+ * @generated SignedSource<<e0fb29152c2739e104189cb017849de7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class HaltCompilerExpression extends EditableNode {
   }
 
   /**
-   * @returns HaltCompilerToken
+   * @return HaltCompilerToken
    */
   public function getKeyword(): HaltCompilerToken {
     return TypeAssert\instance_of(HaltCompilerToken::class, $this->_keyword);
   }
 
   /**
-   * @returns HaltCompilerToken
+   * @return HaltCompilerToken
    */
   public function getKeywordx(): HaltCompilerToken {
     return $this->getKeyword();
@@ -153,14 +153,14 @@ final class HaltCompilerExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -187,7 +187,7 @@ final class HaltCompilerExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getArgumentList(): ?EditableNode {
     if ($this->_argument_list->isMissing()) {
@@ -197,7 +197,7 @@ final class HaltCompilerExpression extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getArgumentListx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_argument_list);
@@ -224,14 +224,14 @@ final class HaltCompilerExpression extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();

--- a/codegen/syntax/IfStatement.php
+++ b/codegen/syntax/IfStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9d48ab305ddb66e80ec83afd2fdfe80c>>
+ * @generated SignedSource<<7c5e78c04ad3c690f515de46f5986972>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -177,14 +177,14 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns IfToken
+   * @return IfToken
    */
   public function getKeyword(): IfToken {
     return TypeAssert\instance_of(IfToken::class, $this->_keyword);
   }
 
   /**
-   * @returns IfToken
+   * @return IfToken
    */
   public function getKeywordx(): IfToken {
     return $this->getKeyword();
@@ -214,14 +214,14 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -251,7 +251,7 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns ArrayIntrinsicExpression | AsExpression | BinaryExpression |
+   * @return ArrayIntrinsicExpression | AsExpression | BinaryExpression |
    * CastExpression | EmptyExpression | FunctionCallExpression |
    * InstanceofExpression | IsExpression | IssetExpression | LiteralExpression
    * | MemberSelectionExpression | ParenthesizedExpression |
@@ -263,7 +263,7 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns ArrayIntrinsicExpression | AsExpression | BinaryExpression |
+   * @return ArrayIntrinsicExpression | AsExpression | BinaryExpression |
    * CastExpression | EmptyExpression | FunctionCallExpression |
    * InstanceofExpression | IsExpression | IssetExpression | LiteralExpression
    * | MemberSelectionExpression | ParenthesizedExpression |
@@ -298,14 +298,14 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -335,7 +335,7 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns BreakStatement | CompoundStatement | ContinueStatement |
+   * @return BreakStatement | CompoundStatement | ContinueStatement |
    * EchoStatement | ExpressionStatement | GlobalStatement | GotoStatement |
    * ReturnStatement | ThrowStatement | UnsetStatement
    */
@@ -344,7 +344,7 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns BreakStatement | CompoundStatement | ContinueStatement |
+   * @return BreakStatement | CompoundStatement | ContinueStatement |
    * EchoStatement | ExpressionStatement | GlobalStatement | GotoStatement |
    * ReturnStatement | ThrowStatement | UnsetStatement
    */
@@ -376,7 +376,7 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getElseifClauses(): ?EditableList<EditableNode> {
     if ($this->_elseif_clauses->isMissing()) {
@@ -386,7 +386,7 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getElseifClausesx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_elseif_clauses);
@@ -416,7 +416,7 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns ElseClause | Missing
+   * @return ElseClause | null
    */
   public function getElseClause(): ?ElseClause {
     if ($this->_else_clause->isMissing()) {
@@ -426,7 +426,7 @@ final class IfStatement extends EditableNode implements IControlFlowStatement {
   }
 
   /**
-   * @returns ElseClause
+   * @return ElseClause
    */
   public function getElseClausex(): ElseClause {
     return TypeAssert\instance_of(ElseClause::class, $this->_else_clause);

--- a/codegen/syntax/InclusionDirective.php
+++ b/codegen/syntax/InclusionDirective.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<83a55a9df91186c9e378cc690d403865>>
+ * @generated SignedSource<<c626083815d15e0469614291f808c88d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -87,7 +87,7 @@ final class InclusionDirective extends EditableNode {
   }
 
   /**
-   * @returns InclusionExpression
+   * @return InclusionExpression
    */
   public function getExpression(): InclusionExpression {
     return
@@ -95,7 +95,7 @@ final class InclusionDirective extends EditableNode {
   }
 
   /**
-   * @returns InclusionExpression
+   * @return InclusionExpression
    */
   public function getExpressionx(): InclusionExpression {
     return $this->getExpression();
@@ -117,14 +117,14 @@ final class InclusionDirective extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/InclusionExpression.php
+++ b/codegen/syntax/InclusionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4f5556b44e4f860ef90aaca8b92bd5e2>>
+ * @generated SignedSource<<cd6ba52db76f28fa62e7142d553e7b0b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,16 +82,14 @@ final class InclusionExpression extends EditableNode {
   }
 
   /**
-   * @returns IncludeToken | Include_onceToken | RequireToken |
-   * Require_onceToken
+   * @return IncludeToken | Include_onceToken | RequireToken | Require_onceToken
    */
   public function getRequire(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_require);
   }
 
   /**
-   * @returns IncludeToken | Include_onceToken | RequireToken |
-   * Require_onceToken
+   * @return IncludeToken | Include_onceToken | RequireToken | Require_onceToken
    */
   public function getRequirex(): EditableToken {
     return $this->getRequire();
@@ -113,7 +111,7 @@ final class InclusionExpression extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression | LiteralExpression | ParenthesizedExpression |
+   * @return BinaryExpression | LiteralExpression | ParenthesizedExpression |
    * SubscriptExpression | NameToken | VariableExpression
    */
   public function getFilename(): EditableNode {
@@ -121,7 +119,7 @@ final class InclusionExpression extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression | LiteralExpression | ParenthesizedExpression |
+   * @return BinaryExpression | LiteralExpression | ParenthesizedExpression |
    * SubscriptExpression | NameToken | VariableExpression
    */
   public function getFilenamex(): EditableNode {

--- a/codegen/syntax/InstanceofExpression.php
+++ b/codegen/syntax/InstanceofExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<316f0f7f7ba81fc2bed90fc96440d1e9>>
+ * @generated SignedSource<<2c75885f528fda8f58f7f839f893e71b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,8 +101,8 @@ final class InstanceofExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | CastExpression | CollectionLiteralExpression
-   * | FunctionCallExpression | LiteralExpression | MemberSelectionExpression |
+   * @return AnonymousFunction | CastExpression | CollectionLiteralExpression |
+   * FunctionCallExpression | LiteralExpression | MemberSelectionExpression |
    * ObjectCreationExpression | ParenthesizedExpression |
    * PipeVariableExpression | PrefixUnaryExpression | ScopeResolutionExpression
    * | SubscriptExpression | VariableExpression
@@ -112,8 +112,8 @@ final class InstanceofExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | CastExpression | CollectionLiteralExpression
-   * | FunctionCallExpression | LiteralExpression | MemberSelectionExpression |
+   * @return AnonymousFunction | CastExpression | CollectionLiteralExpression |
+   * FunctionCallExpression | LiteralExpression | MemberSelectionExpression |
    * ObjectCreationExpression | ParenthesizedExpression |
    * PipeVariableExpression | PrefixUnaryExpression | ScopeResolutionExpression
    * | SubscriptExpression | VariableExpression
@@ -138,14 +138,14 @@ final class InstanceofExpression extends EditableNode {
   }
 
   /**
-   * @returns InstanceofToken
+   * @return InstanceofToken
    */
   public function getOperator(): InstanceofToken {
     return TypeAssert\instance_of(InstanceofToken::class, $this->_operator);
   }
 
   /**
-   * @returns InstanceofToken
+   * @return InstanceofToken
    */
   public function getOperatorx(): InstanceofToken {
     return $this->getOperator();
@@ -167,7 +167,7 @@ final class InstanceofExpression extends EditableNode {
   }
 
   /**
-   * @returns MemberSelectionExpression | Missing | ParenthesizedExpression |
+   * @return MemberSelectionExpression | null | ParenthesizedExpression |
    * QualifiedName | ScopeResolutionExpression | SubscriptExpression |
    * NameToken | VariableExpression
    */
@@ -179,7 +179,7 @@ final class InstanceofExpression extends EditableNode {
   }
 
   /**
-   * @returns MemberSelectionExpression | ParenthesizedExpression |
+   * @return MemberSelectionExpression | ParenthesizedExpression |
    * QualifiedName | ScopeResolutionExpression | SubscriptExpression |
    * NameToken | VariableExpression
    */

--- a/codegen/syntax/IsExpression.php
+++ b/codegen/syntax/IsExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<787808121e5e2a60ec6cb21a125f98af>>
+ * @generated SignedSource<<57de81f2803de4a5690047559e683022>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,16 +101,16 @@ final class IsExpression extends EditableNode {
   }
 
   /**
-   * @returns FunctionCallWithTypeArgumentsExpression | PipeVariableExpression
-   * | PrefixUnaryExpression | VariableExpression
+   * @return FunctionCallWithTypeArgumentsExpression | PipeVariableExpression |
+   * PrefixUnaryExpression | VariableExpression
    */
   public function getLeftOperand(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_operand);
   }
 
   /**
-   * @returns FunctionCallWithTypeArgumentsExpression | PipeVariableExpression
-   * | PrefixUnaryExpression | VariableExpression
+   * @return FunctionCallWithTypeArgumentsExpression | PipeVariableExpression |
+   * PrefixUnaryExpression | VariableExpression
    */
   public function getLeftOperandx(): EditableNode {
     return $this->getLeftOperand();
@@ -132,14 +132,14 @@ final class IsExpression extends EditableNode {
   }
 
   /**
-   * @returns IsToken
+   * @return IsToken
    */
   public function getOperator(): IsToken {
     return TypeAssert\instance_of(IsToken::class, $this->_operator);
   }
 
   /**
-   * @returns IsToken
+   * @return IsToken
    */
   public function getOperatorx(): IsToken {
     return $this->getOperator();
@@ -161,7 +161,7 @@ final class IsExpression extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | DictionaryTypeSpecifier |
+   * @return ClosureTypeSpecifier | DictionaryTypeSpecifier |
    * GenericTypeSpecifier | KeysetTypeSpecifier | NullableTypeSpecifier |
    * ShapeTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier |
    * TupleTypeSpecifier | TypeConstant | VectorTypeSpecifier
@@ -171,7 +171,7 @@ final class IsExpression extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | DictionaryTypeSpecifier |
+   * @return ClosureTypeSpecifier | DictionaryTypeSpecifier |
    * GenericTypeSpecifier | KeysetTypeSpecifier | NullableTypeSpecifier |
    * ShapeTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier |
    * TupleTypeSpecifier | TypeConstant | VectorTypeSpecifier

--- a/codegen/syntax/IssetExpression.php
+++ b/codegen/syntax/IssetExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9fd5e9d9809d3513907a5b15f0d97c34>>
+ * @generated SignedSource<<46b07d07c23f5fae6e98976311bc8773>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class IssetExpression extends EditableNode {
   }
 
   /**
-   * @returns IssetToken
+   * @return IssetToken
    */
   public function getKeyword(): IssetToken {
     return TypeAssert\instance_of(IssetToken::class, $this->_keyword);
   }
 
   /**
-   * @returns IssetToken
+   * @return IssetToken
    */
   public function getKeywordx(): IssetToken {
     return $this->getKeyword();
@@ -153,14 +153,14 @@ final class IssetExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -187,7 +187,7 @@ final class IssetExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<FunctionCallExpression> | EditableList<EditableNode>
+   * @return EditableList<FunctionCallExpression> | EditableList<EditableNode>
    * | EditableList<MemberSelectionExpression> |
    * EditableList<PrefixUnaryExpression> |
    * EditableList<SafeMemberSelectionExpression> |
@@ -199,7 +199,7 @@ final class IssetExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<FunctionCallExpression> | EditableList<EditableNode>
+   * @return EditableList<FunctionCallExpression> | EditableList<EditableNode>
    * | EditableList<MemberSelectionExpression> |
    * EditableList<PrefixUnaryExpression> |
    * EditableList<SafeMemberSelectionExpression> |
@@ -231,14 +231,14 @@ final class IssetExpression extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();

--- a/codegen/syntax/KeysetIntrinsicExpression.php
+++ b/codegen/syntax/KeysetIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8af418dd148dfdb36b8ba95c979b4819>>
+ * @generated SignedSource<<d017837f6ad8231a3814a96369430d19>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -145,14 +145,14 @@ final class KeysetIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns KeysetToken
+   * @return KeysetToken
    */
   public function getKeyword(): KeysetToken {
     return TypeAssert\instance_of(KeysetToken::class, $this->_keyword);
   }
 
   /**
-   * @returns KeysetToken
+   * @return KeysetToken
    */
   public function getKeywordx(): KeysetToken {
     return $this->getKeyword();
@@ -180,7 +180,7 @@ final class KeysetIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getExplicitType(): ?EditableNode {
     if ($this->_explicit_type->isMissing()) {
@@ -190,7 +190,7 @@ final class KeysetIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getExplicitTypex(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_explicit_type);
@@ -218,7 +218,7 @@ final class KeysetIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBracketToken
+   * @return LeftBracketToken
    */
   public function getLeftBracket(): LeftBracketToken {
     return
@@ -226,7 +226,7 @@ final class KeysetIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBracketToken
+   * @return LeftBracketToken
    */
   public function getLeftBracketx(): LeftBracketToken {
     return $this->getLeftBracket();
@@ -254,7 +254,7 @@ final class KeysetIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ArrayIntrinsicExpression> |
+   * @return EditableList<ArrayIntrinsicExpression> |
    * EditableList<EditableNode> | EditableList<CollectionLiteralExpression> |
    * EditableList<ConditionalExpression> |
    * EditableList<DictionaryIntrinsicExpression> |
@@ -263,7 +263,7 @@ final class KeysetIntrinsicExpression extends EditableNode {
    * | EditableList<ObjectCreationExpression> |
    * EditableList<ScopeResolutionExpression> | EditableList<NameToken> |
    * EditableList<VariableExpression> | EditableList<VectorIntrinsicExpression>
-   * | Missing
+   * | null
    */
   public function getMembers(): ?EditableList<EditableNode> {
     if ($this->_members->isMissing()) {
@@ -273,7 +273,7 @@ final class KeysetIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ArrayIntrinsicExpression> |
+   * @return EditableList<ArrayIntrinsicExpression> |
    * EditableList<EditableNode> | EditableList<CollectionLiteralExpression> |
    * EditableList<ConditionalExpression> |
    * EditableList<DictionaryIntrinsicExpression> |
@@ -309,7 +309,7 @@ final class KeysetIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBracketToken
+   * @return RightBracketToken
    */
   public function getRightBracket(): RightBracketToken {
     return
@@ -317,7 +317,7 @@ final class KeysetIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBracketToken
+   * @return RightBracketToken
    */
   public function getRightBracketx(): RightBracketToken {
     return $this->getRightBracket();

--- a/codegen/syntax/KeysetTypeSpecifier.php
+++ b/codegen/syntax/KeysetTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2e518b9a893f139bc92c5ad5243682df>>
+ * @generated SignedSource<<99567486820fb5833edefbc5a2fb0bc4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -135,14 +135,14 @@ final class KeysetTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns KeysetToken
+   * @return KeysetToken
    */
   public function getKeyword(): KeysetToken {
     return TypeAssert\instance_of(KeysetToken::class, $this->_keyword);
   }
 
   /**
-   * @returns KeysetToken
+   * @return KeysetToken
    */
   public function getKeywordx(): KeysetToken {
     return $this->getKeyword();
@@ -170,14 +170,14 @@ final class KeysetTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAnglex(): LessThanToken {
     return $this->getLeftAngle();
@@ -205,14 +205,14 @@ final class KeysetTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getType(): SimpleTypeSpecifier {
     return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_type);
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getTypex(): SimpleTypeSpecifier {
     return $this->getType();
@@ -240,7 +240,7 @@ final class KeysetTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getTrailingComma(): ?EditableNode {
     if ($this->_trailing_comma->isMissing()) {
@@ -250,7 +250,7 @@ final class KeysetTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getTrailingCommax(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_trailing_comma);
@@ -278,14 +278,14 @@ final class KeysetTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAnglex(): GreaterThanToken {
     return $this->getRightAngle();

--- a/codegen/syntax/LambdaExpression.php
+++ b/codegen/syntax/LambdaExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<948770ddde2618e0d8218a85cd0d3823>>
+ * @generated SignedSource<<664e7cd39cddd81337d7c55a1933b073>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -161,7 +161,7 @@ final class LambdaExpression extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification | Missing
+   * @return AttributeSpecification | null
    */
   public function getAttributeSpec(): ?AttributeSpecification {
     if ($this->_attribute_spec->isMissing()) {
@@ -174,7 +174,7 @@ final class LambdaExpression extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification
+   * @return AttributeSpecification
    */
   public function getAttributeSpecx(): AttributeSpecification {
     return TypeAssert\instance_of(
@@ -206,7 +206,7 @@ final class LambdaExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing | AsyncToken
+   * @return null | AsyncToken
    */
   public function getAsync(): ?AsyncToken {
     if ($this->_async->isMissing()) {
@@ -216,7 +216,7 @@ final class LambdaExpression extends EditableNode {
   }
 
   /**
-   * @returns AsyncToken
+   * @return AsyncToken
    */
   public function getAsyncx(): AsyncToken {
     return TypeAssert\instance_of(AsyncToken::class, $this->_async);
@@ -245,7 +245,7 @@ final class LambdaExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing | CoroutineToken
+   * @return null | CoroutineToken
    */
   public function getCoroutine(): ?CoroutineToken {
     if ($this->_coroutine->isMissing()) {
@@ -255,7 +255,7 @@ final class LambdaExpression extends EditableNode {
   }
 
   /**
-   * @returns CoroutineToken
+   * @return CoroutineToken
    */
   public function getCoroutinex(): CoroutineToken {
     return TypeAssert\instance_of(CoroutineToken::class, $this->_coroutine);
@@ -284,14 +284,14 @@ final class LambdaExpression extends EditableNode {
   }
 
   /**
-   * @returns LambdaSignature | VariableToken
+   * @return LambdaSignature | VariableToken
    */
   public function getSignature(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_signature);
   }
 
   /**
-   * @returns LambdaSignature | VariableToken
+   * @return LambdaSignature | VariableToken
    */
   public function getSignaturex(): EditableNode {
     return $this->getSignature();
@@ -320,7 +320,7 @@ final class LambdaExpression extends EditableNode {
   }
 
   /**
-   * @returns EqualEqualGreaterThanToken
+   * @return EqualEqualGreaterThanToken
    */
   public function getArrow(): EqualEqualGreaterThanToken {
     return
@@ -328,7 +328,7 @@ final class LambdaExpression extends EditableNode {
   }
 
   /**
-   * @returns EqualEqualGreaterThanToken
+   * @return EqualEqualGreaterThanToken
    */
   public function getArrowx(): EqualEqualGreaterThanToken {
     return $this->getArrow();
@@ -357,7 +357,7 @@ final class LambdaExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayIntrinsicExpression | BinaryExpression | CastExpression |
+   * @return ArrayIntrinsicExpression | BinaryExpression | CastExpression |
    * CompoundStatement | ConditionalExpression | FunctionCallExpression |
    * LambdaExpression | LiteralExpression | MemberSelectionExpression |
    * ObjectCreationExpression | ParenthesizedExpression | PrefixUnaryExpression
@@ -368,7 +368,7 @@ final class LambdaExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayIntrinsicExpression | BinaryExpression | CastExpression |
+   * @return ArrayIntrinsicExpression | BinaryExpression | CastExpression |
    * CompoundStatement | ConditionalExpression | FunctionCallExpression |
    * LambdaExpression | LiteralExpression | MemberSelectionExpression |
    * ObjectCreationExpression | ParenthesizedExpression | PrefixUnaryExpression

--- a/codegen/syntax/LambdaSignature.php
+++ b/codegen/syntax/LambdaSignature.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<054a7f11c9bb79b1a90db8e47fbb0d9b>>
+ * @generated SignedSource<<a0aa0a0baeea58bff92e7d4510abc8e0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -133,14 +133,14 @@ final class LambdaSignature extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -168,8 +168,8 @@ final class LambdaSignature extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ParameterDeclaration> | EditableList<EditableNode> |
-   * EditableList<VariadicParameter> | Missing
+   * @return EditableList<ParameterDeclaration> | EditableList<EditableNode> |
+   * EditableList<VariadicParameter> | null
    */
   public function getParameters(): ?EditableList<EditableNode> {
     if ($this->_parameters->isMissing()) {
@@ -179,7 +179,7 @@ final class LambdaSignature extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ParameterDeclaration> | EditableList<EditableNode> |
+   * @return EditableList<ParameterDeclaration> | EditableList<EditableNode> |
    * EditableList<VariadicParameter>
    */
   public function getParametersx(): EditableList<EditableNode> {
@@ -208,14 +208,14 @@ final class LambdaSignature extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -243,7 +243,7 @@ final class LambdaSignature extends EditableNode {
   }
 
   /**
-   * @returns Missing | ColonToken
+   * @return null | ColonToken
    */
   public function getColon(): ?ColonToken {
     if ($this->_colon->isMissing()) {
@@ -253,7 +253,7 @@ final class LambdaSignature extends EditableNode {
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColonx(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
@@ -281,7 +281,7 @@ final class LambdaSignature extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | GenericTypeSpecifier | Missing |
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier | null |
    * SimpleTypeSpecifier
    */
   public function getType(): ?EditableNode {
@@ -292,7 +292,7 @@ final class LambdaSignature extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | GenericTypeSpecifier | SimpleTypeSpecifier
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier | SimpleTypeSpecifier
    */
   public function getTypex(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);

--- a/codegen/syntax/LetStatement.php
+++ b/codegen/syntax/LetStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<86a36e36a886a01ecd8ed02dd91754e9>>
+ * @generated SignedSource<<cbeab3de95b2869d73dca9b3353c9a73>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -147,14 +147,14 @@ final class LetStatement extends EditableNode {
   }
 
   /**
-   * @returns LetToken
+   * @return LetToken
    */
   public function getKeyword(): LetToken {
     return TypeAssert\instance_of(LetToken::class, $this->_keyword);
   }
 
   /**
-   * @returns LetToken
+   * @return LetToken
    */
   public function getKeywordx(): LetToken {
     return $this->getKeyword();
@@ -183,14 +183,14 @@ final class LetStatement extends EditableNode {
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getNamex(): NameToken {
     return $this->getName();
@@ -219,7 +219,7 @@ final class LetStatement extends EditableNode {
   }
 
   /**
-   * @returns Missing | ColonToken
+   * @return null | ColonToken
    */
   public function getColon(): ?ColonToken {
     if ($this->_colon->isMissing()) {
@@ -229,7 +229,7 @@ final class LetStatement extends EditableNode {
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColonx(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
@@ -258,7 +258,7 @@ final class LetStatement extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | GenericTypeSpecifier | Missing |
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier | null |
    * NullableTypeSpecifier | SimpleTypeSpecifier
    */
   public function getType(): ?EditableNode {
@@ -269,7 +269,7 @@ final class LetStatement extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | GenericTypeSpecifier |
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier |
    * NullableTypeSpecifier | SimpleTypeSpecifier
    */
   public function getTypex(): EditableNode {
@@ -299,7 +299,7 @@ final class LetStatement extends EditableNode {
   }
 
   /**
-   * @returns SimpleInitializer
+   * @return SimpleInitializer
    */
   public function getInitializer(): SimpleInitializer {
     return
@@ -307,7 +307,7 @@ final class LetStatement extends EditableNode {
   }
 
   /**
-   * @returns SimpleInitializer
+   * @return SimpleInitializer
    */
   public function getInitializerx(): SimpleInitializer {
     return $this->getInitializer();
@@ -336,14 +336,14 @@ final class LetStatement extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/ListExpression.php
+++ b/codegen/syntax/ListExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6041c108a5012b665480b290cd66d2eb>>
+ * @generated SignedSource<<96884181bb6bcd40560d4ed1e6a2a347>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class ListExpression extends EditableNode {
   }
 
   /**
-   * @returns ListToken
+   * @return ListToken
    */
   public function getKeyword(): ListToken {
     return TypeAssert\instance_of(ListToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ListToken
+   * @return ListToken
    */
   public function getKeywordx(): ListToken {
     return $this->getKeyword();
@@ -149,14 +149,14 @@ final class ListExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -183,10 +183,10 @@ final class ListExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ListExpression> | EditableList<EditableNode> |
+   * @return EditableList<ListExpression> | EditableList<EditableNode> |
    * EditableList<?EditableNode> | EditableList<MemberSelectionExpression> |
    * EditableList<?VariableExpression> | EditableList<SubscriptExpression> |
-   * EditableList<VariableExpression> | Missing
+   * EditableList<VariableExpression> | null
    */
   public function getMembers(): ?EditableList<?EditableNode> {
     if ($this->_members->isMissing()) {
@@ -196,7 +196,7 @@ final class ListExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ListExpression> | EditableList<EditableNode> |
+   * @return EditableList<ListExpression> | EditableList<EditableNode> |
    * EditableList<?EditableNode> | EditableList<MemberSelectionExpression> |
    * EditableList<?VariableExpression> | EditableList<SubscriptExpression> |
    * EditableList<VariableExpression>
@@ -222,14 +222,14 @@ final class ListExpression extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();

--- a/codegen/syntax/ListItem.php
+++ b/codegen/syntax/ListItem.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<de3ecaead112058e286d80170d4526e7>>
+ * @generated SignedSource<<4a8724afe12b3c5659012f449ad27e52>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,7 +82,7 @@ final class ListItem extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | AsExpression | AwaitableCreationExpression |
    * BinaryExpression | CastExpression | ClassnameTypeSpecifier |
    * ClosureParameterTypeSpecifier | ClosureTypeSpecifier |
@@ -94,7 +94,7 @@ final class ListItem extends EditableNode {
    * InclusionExpression | InstanceofExpression | IsExpression |
    * IssetExpression | KeysetIntrinsicExpression | LambdaExpression |
    * ListExpression | LiteralExpression | MapArrayTypeSpecifier |
-   * MemberSelectionExpression | Missing | NamespaceUseClause |
+   * MemberSelectionExpression | null | NamespaceUseClause |
    * NullableTypeSpecifier | ObjectCreationExpression | ParameterDeclaration |
    * ParenthesizedExpression | PipeVariableExpression | PostfixUnaryExpression
    * | PrefixUnaryExpression | PropertyDeclarator | QualifiedName |
@@ -117,7 +117,7 @@ final class ListItem extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | AsExpression | AwaitableCreationExpression |
    * BinaryExpression | CastExpression | ClassnameTypeSpecifier |
    * ClosureParameterTypeSpecifier | ClosureTypeSpecifier |
@@ -163,7 +163,7 @@ final class ListItem extends EditableNode {
   }
 
   /**
-   * @returns Missing | CommaToken | SemicolonToken | BackslashToken
+   * @return null | CommaToken | SemicolonToken | BackslashToken
    */
   public function getSeparator(): ?EditableToken {
     if ($this->_separator->isMissing()) {
@@ -173,7 +173,7 @@ final class ListItem extends EditableNode {
   }
 
   /**
-   * @returns CommaToken | SemicolonToken | BackslashToken
+   * @return CommaToken | SemicolonToken | BackslashToken
    */
   public function getSeparatorx(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_separator);

--- a/codegen/syntax/LiteralExpression.php
+++ b/codegen/syntax/LiteralExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5196b52bffd06ea799ab56d3e8da9dda>>
+ * @generated SignedSource<<3b1fb55e377beede792366c055521dbc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -71,14 +71,14 @@ final class LiteralExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getExpressionx(): EditableNode {
     return $this->getExpression();

--- a/codegen/syntax/MapArrayTypeSpecifier.php
+++ b/codegen/syntax/MapArrayTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<09386bb492144ebcaace76ec355a9860>>
+ * @generated SignedSource<<b2c636f44514939bf1727d927bf52623>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -149,14 +149,14 @@ final class MapArrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ArrayToken
+   * @return ArrayToken
    */
   public function getKeyword(): ArrayToken {
     return TypeAssert\instance_of(ArrayToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ArrayToken
+   * @return ArrayToken
    */
   public function getKeywordx(): ArrayToken {
     return $this->getKeyword();
@@ -185,14 +185,14 @@ final class MapArrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAnglex(): LessThanToken {
     return $this->getLeftAngle();
@@ -221,14 +221,14 @@ final class MapArrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getKey(): SimpleTypeSpecifier {
     return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_key);
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getKeyx(): SimpleTypeSpecifier {
     return $this->getKey();
@@ -257,14 +257,14 @@ final class MapArrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns CommaToken
+   * @return CommaToken
    */
   public function getComma(): CommaToken {
     return TypeAssert\instance_of(CommaToken::class, $this->_comma);
   }
 
   /**
-   * @returns CommaToken
+   * @return CommaToken
    */
   public function getCommax(): CommaToken {
     return $this->getComma();
@@ -293,7 +293,7 @@ final class MapArrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns GenericTypeSpecifier | Missing | NullableTypeSpecifier |
+   * @return GenericTypeSpecifier | null | NullableTypeSpecifier |
    * ShapeTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier |
    * TupleTypeSpecifier
    */
@@ -305,7 +305,7 @@ final class MapArrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns GenericTypeSpecifier | NullableTypeSpecifier | ShapeTypeSpecifier
+   * @return GenericTypeSpecifier | NullableTypeSpecifier | ShapeTypeSpecifier
    * | SimpleTypeSpecifier | SoftTypeSpecifier | TupleTypeSpecifier
    */
   public function getValuex(): EditableNode {
@@ -335,14 +335,14 @@ final class MapArrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAnglex(): GreaterThanToken {
     return $this->getRightAngle();

--- a/codegen/syntax/MarkupSection.php
+++ b/codegen/syntax/MarkupSection.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bf6a4e3092776a7feb0cb3c285708c16>>
+ * @generated SignedSource<<90e5c49c3c7989da0fc254f4b99801ef>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -114,7 +114,7 @@ final class MarkupSection extends EditableNode {
   }
 
   /**
-   * @returns Missing | QuestionGreaterThanToken
+   * @return null | QuestionGreaterThanToken
    */
   public function getPrefix(): ?QuestionGreaterThanToken {
     if ($this->_prefix->isMissing()) {
@@ -125,7 +125,7 @@ final class MarkupSection extends EditableNode {
   }
 
   /**
-   * @returns QuestionGreaterThanToken
+   * @return QuestionGreaterThanToken
    */
   public function getPrefixx(): QuestionGreaterThanToken {
     return
@@ -149,7 +149,7 @@ final class MarkupSection extends EditableNode {
   }
 
   /**
-   * @returns Missing | MarkupToken
+   * @return null | MarkupToken
    */
   public function getText(): ?MarkupToken {
     if ($this->_text->isMissing()) {
@@ -159,7 +159,7 @@ final class MarkupSection extends EditableNode {
   }
 
   /**
-   * @returns MarkupToken
+   * @return MarkupToken
    */
   public function getTextx(): MarkupToken {
     return TypeAssert\instance_of(MarkupToken::class, $this->_text);
@@ -181,7 +181,7 @@ final class MarkupSection extends EditableNode {
   }
 
   /**
-   * @returns MarkupSuffix | Missing
+   * @return MarkupSuffix | null
    */
   public function getSuffix(): ?MarkupSuffix {
     if ($this->_suffix->isMissing()) {
@@ -191,7 +191,7 @@ final class MarkupSection extends EditableNode {
   }
 
   /**
-   * @returns MarkupSuffix
+   * @return MarkupSuffix
    */
   public function getSuffixx(): MarkupSuffix {
     return TypeAssert\instance_of(MarkupSuffix::class, $this->_suffix);
@@ -213,7 +213,7 @@ final class MarkupSection extends EditableNode {
   }
 
   /**
-   * @returns ExpressionStatement | Missing
+   * @return ExpressionStatement | null
    */
   public function getExpression(): ?ExpressionStatement {
     if ($this->_expression->isMissing()) {
@@ -224,7 +224,7 @@ final class MarkupSection extends EditableNode {
   }
 
   /**
-   * @returns ExpressionStatement
+   * @return ExpressionStatement
    */
   public function getExpressionx(): ExpressionStatement {
     return

--- a/codegen/syntax/MarkupSuffix.php
+++ b/codegen/syntax/MarkupSuffix.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<70a95be935fffb99a17ecac91202623f>>
+ * @generated SignedSource<<380fb05bed3d8a4d3a1c8d6ff3d01c5b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -89,7 +89,7 @@ final class MarkupSuffix extends EditableNode {
   }
 
   /**
-   * @returns LessThanQuestionToken
+   * @return LessThanQuestionToken
    */
   public function getLessThanQuestion(): LessThanQuestionToken {
     return TypeAssert\instance_of(
@@ -99,7 +99,7 @@ final class MarkupSuffix extends EditableNode {
   }
 
   /**
-   * @returns LessThanQuestionToken
+   * @return LessThanQuestionToken
    */
   public function getLessThanQuestionx(): LessThanQuestionToken {
     return $this->getLessThanQuestion();
@@ -121,7 +121,7 @@ final class MarkupSuffix extends EditableNode {
   }
 
   /**
-   * @returns Missing | EqualToken | NameToken
+   * @return null | EqualToken | NameToken
    */
   public function getName(): ?EditableToken {
     if ($this->_name->isMissing()) {
@@ -131,7 +131,7 @@ final class MarkupSuffix extends EditableNode {
   }
 
   /**
-   * @returns EqualToken | NameToken
+   * @return EqualToken | NameToken
    */
   public function getNamex(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_name);

--- a/codegen/syntax/MemberSelectionExpression.php
+++ b/codegen/syntax/MemberSelectionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6b1f42032eb97c4959addc22cc8f2a25>>
+ * @generated SignedSource<<dca35918dbba00ae98e75873ba3ee274>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,7 +101,7 @@ final class MemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns FunctionCallExpression | MemberSelectionExpression |
+   * @return FunctionCallExpression | MemberSelectionExpression |
    * ObjectCreationExpression | ParenthesizedExpression |
    * PipeVariableExpression | PrefixUnaryExpression | ScopeResolutionExpression
    * | SubscriptExpression | NameToken | VariableExpression
@@ -111,7 +111,7 @@ final class MemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns FunctionCallExpression | MemberSelectionExpression |
+   * @return FunctionCallExpression | MemberSelectionExpression |
    * ObjectCreationExpression | ParenthesizedExpression |
    * PipeVariableExpression | PrefixUnaryExpression | ScopeResolutionExpression
    * | SubscriptExpression | NameToken | VariableExpression
@@ -136,7 +136,7 @@ final class MemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns MinusGreaterThanToken
+   * @return MinusGreaterThanToken
    */
   public function getOperator(): MinusGreaterThanToken {
     return
@@ -144,7 +144,7 @@ final class MemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns MinusGreaterThanToken
+   * @return MinusGreaterThanToken
    */
   public function getOperatorx(): MinusGreaterThanToken {
     return $this->getOperator();
@@ -166,7 +166,7 @@ final class MemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns BracedExpression | PrefixUnaryExpression | XHPClassNameToken |
+   * @return BracedExpression | PrefixUnaryExpression | XHPClassNameToken |
    * NameToken | VariableToken
    */
   public function getName(): EditableNode {
@@ -174,7 +174,7 @@ final class MemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns BracedExpression | PrefixUnaryExpression | XHPClassNameToken |
+   * @return BracedExpression | PrefixUnaryExpression | XHPClassNameToken |
    * NameToken | VariableToken
    */
   public function getNamex(): EditableNode {

--- a/codegen/syntax/MethodishDeclaration.php
+++ b/codegen/syntax/MethodishDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<418c7267e38ea8be641ee84ddadbe40e>>
+ * @generated SignedSource<<05b8ff9e39856c1f8bd4e6b807d8e13c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -124,7 +124,7 @@ final class MethodishDeclaration
   }
 
   /**
-   * @returns AttributeSpecification | Missing
+   * @return AttributeSpecification | null
    */
   public function getAttribute(): ?AttributeSpecification {
     if ($this->_attribute->isMissing()) {
@@ -135,7 +135,7 @@ final class MethodishDeclaration
   }
 
   /**
-   * @returns AttributeSpecification
+   * @return AttributeSpecification
    */
   public function getAttributex(): AttributeSpecification {
     return
@@ -163,7 +163,7 @@ final class MethodishDeclaration
   }
 
   /**
-   * @returns FunctionDeclarationHeader
+   * @return FunctionDeclarationHeader
    */
   public function getFunctionDeclHeader(): FunctionDeclarationHeader {
     return TypeAssert\instance_of(
@@ -173,7 +173,7 @@ final class MethodishDeclaration
   }
 
   /**
-   * @returns FunctionDeclarationHeader
+   * @return FunctionDeclarationHeader
    */
   public function getFunctionDeclHeaderx(): FunctionDeclarationHeader {
     return $this->getFunctionDeclHeader();
@@ -200,7 +200,7 @@ final class MethodishDeclaration
   }
 
   /**
-   * @returns CompoundStatement | Missing
+   * @return CompoundStatement | null
    */
   public function getFunctionBody(): ?CompoundStatement {
     if ($this->_function_body->isMissing()) {
@@ -211,7 +211,7 @@ final class MethodishDeclaration
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getFunctionBodyx(): CompoundStatement {
     return
@@ -239,7 +239,7 @@ final class MethodishDeclaration
   }
 
   /**
-   * @returns Missing | SemicolonToken
+   * @return null | SemicolonToken
    */
   public function getSemicolon(): ?SemicolonToken {
     if ($this->_semicolon->isMissing()) {
@@ -249,7 +249,7 @@ final class MethodishDeclaration
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);

--- a/codegen/syntax/NamespaceBody.php
+++ b/codegen/syntax/NamespaceBody.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<37debaacbb53751805afe1af46efcfb8>>
+ * @generated SignedSource<<3ebd1f8a5e3e127efa1717c8135e3b93>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class NamespaceBody extends EditableNode {
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBracex(): LeftBraceToken {
     return $this->getLeftBrace();
@@ -130,7 +130,7 @@ final class NamespaceBody extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getDeclarations(): ?EditableList<EditableNode> {
     if ($this->_declarations->isMissing()) {
@@ -140,7 +140,7 @@ final class NamespaceBody extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getDeclarationsx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_declarations);
@@ -162,7 +162,7 @@ final class NamespaceBody extends EditableNode {
   }
 
   /**
-   * @returns Missing | RightBraceToken
+   * @return null | RightBraceToken
    */
   public function getRightBrace(): ?RightBraceToken {
     if ($this->_right_brace->isMissing()) {
@@ -172,7 +172,7 @@ final class NamespaceBody extends EditableNode {
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBracex(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);

--- a/codegen/syntax/NamespaceDeclaration.php
+++ b/codegen/syntax/NamespaceDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ea4d52becb712fd11b7b977d2ddc929d>>
+ * @generated SignedSource<<8a1fb20674d6644f8671275e37181d54>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ abstract class NamespaceDeclarationGeneratedBase extends EditableNode {
   }
 
   /**
-   * @returns NamespaceToken
+   * @return NamespaceToken
    */
   public function getKeyword(): NamespaceToken {
     return TypeAssert\instance_of(NamespaceToken::class, $this->_keyword);
   }
 
   /**
-   * @returns NamespaceToken
+   * @return NamespaceToken
    */
   public function getKeywordx(): NamespaceToken {
     return $this->getKeyword();
@@ -130,7 +130,7 @@ abstract class NamespaceDeclarationGeneratedBase extends EditableNode {
   }
 
   /**
-   * @returns Missing | QualifiedName | NameToken
+   * @return null | QualifiedName | NameToken
    */
   public function getName(): ?EditableNode {
     if ($this->_name->isMissing()) {
@@ -140,7 +140,7 @@ abstract class NamespaceDeclarationGeneratedBase extends EditableNode {
   }
 
   /**
-   * @returns QualifiedName | NameToken
+   * @return QualifiedName | NameToken
    */
   public function getNamex(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
@@ -162,14 +162,14 @@ abstract class NamespaceDeclarationGeneratedBase extends EditableNode {
   }
 
   /**
-   * @returns NamespaceBody | NamespaceEmptyBody
+   * @return NamespaceBody | NamespaceEmptyBody
    */
   public function getBody(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_body);
   }
 
   /**
-   * @returns NamespaceBody | NamespaceEmptyBody
+   * @return NamespaceBody | NamespaceEmptyBody
    */
   public function getBodyx(): EditableNode {
     return $this->getBody();

--- a/codegen/syntax/NamespaceEmptyBody.php
+++ b/codegen/syntax/NamespaceEmptyBody.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6b33a77733d3a1470a6a0777ae2462fb>>
+ * @generated SignedSource<<5a4d1b0d87fec8ca12a2f6f81a2d7606>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -71,14 +71,14 @@ final class NamespaceEmptyBody extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/NamespaceGroupUseDeclaration.php
+++ b/codegen/syntax/NamespaceGroupUseDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bba9ce2e5be75dbaf7212090f51fcf73>>
+ * @generated SignedSource<<acfab585dccae805c4d30c8f92d2adff>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -179,14 +179,14 @@ final class NamespaceGroupUseDeclaration
   }
 
   /**
-   * @returns UseToken
+   * @return UseToken
    */
   public function getKeyword(): UseToken {
     return TypeAssert\instance_of(UseToken::class, $this->_keyword);
   }
 
   /**
-   * @returns UseToken
+   * @return UseToken
    */
   public function getKeywordx(): UseToken {
     return $this->getKeyword();
@@ -216,7 +216,7 @@ final class NamespaceGroupUseDeclaration
   }
 
   /**
-   * @returns Missing | ConstToken | FunctionToken | NamespaceToken | TypeToken
+   * @return null | ConstToken | FunctionToken | NamespaceToken | TypeToken
    */
   public function getKind(): ?EditableToken {
     if ($this->_kind->isMissing()) {
@@ -226,7 +226,7 @@ final class NamespaceGroupUseDeclaration
   }
 
   /**
-   * @returns ConstToken | FunctionToken | NamespaceToken | TypeToken
+   * @return ConstToken | FunctionToken | NamespaceToken | TypeToken
    */
   public function getKindx(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_kind);
@@ -256,14 +256,14 @@ final class NamespaceGroupUseDeclaration
   }
 
   /**
-   * @returns QualifiedName
+   * @return QualifiedName
    */
   public function getPrefix(): QualifiedName {
     return TypeAssert\instance_of(QualifiedName::class, $this->_prefix);
   }
 
   /**
-   * @returns QualifiedName
+   * @return QualifiedName
    */
   public function getPrefixx(): QualifiedName {
     return $this->getPrefix();
@@ -293,14 +293,14 @@ final class NamespaceGroupUseDeclaration
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBracex(): LeftBraceToken {
     return $this->getLeftBrace();
@@ -330,14 +330,14 @@ final class NamespaceGroupUseDeclaration
   }
 
   /**
-   * @returns EditableList<NamespaceUseClause>
+   * @return EditableList<NamespaceUseClause>
    */
   public function getClauses(): EditableList<NamespaceUseClause> {
     return TypeAssert\instance_of(EditableList::class, $this->_clauses);
   }
 
   /**
-   * @returns EditableList<NamespaceUseClause>
+   * @return EditableList<NamespaceUseClause>
    */
   public function getClausesx(): EditableList<NamespaceUseClause> {
     return $this->getClauses();
@@ -367,7 +367,7 @@ final class NamespaceGroupUseDeclaration
   }
 
   /**
-   * @returns Missing | RightBraceToken
+   * @return null | RightBraceToken
    */
   public function getRightBrace(): ?RightBraceToken {
     if ($this->_right_brace->isMissing()) {
@@ -377,7 +377,7 @@ final class NamespaceGroupUseDeclaration
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBracex(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
@@ -407,7 +407,7 @@ final class NamespaceGroupUseDeclaration
   }
 
   /**
-   * @returns Missing | SemicolonToken
+   * @return null | SemicolonToken
    */
   public function getSemicolon(): ?SemicolonToken {
     if ($this->_semicolon->isMissing()) {
@@ -417,7 +417,7 @@ final class NamespaceGroupUseDeclaration
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);

--- a/codegen/syntax/NamespaceUseClause.php
+++ b/codegen/syntax/NamespaceUseClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5892b70cbe60b77e5419604b0a5650b4>>
+ * @generated SignedSource<<48b091b96e2c8388f41e3ecd9f4e303e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -114,7 +114,7 @@ final class NamespaceUseClause extends EditableNode {
   }
 
   /**
-   * @returns Missing | ConstToken | FunctionToken
+   * @return null | ConstToken | FunctionToken
    */
   public function getClauseKind(): ?EditableToken {
     if ($this->_clause_kind->isMissing()) {
@@ -124,7 +124,7 @@ final class NamespaceUseClause extends EditableNode {
   }
 
   /**
-   * @returns ConstToken | FunctionToken
+   * @return ConstToken | FunctionToken
    */
   public function getClauseKindx(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_clause_kind);
@@ -146,14 +146,14 @@ final class NamespaceUseClause extends EditableNode {
   }
 
   /**
-   * @returns QualifiedName | NameToken
+   * @return QualifiedName | NameToken
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
   }
 
   /**
-   * @returns QualifiedName | NameToken
+   * @return QualifiedName | NameToken
    */
   public function getNamex(): EditableNode {
     return $this->getName();
@@ -175,7 +175,7 @@ final class NamespaceUseClause extends EditableNode {
   }
 
   /**
-   * @returns Missing | AsToken
+   * @return null | AsToken
    */
   public function getAs(): ?AsToken {
     if ($this->_as->isMissing()) {
@@ -185,7 +185,7 @@ final class NamespaceUseClause extends EditableNode {
   }
 
   /**
-   * @returns AsToken
+   * @return AsToken
    */
   public function getAsx(): AsToken {
     return TypeAssert\instance_of(AsToken::class, $this->_as);
@@ -207,7 +207,7 @@ final class NamespaceUseClause extends EditableNode {
   }
 
   /**
-   * @returns Missing | NameToken
+   * @return null | NameToken
    */
   public function getAlias(): ?NameToken {
     if ($this->_alias->isMissing()) {
@@ -217,7 +217,7 @@ final class NamespaceUseClause extends EditableNode {
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getAliasx(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_alias);

--- a/codegen/syntax/NamespaceUseDeclaration.php
+++ b/codegen/syntax/NamespaceUseDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fc9ce1fb37896c4298f2a586f0cfb3f5>>
+ * @generated SignedSource<<5d3855770652604757e323702066bde4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -116,14 +116,14 @@ final class NamespaceUseDeclaration
   }
 
   /**
-   * @returns UseToken
+   * @return UseToken
    */
   public function getKeyword(): UseToken {
     return TypeAssert\instance_of(UseToken::class, $this->_keyword);
   }
 
   /**
-   * @returns UseToken
+   * @return UseToken
    */
   public function getKeywordx(): UseToken {
     return $this->getKeyword();
@@ -146,7 +146,7 @@ final class NamespaceUseDeclaration
   }
 
   /**
-   * @returns Missing | ConstToken | FunctionToken | NamespaceToken | TypeToken
+   * @return null | ConstToken | FunctionToken | NamespaceToken | TypeToken
    */
   public function getKind(): ?EditableToken {
     if ($this->_kind->isMissing()) {
@@ -156,7 +156,7 @@ final class NamespaceUseDeclaration
   }
 
   /**
-   * @returns ConstToken | FunctionToken | NamespaceToken | TypeToken
+   * @return ConstToken | FunctionToken | NamespaceToken | TypeToken
    */
   public function getKindx(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_kind);
@@ -178,14 +178,14 @@ final class NamespaceUseDeclaration
   }
 
   /**
-   * @returns EditableList<NamespaceUseClause>
+   * @return EditableList<NamespaceUseClause>
    */
   public function getClauses(): EditableList<NamespaceUseClause> {
     return TypeAssert\instance_of(EditableList::class, $this->_clauses);
   }
 
   /**
-   * @returns EditableList<NamespaceUseClause>
+   * @return EditableList<NamespaceUseClause>
    */
   public function getClausesx(): EditableList<NamespaceUseClause> {
     return $this->getClauses();
@@ -207,14 +207,14 @@ final class NamespaceUseDeclaration
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/NullableAsExpression.php
+++ b/codegen/syntax/NullableAsExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<48ec0d24670e04a1057a0ba96f14f4ab>>
+ * @generated SignedSource<<de1db32b7c5a2e29ba2ef8dc485cbdb2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,7 +101,7 @@ final class NullableAsExpression extends EditableNode {
   }
 
   /**
-   * @returns VariableExpression
+   * @return VariableExpression
    */
   public function getLeftOperand(): VariableExpression {
     return
@@ -109,7 +109,7 @@ final class NullableAsExpression extends EditableNode {
   }
 
   /**
-   * @returns VariableExpression
+   * @return VariableExpression
    */
   public function getLeftOperandx(): VariableExpression {
     return $this->getLeftOperand();
@@ -131,14 +131,14 @@ final class NullableAsExpression extends EditableNode {
   }
 
   /**
-   * @returns QuestionAsToken
+   * @return QuestionAsToken
    */
   public function getOperator(): QuestionAsToken {
     return TypeAssert\instance_of(QuestionAsToken::class, $this->_operator);
   }
 
   /**
-   * @returns QuestionAsToken
+   * @return QuestionAsToken
    */
   public function getOperatorx(): QuestionAsToken {
     return $this->getOperator();
@@ -160,7 +160,7 @@ final class NullableAsExpression extends EditableNode {
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getRightOperand(): SimpleTypeSpecifier {
     return
@@ -168,7 +168,7 @@ final class NullableAsExpression extends EditableNode {
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getRightOperandx(): SimpleTypeSpecifier {
     return $this->getRightOperand();

--- a/codegen/syntax/NullableTypeSpecifier.php
+++ b/codegen/syntax/NullableTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6724d3be551d026a6315bb62eba9ceab>>
+ * @generated SignedSource<<54671d8dab3acfa7d4ea77395a7f6cb0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class NullableTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns QuestionToken
+   * @return QuestionToken
    */
   public function getQuestion(): QuestionToken {
     return TypeAssert\instance_of(QuestionToken::class, $this->_question);
   }
 
   /**
-   * @returns QuestionToken
+   * @return QuestionToken
    */
   public function getQuestionx(): QuestionToken {
     return $this->getQuestion();
@@ -111,7 +111,7 @@ final class NullableTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | DictionaryTypeSpecifier |
+   * @return ClosureTypeSpecifier | DictionaryTypeSpecifier |
    * GenericTypeSpecifier | KeysetTypeSpecifier | MapArrayTypeSpecifier |
    * ShapeTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier |
    * TupleTypeSpecifier | TypeConstant | VectorArrayTypeSpecifier |
@@ -122,7 +122,7 @@ final class NullableTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | DictionaryTypeSpecifier |
+   * @return ClosureTypeSpecifier | DictionaryTypeSpecifier |
    * GenericTypeSpecifier | KeysetTypeSpecifier | MapArrayTypeSpecifier |
    * ShapeTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier |
    * TupleTypeSpecifier | TypeConstant | VectorArrayTypeSpecifier |

--- a/codegen/syntax/ObjectCreationExpression.php
+++ b/codegen/syntax/ObjectCreationExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<94cc30b608da445aeffb85add1f4a392>>
+ * @generated SignedSource<<f05935c41581199963b508c5419ed7fe>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class ObjectCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns NewToken
+   * @return NewToken
    */
   public function getNewKeyword(): NewToken {
     return TypeAssert\instance_of(NewToken::class, $this->_new_keyword);
   }
 
   /**
-   * @returns NewToken
+   * @return NewToken
    */
   public function getNewKeywordx(): NewToken {
     return $this->getNewKeyword();
@@ -111,14 +111,14 @@ final class ObjectCreationExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousClass | ConstructorCall
+   * @return AnonymousClass | ConstructorCall
    */
   public function getObject(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_object);
   }
 
   /**
-   * @returns AnonymousClass | ConstructorCall
+   * @return AnonymousClass | ConstructorCall
    */
   public function getObjectx(): EditableNode {
     return $this->getObject();

--- a/codegen/syntax/ParameterDeclaration.php
+++ b/codegen/syntax/ParameterDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3098dc5df2a146e1613910226564a4f0>>
+ * @generated SignedSource<<263b3e09f94796a9099579ce6cec0921>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -161,7 +161,7 @@ final class ParameterDeclaration extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification | Missing
+   * @return AttributeSpecification | null
    */
   public function getAttribute(): ?AttributeSpecification {
     if ($this->_attribute->isMissing()) {
@@ -172,7 +172,7 @@ final class ParameterDeclaration extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification
+   * @return AttributeSpecification
    */
   public function getAttributex(): AttributeSpecification {
     return
@@ -202,7 +202,7 @@ final class ParameterDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | PrivateToken | ProtectedToken | PublicToken
+   * @return null | PrivateToken | ProtectedToken | PublicToken
    */
   public function getVisibility(): ?EditableToken {
     if ($this->_visibility->isMissing()) {
@@ -212,7 +212,7 @@ final class ParameterDeclaration extends EditableNode {
   }
 
   /**
-   * @returns PrivateToken | ProtectedToken | PublicToken
+   * @return PrivateToken | ProtectedToken | PublicToken
    */
   public function getVisibilityx(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_visibility);
@@ -241,7 +241,7 @@ final class ParameterDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | InoutToken
+   * @return null | InoutToken
    */
   public function getCallConvention(): ?InoutToken {
     if ($this->_call_convention->isMissing()) {
@@ -251,7 +251,7 @@ final class ParameterDeclaration extends EditableNode {
   }
 
   /**
-   * @returns InoutToken
+   * @return InoutToken
    */
   public function getCallConventionx(): InoutToken {
     return TypeAssert\instance_of(InoutToken::class, $this->_call_convention);
@@ -280,12 +280,12 @@ final class ParameterDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
    * DarrayTypeSpecifier | DictionaryTypeSpecifier | GenericTypeSpecifier |
-   * KeysetTypeSpecifier | MapArrayTypeSpecifier | Missing |
-   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
-   * SoftTypeSpecifier | TupleTypeSpecifier | TypeConstant |
-   * VarrayTypeSpecifier | VectorArrayTypeSpecifier | VectorTypeSpecifier
+   * KeysetTypeSpecifier | MapArrayTypeSpecifier | null | NullableTypeSpecifier
+   * | ShapeTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier |
+   * TupleTypeSpecifier | TypeConstant | VarrayTypeSpecifier |
+   * VectorArrayTypeSpecifier | VectorTypeSpecifier
    */
   public function getType(): ?EditableNode {
     if ($this->_type->isMissing()) {
@@ -295,7 +295,7 @@ final class ParameterDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
    * DarrayTypeSpecifier | DictionaryTypeSpecifier | GenericTypeSpecifier |
    * KeysetTypeSpecifier | MapArrayTypeSpecifier | NullableTypeSpecifier |
    * ShapeTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier |
@@ -329,7 +329,7 @@ final class ParameterDeclaration extends EditableNode {
   }
 
   /**
-   * @returns DecoratedExpression | Missing | VariableToken
+   * @return DecoratedExpression | null | VariableToken
    */
   public function getName(): ?EditableNode {
     if ($this->_name->isMissing()) {
@@ -339,7 +339,7 @@ final class ParameterDeclaration extends EditableNode {
   }
 
   /**
-   * @returns DecoratedExpression | VariableToken
+   * @return DecoratedExpression | VariableToken
    */
   public function getNamex(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
@@ -368,7 +368,7 @@ final class ParameterDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | SimpleInitializer
+   * @return null | SimpleInitializer
    */
   public function getDefaultValue(): ?SimpleInitializer {
     if ($this->_default_value->isMissing()) {
@@ -379,7 +379,7 @@ final class ParameterDeclaration extends EditableNode {
   }
 
   /**
-   * @returns SimpleInitializer
+   * @return SimpleInitializer
    */
   public function getDefaultValuex(): SimpleInitializer {
     return

--- a/codegen/syntax/ParenthesizedExpression.php
+++ b/codegen/syntax/ParenthesizedExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<95c84ca61c3e8563760c7621de03cbfb>>
+ * @generated SignedSource<<68db451e1e1b0eb3ade540d77d2b0272>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class ParenthesizedExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -130,7 +130,7 @@ final class ParenthesizedExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayIntrinsicExpression | BinaryExpression |
+   * @return AnonymousFunction | ArrayIntrinsicExpression | BinaryExpression |
    * CastExpression | CollectionLiteralExpression | ConditionalExpression |
    * EmptyExpression | FunctionCallExpression | InclusionExpression |
    * InstanceofExpression | IssetExpression | LambdaExpression |
@@ -145,7 +145,7 @@ final class ParenthesizedExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayIntrinsicExpression | BinaryExpression |
+   * @return AnonymousFunction | ArrayIntrinsicExpression | BinaryExpression |
    * CastExpression | CollectionLiteralExpression | ConditionalExpression |
    * EmptyExpression | FunctionCallExpression | InclusionExpression |
    * InstanceofExpression | IssetExpression | LambdaExpression |
@@ -175,7 +175,7 @@ final class ParenthesizedExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing | RightParenToken
+   * @return null | RightParenToken
    */
   public function getRightParen(): ?RightParenToken {
     if ($this->_right_paren->isMissing()) {
@@ -185,7 +185,7 @@ final class ParenthesizedExpression extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);

--- a/codegen/syntax/Php7AnonymousFunction.php
+++ b/codegen/syntax/Php7AnonymousFunction.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4c6a37864effc40565d4b6f978a5d07f>>
+ * @generated SignedSource<<d63db96ab03aa21219408f21a8bbf352>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -274,7 +274,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getAttributeSpec(): ?EditableNode {
     if ($this->_attribute_spec->isMissing()) {
@@ -284,7 +284,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getAttributeSpecx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_attribute_spec);
@@ -320,7 +320,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getStaticKeyword(): ?EditableNode {
     if ($this->_static_keyword->isMissing()) {
@@ -330,7 +330,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getStaticKeywordx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_static_keyword);
@@ -366,7 +366,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getAsyncKeyword(): ?EditableNode {
     if ($this->_async_keyword->isMissing()) {
@@ -376,7 +376,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getAsyncKeywordx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_async_keyword);
@@ -412,7 +412,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getCoroutineKeyword(): ?EditableNode {
     if ($this->_coroutine_keyword->isMissing()) {
@@ -423,7 +423,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getCoroutineKeywordx(): EditableNode {
     return
@@ -460,7 +460,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns FunctionToken
+   * @return FunctionToken
    */
   public function getFunctionKeyword(): FunctionToken {
     return
@@ -468,7 +468,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns FunctionToken
+   * @return FunctionToken
    */
   public function getFunctionKeywordx(): FunctionToken {
     return $this->getFunctionKeyword();
@@ -504,7 +504,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getAmpersand(): ?EditableNode {
     if ($this->_ampersand->isMissing()) {
@@ -514,7 +514,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getAmpersandx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_ampersand);
@@ -550,14 +550,14 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -593,7 +593,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getParameters(): ?EditableNode {
     if ($this->_parameters->isMissing()) {
@@ -603,7 +603,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getParametersx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_parameters);
@@ -639,14 +639,14 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -682,7 +682,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunctionUseClause
+   * @return AnonymousFunctionUseClause
    */
   public function getUse(): AnonymousFunctionUseClause {
     return
@@ -690,7 +690,7 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunctionUseClause
+   * @return AnonymousFunctionUseClause
    */
   public function getUsex(): AnonymousFunctionUseClause {
     return $this->getUse();
@@ -726,14 +726,14 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColon(): ColonToken {
     return TypeAssert\instance_of(ColonToken::class, $this->_colon);
   }
 
   /**
-   * @returns ColonToken
+   * @return ColonToken
    */
   public function getColonx(): ColonToken {
     return $this->getColon();
@@ -769,14 +769,14 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getType(): SimpleTypeSpecifier {
     return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_type);
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getTypex(): SimpleTypeSpecifier {
     return $this->getType();
@@ -812,14 +812,14 @@ final class Php7AnonymousFunction extends EditableNode {
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getBody(): CompoundStatement {
     return TypeAssert\instance_of(CompoundStatement::class, $this->_body);
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getBodyx(): CompoundStatement {
     return $this->getBody();

--- a/codegen/syntax/PipeVariableExpression.php
+++ b/codegen/syntax/PipeVariableExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<954899c7bb0796e80afe72c6330afc77>>
+ * @generated SignedSource<<65cf07941a12082f1672cdb347000000>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -71,14 +71,14 @@ final class PipeVariableExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getExpressionx(): EditableNode {
     return $this->getExpression();

--- a/codegen/syntax/PostfixUnaryExpression.php
+++ b/codegen/syntax/PostfixUnaryExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<61ed792f78c4e0eefa5ac63afd9baaab>>
+ * @generated SignedSource<<d6288478631c64d318d5bf376613a858>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,7 +82,7 @@ final class PostfixUnaryExpression extends EditableNode {
   }
 
   /**
-   * @returns MemberSelectionExpression | PrefixUnaryExpression |
+   * @return MemberSelectionExpression | PrefixUnaryExpression |
    * ScopeResolutionExpression | SubscriptExpression | VariableExpression
    */
   public function getOperand(): EditableNode {
@@ -90,7 +90,7 @@ final class PostfixUnaryExpression extends EditableNode {
   }
 
   /**
-   * @returns MemberSelectionExpression | PrefixUnaryExpression |
+   * @return MemberSelectionExpression | PrefixUnaryExpression |
    * ScopeResolutionExpression | SubscriptExpression | VariableExpression
    */
   public function getOperandx(): EditableNode {
@@ -113,14 +113,14 @@ final class PostfixUnaryExpression extends EditableNode {
   }
 
   /**
-   * @returns PlusPlusToken | MinusMinusToken
+   * @return PlusPlusToken | MinusMinusToken
    */
   public function getOperator(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_operator);
   }
 
   /**
-   * @returns PlusPlusToken | MinusMinusToken
+   * @return PlusPlusToken | MinusMinusToken
    */
   public function getOperatorx(): EditableToken {
     return $this->getOperator();

--- a/codegen/syntax/PrefixUnaryExpression.php
+++ b/codegen/syntax/PrefixUnaryExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bb9bb2ed717dbb50b9e4ef81b6391d32>>
+ * @generated SignedSource<<fc150534346c197114b0aa711a0423ed>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,7 +82,7 @@ final class PrefixUnaryExpression extends EditableNode {
   }
 
   /**
-   * @returns ExclamationToken | DollarToken | AmpersandToken | PlusToken |
+   * @return ExclamationToken | DollarToken | AmpersandToken | PlusToken |
    * PlusPlusToken | MinusToken | MinusMinusToken | AtToken | AwaitToken |
    * CloneToken | PrintToken | SuspendToken | TildeToken
    */
@@ -91,7 +91,7 @@ final class PrefixUnaryExpression extends EditableNode {
   }
 
   /**
-   * @returns ExclamationToken | DollarToken | AmpersandToken | PlusToken |
+   * @return ExclamationToken | DollarToken | AmpersandToken | PlusToken |
    * PlusPlusToken | MinusToken | MinusMinusToken | AtToken | AwaitToken |
    * CloneToken | PrintToken | SuspendToken | TildeToken
    */
@@ -115,7 +115,7 @@ final class PrefixUnaryExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayIntrinsicExpression |
+   * @return AnonymousFunction | ArrayIntrinsicExpression |
    * AwaitableCreationExpression | BinaryExpression | BracedExpression |
    * CastExpression | ConditionalExpression | DefineExpression |
    * EmptyExpression | EvalExpression | FunctionCallExpression |
@@ -131,7 +131,7 @@ final class PrefixUnaryExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayIntrinsicExpression |
+   * @return AnonymousFunction | ArrayIntrinsicExpression |
    * AwaitableCreationExpression | BinaryExpression | BracedExpression |
    * CastExpression | ConditionalExpression | DefineExpression |
    * EmptyExpression | EvalExpression | FunctionCallExpression |

--- a/codegen/syntax/PrefixedStringExpression.php
+++ b/codegen/syntax/PrefixedStringExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<dd6466e39bf96392a097f795856d869f>>
+ * @generated SignedSource<<8a5328ddb2884528c7791b14d1d8912e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class PrefixedStringExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getNamex(): EditableNode {
     return $this->getName();
@@ -111,14 +111,14 @@ final class PrefixedStringExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getStr(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_str);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getStrx(): EditableNode {
     return $this->getStr();

--- a/codegen/syntax/PropertyDeclaration.php
+++ b/codegen/syntax/PropertyDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<117575a6e9acfce27a772e4ae2b2a68a>>
+ * @generated SignedSource<<6a0228d7313440582561c59f7f06a726>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -135,7 +135,7 @@ final class PropertyDeclaration extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification | Missing
+   * @return AttributeSpecification | null
    */
   public function getAttributeSpec(): ?AttributeSpecification {
     if ($this->_attribute_spec->isMissing()) {
@@ -148,7 +148,7 @@ final class PropertyDeclaration extends EditableNode {
   }
 
   /**
-   * @returns AttributeSpecification
+   * @return AttributeSpecification
    */
   public function getAttributeSpecx(): AttributeSpecification {
     return TypeAssert\instance_of(
@@ -179,14 +179,14 @@ final class PropertyDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | VarToken
+   * @return EditableList<EditableNode> | VarToken
    */
   public function getModifiers(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_modifiers);
   }
 
   /**
-   * @returns EditableList<EditableNode> | VarToken
+   * @return EditableList<EditableNode> | VarToken
    */
   public function getModifiersx(): EditableNode {
     return $this->getModifiers();
@@ -214,10 +214,10 @@ final class PropertyDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | DarrayTypeSpecifier |
+   * @return ClosureTypeSpecifier | DarrayTypeSpecifier |
    * DictionaryTypeSpecifier | GenericTypeSpecifier | MapArrayTypeSpecifier |
-   * Missing | NullableTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier
-   * | TupleTypeSpecifier | TypeConstant | VarrayTypeSpecifier |
+   * null | NullableTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier |
+   * TupleTypeSpecifier | TypeConstant | VarrayTypeSpecifier |
    * VectorArrayTypeSpecifier | VectorTypeSpecifier
    */
   public function getType(): ?EditableNode {
@@ -228,7 +228,7 @@ final class PropertyDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | DarrayTypeSpecifier |
+   * @return ClosureTypeSpecifier | DarrayTypeSpecifier |
    * DictionaryTypeSpecifier | GenericTypeSpecifier | MapArrayTypeSpecifier |
    * NullableTypeSpecifier | SimpleTypeSpecifier | SoftTypeSpecifier |
    * TupleTypeSpecifier | TypeConstant | VarrayTypeSpecifier |
@@ -260,14 +260,14 @@ final class PropertyDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<PropertyDeclarator>
+   * @return EditableList<PropertyDeclarator>
    */
   public function getDeclarators(): EditableList<PropertyDeclarator> {
     return TypeAssert\instance_of(EditableList::class, $this->_declarators);
   }
 
   /**
-   * @returns EditableList<PropertyDeclarator>
+   * @return EditableList<PropertyDeclarator>
    */
   public function getDeclaratorsx(): EditableList<PropertyDeclarator> {
     return $this->getDeclarators();
@@ -295,14 +295,14 @@ final class PropertyDeclaration extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/PropertyDeclarator.php
+++ b/codegen/syntax/PropertyDeclarator.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e480de5445c3981abda3e4c19a1f53c9>>
+ * @generated SignedSource<<bfce08f37ce67eefbc18dc87b0a8c848>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class PropertyDeclarator extends EditableNode {
   }
 
   /**
-   * @returns VariableToken
+   * @return VariableToken
    */
   public function getName(): VariableToken {
     return TypeAssert\instance_of(VariableToken::class, $this->_name);
   }
 
   /**
-   * @returns VariableToken
+   * @return VariableToken
    */
   public function getNamex(): VariableToken {
     return $this->getName();
@@ -111,7 +111,7 @@ final class PropertyDeclarator extends EditableNode {
   }
 
   /**
-   * @returns Missing | SimpleInitializer
+   * @return null | SimpleInitializer
    */
   public function getInitializer(): ?SimpleInitializer {
     if ($this->_initializer->isMissing()) {
@@ -122,7 +122,7 @@ final class PropertyDeclarator extends EditableNode {
   }
 
   /**
-   * @returns SimpleInitializer
+   * @return SimpleInitializer
    */
   public function getInitializerx(): SimpleInitializer {
     return

--- a/codegen/syntax/QualifiedName.php
+++ b/codegen/syntax/QualifiedName.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9bd5049fbd3cc5de04cf5151949bde9c>>
+ * @generated SignedSource<<928736883fc6861fc2dcb834e258f805>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -71,14 +71,14 @@ final class QualifiedName extends EditableNode {
   }
 
   /**
-   * @returns EditableList<?NameToken> | EditableList<NameToken>
+   * @return EditableList<?NameToken> | EditableList<NameToken>
    */
   public function getParts(): EditableList<?NameToken> {
     return TypeAssert\instance_of(EditableList::class, $this->_parts);
   }
 
   /**
-   * @returns EditableList<?NameToken> | EditableList<NameToken>
+   * @return EditableList<?NameToken> | EditableList<NameToken>
    */
   public function getPartsx(): EditableList<?NameToken> {
     return $this->getParts();

--- a/codegen/syntax/ReifiedTypeArgument.php
+++ b/codegen/syntax/ReifiedTypeArgument.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2f4de5530ce73ec0779faf9664a31323>>
+ * @generated SignedSource<<9e1dae621dbd00ad4f3d9973b2f31798>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class ReifiedTypeArgument extends EditableNode {
   }
 
   /**
-   * @returns ReifiedToken
+   * @return ReifiedToken
    */
   public function getReified(): ReifiedToken {
     return TypeAssert\instance_of(ReifiedToken::class, $this->_reified);
   }
 
   /**
-   * @returns ReifiedToken
+   * @return ReifiedToken
    */
   public function getReifiedx(): ReifiedToken {
     return $this->getReified();
@@ -111,14 +111,14 @@ final class ReifiedTypeArgument extends EditableNode {
   }
 
   /**
-   * @returns SimpleTypeSpecifier | TupleTypeSpecifier | TypeConstant
+   * @return SimpleTypeSpecifier | TupleTypeSpecifier | TypeConstant
    */
   public function getType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
   }
 
   /**
-   * @returns SimpleTypeSpecifier | TupleTypeSpecifier | TypeConstant
+   * @return SimpleTypeSpecifier | TupleTypeSpecifier | TypeConstant
    */
   public function getTypex(): EditableNode {
     return $this->getType();

--- a/codegen/syntax/RequireClause.php
+++ b/codegen/syntax/RequireClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8f85b4ea79f10c3d9924c9ce5d9cfcfb>>
+ * @generated SignedSource<<b65d38f96f5f58f4a966ec6880c5085d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -114,14 +114,14 @@ final class RequireClause extends EditableNode {
   }
 
   /**
-   * @returns RequireToken
+   * @return RequireToken
    */
   public function getKeyword(): RequireToken {
     return TypeAssert\instance_of(RequireToken::class, $this->_keyword);
   }
 
   /**
-   * @returns RequireToken
+   * @return RequireToken
    */
   public function getKeywordx(): RequireToken {
     return $this->getKeyword();
@@ -143,14 +143,14 @@ final class RequireClause extends EditableNode {
   }
 
   /**
-   * @returns ExtendsToken | ImplementsToken
+   * @return ExtendsToken | ImplementsToken
    */
   public function getKind(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_kind);
   }
 
   /**
-   * @returns ExtendsToken | ImplementsToken
+   * @return ExtendsToken | ImplementsToken
    */
   public function getKindx(): EditableToken {
     return $this->getKind();
@@ -172,14 +172,14 @@ final class RequireClause extends EditableNode {
   }
 
   /**
-   * @returns GenericTypeSpecifier | SimpleTypeSpecifier
+   * @return GenericTypeSpecifier | SimpleTypeSpecifier
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
   }
 
   /**
-   * @returns GenericTypeSpecifier | SimpleTypeSpecifier
+   * @return GenericTypeSpecifier | SimpleTypeSpecifier
    */
   public function getNamex(): EditableNode {
     return $this->getName();
@@ -201,14 +201,14 @@ final class RequireClause extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/ReturnStatement.php
+++ b/codegen/syntax/ReturnStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a86ee9f4877d5eb1083fbbda254887e3>>
+ * @generated SignedSource<<49be2543c18ffec790beb1bc0cea2225>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class ReturnStatement extends EditableNode {
   }
 
   /**
-   * @returns ReturnToken
+   * @return ReturnToken
    */
   public function getKeyword(): ReturnToken {
     return TypeAssert\instance_of(ReturnToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ReturnToken
+   * @return ReturnToken
    */
   public function getKeywordx(): ReturnToken {
     return $this->getKeyword();
@@ -130,7 +130,7 @@ final class ReturnStatement extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | AsExpression | AwaitableCreationExpression |
    * BinaryExpression | CastExpression | CollectionLiteralExpression |
    * ConditionalExpression | DarrayIntrinsicExpression |
@@ -138,7 +138,7 @@ final class ReturnStatement extends EditableNode {
    * FunctionCallExpression | FunctionCallWithTypeArgumentsExpression |
    * InstanceofExpression | IsExpression | IssetExpression |
    * KeysetIntrinsicExpression | LambdaExpression | LiteralExpression |
-   * MemberSelectionExpression | Missing | ObjectCreationExpression |
+   * MemberSelectionExpression | null | ObjectCreationExpression |
    * ParenthesizedExpression | PostfixUnaryExpression | PrefixUnaryExpression |
    * QualifiedName | SafeMemberSelectionExpression | ScopeResolutionExpression
    * | ShapeExpression | SubscriptExpression | NameToken | TupleExpression |
@@ -153,7 +153,7 @@ final class ReturnStatement extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | AsExpression | AwaitableCreationExpression |
    * BinaryExpression | CastExpression | CollectionLiteralExpression |
    * ConditionalExpression | DarrayIntrinsicExpression |
@@ -188,7 +188,7 @@ final class ReturnStatement extends EditableNode {
   }
 
   /**
-   * @returns Missing | SemicolonToken
+   * @return null | SemicolonToken
    */
   public function getSemicolon(): ?SemicolonToken {
     if ($this->_semicolon->isMissing()) {
@@ -198,7 +198,7 @@ final class ReturnStatement extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);

--- a/codegen/syntax/SafeMemberSelectionExpression.php
+++ b/codegen/syntax/SafeMemberSelectionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f5c5be209252300ac03c604491d6cd3d>>
+ * @generated SignedSource<<ef7df98ad2a607aa15d37820b7113aea>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,7 +101,7 @@ final class SafeMemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns FunctionCallExpression | MemberSelectionExpression |
+   * @return FunctionCallExpression | MemberSelectionExpression |
    * PrefixUnaryExpression | SafeMemberSelectionExpression |
    * ScopeResolutionExpression | VariableExpression
    */
@@ -110,7 +110,7 @@ final class SafeMemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns FunctionCallExpression | MemberSelectionExpression |
+   * @return FunctionCallExpression | MemberSelectionExpression |
    * PrefixUnaryExpression | SafeMemberSelectionExpression |
    * ScopeResolutionExpression | VariableExpression
    */
@@ -134,7 +134,7 @@ final class SafeMemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns QuestionMinusGreaterThanToken
+   * @return QuestionMinusGreaterThanToken
    */
   public function getOperator(): QuestionMinusGreaterThanToken {
     return TypeAssert\instance_of(
@@ -144,7 +144,7 @@ final class SafeMemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns QuestionMinusGreaterThanToken
+   * @return QuestionMinusGreaterThanToken
    */
   public function getOperatorx(): QuestionMinusGreaterThanToken {
     return $this->getOperator();
@@ -166,14 +166,14 @@ final class SafeMemberSelectionExpression extends EditableNode {
   }
 
   /**
-   * @returns PrefixUnaryExpression | XHPClassNameToken | NameToken
+   * @return PrefixUnaryExpression | XHPClassNameToken | NameToken
    */
   public function getName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_name);
   }
 
   /**
-   * @returns PrefixUnaryExpression | XHPClassNameToken | NameToken
+   * @return PrefixUnaryExpression | XHPClassNameToken | NameToken
    */
   public function getNamex(): EditableNode {
     return $this->getName();

--- a/codegen/syntax/ScopeResolutionExpression.php
+++ b/codegen/syntax/ScopeResolutionExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a4d26ce02300bc32a1759e2797559c86>>
+ * @generated SignedSource<<36978fae04a6ea600d577d5f37bc66c9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,7 +101,7 @@ final class ScopeResolutionExpression extends EditableNode {
   }
 
   /**
-   * @returns FunctionCallExpression | GenericTypeSpecifier | LiteralExpression
+   * @return FunctionCallExpression | GenericTypeSpecifier | LiteralExpression
    * | ParenthesizedExpression | PipeVariableExpression | PrefixUnaryExpression
    * | QualifiedName | ScopeResolutionExpression | SimpleTypeSpecifier |
    * XHPClassNameToken | NameToken | ParentToken | SelfToken | StaticToken |
@@ -112,7 +112,7 @@ final class ScopeResolutionExpression extends EditableNode {
   }
 
   /**
-   * @returns FunctionCallExpression | GenericTypeSpecifier | LiteralExpression
+   * @return FunctionCallExpression | GenericTypeSpecifier | LiteralExpression
    * | ParenthesizedExpression | PipeVariableExpression | PrefixUnaryExpression
    * | QualifiedName | ScopeResolutionExpression | SimpleTypeSpecifier |
    * XHPClassNameToken | NameToken | ParentToken | SelfToken | StaticToken |
@@ -138,14 +138,14 @@ final class ScopeResolutionExpression extends EditableNode {
   }
 
   /**
-   * @returns ColonColonToken
+   * @return ColonColonToken
    */
   public function getOperator(): ColonColonToken {
     return TypeAssert\instance_of(ColonColonToken::class, $this->_operator);
   }
 
   /**
-   * @returns ColonColonToken
+   * @return ColonColonToken
    */
   public function getOperatorx(): ColonColonToken {
     return $this->getOperator();
@@ -167,7 +167,7 @@ final class ScopeResolutionExpression extends EditableNode {
   }
 
   /**
-   * @returns BracedExpression | PrefixUnaryExpression | ClassToken | NameToken
+   * @return BracedExpression | PrefixUnaryExpression | ClassToken | NameToken
    * | VariableToken
    */
   public function getName(): EditableNode {
@@ -175,7 +175,7 @@ final class ScopeResolutionExpression extends EditableNode {
   }
 
   /**
-   * @returns BracedExpression | PrefixUnaryExpression | ClassToken | NameToken
+   * @return BracedExpression | PrefixUnaryExpression | ClassToken | NameToken
    * | VariableToken
    */
   public function getNamex(): EditableNode {

--- a/codegen/syntax/Script.php
+++ b/codegen/syntax/Script.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f9561df0b4fa9c9ee18ef07d08e55a58>>
+ * @generated SignedSource<<1b3e5f2f21688c1410827ef5ca572ac4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -71,14 +71,14 @@ final class Script extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getDeclarations(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_declarations);
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getDeclarationsx(): EditableList<EditableNode> {
     return $this->getDeclarations();

--- a/codegen/syntax/ShapeExpression.php
+++ b/codegen/syntax/ShapeExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5c0c853456635ddd29e88cf3d10dfa57>>
+ * @generated SignedSource<<a3137581d153f42863130fb3f422fddb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class ShapeExpression extends EditableNode {
   }
 
   /**
-   * @returns ShapeToken
+   * @return ShapeToken
    */
   public function getKeyword(): ShapeToken {
     return TypeAssert\instance_of(ShapeToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ShapeToken
+   * @return ShapeToken
    */
   public function getKeywordx(): ShapeToken {
     return $this->getKeyword();
@@ -149,14 +149,14 @@ final class ShapeExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -183,7 +183,7 @@ final class ShapeExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<FieldInitializer> | Missing
+   * @return EditableList<FieldInitializer> | null
    */
   public function getFields(): ?EditableList<FieldInitializer> {
     if ($this->_fields->isMissing()) {
@@ -193,7 +193,7 @@ final class ShapeExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<FieldInitializer>
+   * @return EditableList<FieldInitializer>
    */
   public function getFieldsx(): EditableList<FieldInitializer> {
     return TypeAssert\instance_of(EditableList::class, $this->_fields);
@@ -216,14 +216,14 @@ final class ShapeExpression extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();

--- a/codegen/syntax/ShapeTypeSpecifier.php
+++ b/codegen/syntax/ShapeTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ec962cec6acb178332b930a41df4d5a5>>
+ * @generated SignedSource<<6ed0262f09ee0dba43adddccaca3e206>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -133,14 +133,14 @@ final class ShapeTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ShapeToken
+   * @return ShapeToken
    */
   public function getKeyword(): ShapeToken {
     return TypeAssert\instance_of(ShapeToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ShapeToken
+   * @return ShapeToken
    */
   public function getKeywordx(): ShapeToken {
     return $this->getKeyword();
@@ -168,14 +168,14 @@ final class ShapeTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -203,7 +203,7 @@ final class ShapeTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns EditableList<FieldSpecifier> | Missing
+   * @return EditableList<FieldSpecifier> | null
    */
   public function getFields(): ?EditableList<FieldSpecifier> {
     if ($this->_fields->isMissing()) {
@@ -213,7 +213,7 @@ final class ShapeTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns EditableList<FieldSpecifier>
+   * @return EditableList<FieldSpecifier>
    */
   public function getFieldsx(): EditableList<FieldSpecifier> {
     return TypeAssert\instance_of(EditableList::class, $this->_fields);
@@ -241,7 +241,7 @@ final class ShapeTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns Missing | DotDotDotToken
+   * @return null | DotDotDotToken
    */
   public function getEllipsis(): ?DotDotDotToken {
     if ($this->_ellipsis->isMissing()) {
@@ -251,7 +251,7 @@ final class ShapeTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns DotDotDotToken
+   * @return DotDotDotToken
    */
   public function getEllipsisx(): DotDotDotToken {
     return TypeAssert\instance_of(DotDotDotToken::class, $this->_ellipsis);
@@ -279,14 +279,14 @@ final class ShapeTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();

--- a/codegen/syntax/SimpleInitializer.php
+++ b/codegen/syntax/SimpleInitializer.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d13ceb1786a12012ae19e4eb23d7925a>>
+ * @generated SignedSource<<d62d5ee4ae95c3b90be1832d15b323c4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class SimpleInitializer extends EditableNode {
   }
 
   /**
-   * @returns EqualToken
+   * @return EqualToken
    */
   public function getEqual(): EqualToken {
     return TypeAssert\instance_of(EqualToken::class, $this->_equal);
   }
 
   /**
-   * @returns EqualToken
+   * @return EqualToken
    */
   public function getEqualx(): EqualToken {
     return $this->getEqual();
@@ -111,7 +111,7 @@ final class SimpleInitializer extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
    * CollectionLiteralExpression | ConditionalExpression |
    * DarrayIntrinsicExpression | DictionaryIntrinsicExpression |
@@ -127,7 +127,7 @@ final class SimpleInitializer extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayCreationExpression |
+   * @return AnonymousFunction | ArrayCreationExpression |
    * ArrayIntrinsicExpression | BinaryExpression | CastExpression |
    * CollectionLiteralExpression | ConditionalExpression |
    * DarrayIntrinsicExpression | DictionaryIntrinsicExpression |

--- a/codegen/syntax/SimpleTypeSpecifier.php
+++ b/codegen/syntax/SimpleTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<17c9cd27ccd934dfba04bd7db1c09d1d>>
+ * @generated SignedSource<<efeeab9bc321b2af4dd477a9901773d1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -71,7 +71,7 @@ final class SimpleTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns QualifiedName | XHPClassNameToken | ConstructToken | ArrayToken |
+   * @return QualifiedName | XHPClassNameToken | ConstructToken | ArrayToken |
    * ArraykeyToken | BoolToken | BooleanToken | DarrayToken | DictToken |
    * DoubleToken | FloatToken | IntToken | IntegerToken | KeysetToken |
    * MixedToken | NameToken | NoreturnToken | NumToken | ObjectToken |
@@ -83,7 +83,7 @@ final class SimpleTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns QualifiedName | XHPClassNameToken | ConstructToken | ArrayToken |
+   * @return QualifiedName | XHPClassNameToken | ConstructToken | ArrayToken |
    * ArraykeyToken | BoolToken | BooleanToken | DarrayToken | DictToken |
    * DoubleToken | FloatToken | IntToken | IntegerToken | KeysetToken |
    * MixedToken | NameToken | NoreturnToken | NumToken | ObjectToken |

--- a/codegen/syntax/SoftTypeSpecifier.php
+++ b/codegen/syntax/SoftTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<46946695a433feb860a6573dba18cea1>>
+ * @generated SignedSource<<d1cfee3afd819a945841c2ac9b1e77c3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class SoftTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns AtToken
+   * @return AtToken
    */
   public function getAt(): AtToken {
     return TypeAssert\instance_of(AtToken::class, $this->_at);
   }
 
   /**
-   * @returns AtToken
+   * @return AtToken
    */
   public function getAtx(): AtToken {
     return $this->getAt();
@@ -111,7 +111,7 @@ final class SoftTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | GenericTypeSpecifier |
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier |
    * MapArrayTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier |
    * TupleTypeSpecifier
    */
@@ -120,7 +120,7 @@ final class SoftTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | GenericTypeSpecifier |
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier |
    * MapArrayTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier |
    * TupleTypeSpecifier
    */

--- a/codegen/syntax/StaticDeclarator.php
+++ b/codegen/syntax/StaticDeclarator.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e71beb716e6e854c61f4a7280c81a3f3>>
+ * @generated SignedSource<<db28f44b5d1dd5afb50338f13e4d68ec>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class StaticDeclarator extends EditableNode {
   }
 
   /**
-   * @returns VariableToken
+   * @return VariableToken
    */
   public function getName(): VariableToken {
     return TypeAssert\instance_of(VariableToken::class, $this->_name);
   }
 
   /**
-   * @returns VariableToken
+   * @return VariableToken
    */
   public function getNamex(): VariableToken {
     return $this->getName();
@@ -111,7 +111,7 @@ final class StaticDeclarator extends EditableNode {
   }
 
   /**
-   * @returns Missing | SimpleInitializer
+   * @return null | SimpleInitializer
    */
   public function getInitializer(): ?SimpleInitializer {
     if ($this->_initializer->isMissing()) {
@@ -122,7 +122,7 @@ final class StaticDeclarator extends EditableNode {
   }
 
   /**
-   * @returns SimpleInitializer
+   * @return SimpleInitializer
    */
   public function getInitializerx(): SimpleInitializer {
     return

--- a/codegen/syntax/SubscriptExpression.php
+++ b/codegen/syntax/SubscriptExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8844d5ccb4478b20068126a026f9b497>>
+ * @generated SignedSource<<53827dd2d1bf06f560f126a44369964f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,7 +119,7 @@ final class SubscriptExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayCreationExpression | ArrayIntrinsicExpression |
+   * @return ArrayCreationExpression | ArrayIntrinsicExpression |
    * FunctionCallExpression | LiteralExpression | MemberSelectionExpression |
    * ParenthesizedExpression | PrefixUnaryExpression |
    * SafeMemberSelectionExpression | ScopeResolutionExpression |
@@ -130,7 +130,7 @@ final class SubscriptExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayCreationExpression | ArrayIntrinsicExpression |
+   * @return ArrayCreationExpression | ArrayIntrinsicExpression |
    * FunctionCallExpression | LiteralExpression | MemberSelectionExpression |
    * ParenthesizedExpression | PrefixUnaryExpression |
    * SafeMemberSelectionExpression | ScopeResolutionExpression |
@@ -161,14 +161,14 @@ final class SubscriptExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBracketToken | LeftBraceToken
+   * @return LeftBracketToken | LeftBraceToken
    */
   public function getLeftBracket(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_left_bracket);
   }
 
   /**
-   * @returns LeftBracketToken | LeftBraceToken
+   * @return LeftBracketToken | LeftBraceToken
    */
   public function getLeftBracketx(): EditableToken {
     return $this->getLeftBracket();
@@ -195,9 +195,9 @@ final class SubscriptExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayIntrinsicExpression | BinaryExpression |
+   * @return AnonymousFunction | ArrayIntrinsicExpression | BinaryExpression |
    * CastExpression | FunctionCallExpression | LiteralExpression |
-   * MemberSelectionExpression | Missing | ObjectCreationExpression |
+   * MemberSelectionExpression | null | ObjectCreationExpression |
    * ParenthesizedExpression | PostfixUnaryExpression | PrefixUnaryExpression |
    * SafeMemberSelectionExpression | ScopeResolutionExpression |
    * SubscriptExpression | EchoToken | NameToken | ReturnToken |
@@ -211,7 +211,7 @@ final class SubscriptExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | ArrayIntrinsicExpression | BinaryExpression |
+   * @return AnonymousFunction | ArrayIntrinsicExpression | BinaryExpression |
    * CastExpression | FunctionCallExpression | LiteralExpression |
    * MemberSelectionExpression | ObjectCreationExpression |
    * ParenthesizedExpression | PostfixUnaryExpression | PrefixUnaryExpression |
@@ -240,7 +240,7 @@ final class SubscriptExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing | RightBracketToken | RightBraceToken
+   * @return null | RightBracketToken | RightBraceToken
    */
   public function getRightBracket(): ?EditableToken {
     if ($this->_right_bracket->isMissing()) {
@@ -250,7 +250,7 @@ final class SubscriptExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBracketToken | RightBraceToken
+   * @return RightBracketToken | RightBraceToken
    */
   public function getRightBracketx(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_right_bracket);

--- a/codegen/syntax/SwitchFallthrough.php
+++ b/codegen/syntax/SwitchFallthrough.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b7a1514549bc1d2d38e140b2ba81fd5f>>
+ * @generated SignedSource<<bc196035e77196040fdeba5790dbab05>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,7 +82,7 @@ final class SwitchFallthrough extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getKeyword(): ?EditableNode {
     if ($this->_keyword->isMissing()) {
@@ -92,7 +92,7 @@ final class SwitchFallthrough extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getKeywordx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_keyword);
@@ -114,7 +114,7 @@ final class SwitchFallthrough extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getSemicolon(): ?EditableNode {
     if ($this->_semicolon->isMissing()) {
@@ -124,7 +124,7 @@ final class SwitchFallthrough extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getSemicolonx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_semicolon);

--- a/codegen/syntax/SwitchSection.php
+++ b/codegen/syntax/SwitchSection.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<89bd5a559e6e1c4817a1290654246f86>>
+ * @generated SignedSource<<fdffbb6998a2b11732e17abeeb2ee85e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class SwitchSection extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getLabels(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_labels);
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getLabelsx(): EditableList<EditableNode> {
     return $this->getLabels();
@@ -130,7 +130,7 @@ final class SwitchSection extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getStatements(): ?EditableList<EditableNode> {
     if ($this->_statements->isMissing()) {
@@ -140,7 +140,7 @@ final class SwitchSection extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getStatementsx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_statements);
@@ -162,7 +162,7 @@ final class SwitchSection extends EditableNode {
   }
 
   /**
-   * @returns Missing | SwitchFallthrough
+   * @return null | SwitchFallthrough
    */
   public function getFallthrough(): ?SwitchFallthrough {
     if ($this->_fallthrough->isMissing()) {
@@ -173,7 +173,7 @@ final class SwitchSection extends EditableNode {
   }
 
   /**
-   * @returns SwitchFallthrough
+   * @return SwitchFallthrough
    */
   public function getFallthroughx(): SwitchFallthrough {
     return

--- a/codegen/syntax/SwitchStatement.php
+++ b/codegen/syntax/SwitchStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fe76961e126174d88fac5c2173c1f912>>
+ * @generated SignedSource<<4794693eee03d927bf7edc8ff8cd284b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -179,14 +179,14 @@ final class SwitchStatement
   }
 
   /**
-   * @returns SwitchToken
+   * @return SwitchToken
    */
   public function getKeyword(): SwitchToken {
     return TypeAssert\instance_of(SwitchToken::class, $this->_keyword);
   }
 
   /**
-   * @returns SwitchToken
+   * @return SwitchToken
    */
   public function getKeywordx(): SwitchToken {
     return $this->getKeyword();
@@ -216,14 +216,14 @@ final class SwitchStatement
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -253,7 +253,7 @@ final class SwitchStatement
   }
 
   /**
-   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * @return BinaryExpression | FunctionCallExpression | LiteralExpression |
    * MemberSelectionExpression | ObjectCreationExpression |
    * PrefixUnaryExpression | SubscriptExpression | VariableExpression
    */
@@ -262,7 +262,7 @@ final class SwitchStatement
   }
 
   /**
-   * @returns BinaryExpression | FunctionCallExpression | LiteralExpression |
+   * @return BinaryExpression | FunctionCallExpression | LiteralExpression |
    * MemberSelectionExpression | ObjectCreationExpression |
    * PrefixUnaryExpression | SubscriptExpression | VariableExpression
    */
@@ -294,14 +294,14 @@ final class SwitchStatement
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -331,14 +331,14 @@ final class SwitchStatement
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBracex(): LeftBraceToken {
     return $this->getLeftBrace();
@@ -368,7 +368,7 @@ final class SwitchStatement
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getSections(): ?EditableList<EditableNode> {
     if ($this->_sections->isMissing()) {
@@ -378,7 +378,7 @@ final class SwitchStatement
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getSectionsx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_sections);
@@ -408,14 +408,14 @@ final class SwitchStatement
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBrace(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBracex(): RightBraceToken {
     return $this->getRightBrace();

--- a/codegen/syntax/ThrowStatement.php
+++ b/codegen/syntax/ThrowStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<12e7a72abf515cd24912c631d3f6a982>>
+ * @generated SignedSource<<fe5190394b58902e50af8f1d57434c80>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class ThrowStatement extends EditableNode {
   }
 
   /**
-   * @returns ThrowToken
+   * @return ThrowToken
    */
   public function getKeyword(): ThrowToken {
     return TypeAssert\instance_of(ThrowToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ThrowToken
+   * @return ThrowToken
    */
   public function getKeywordx(): ThrowToken {
     return $this->getKeyword();
@@ -130,7 +130,7 @@ final class ThrowStatement extends EditableNode {
   }
 
   /**
-   * @returns FunctionCallExpression | LiteralExpression |
+   * @return FunctionCallExpression | LiteralExpression |
    * MemberSelectionExpression | ObjectCreationExpression |
    * ParenthesizedExpression | VariableExpression
    */
@@ -139,7 +139,7 @@ final class ThrowStatement extends EditableNode {
   }
 
   /**
-   * @returns FunctionCallExpression | LiteralExpression |
+   * @return FunctionCallExpression | LiteralExpression |
    * MemberSelectionExpression | ObjectCreationExpression |
    * ParenthesizedExpression | VariableExpression
    */
@@ -163,14 +163,14 @@ final class ThrowStatement extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/TraitUse.php
+++ b/codegen/syntax/TraitUse.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8aec8e80c06f10ec335320c77637937e>>
+ * @generated SignedSource<<37f5a29fe46c8102977f8d19c9556e1a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class TraitUse extends EditableNode {
   }
 
   /**
-   * @returns UseToken
+   * @return UseToken
    */
   public function getKeyword(): UseToken {
     return TypeAssert\instance_of(UseToken::class, $this->_keyword);
   }
 
   /**
-   * @returns UseToken
+   * @return UseToken
    */
   public function getKeywordx(): UseToken {
     return $this->getKeyword();
@@ -130,7 +130,7 @@ final class TraitUse extends EditableNode {
   }
 
   /**
-   * @returns EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
+   * @return EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
    * EditableList<SimpleTypeSpecifier>
    */
   public function getNames(): EditableList<EditableNode> {
@@ -138,7 +138,7 @@ final class TraitUse extends EditableNode {
   }
 
   /**
-   * @returns EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
+   * @return EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
    * EditableList<SimpleTypeSpecifier>
    */
   public function getNamesx(): EditableList<EditableNode> {
@@ -161,14 +161,14 @@ final class TraitUse extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/TraitUseAliasItem.php
+++ b/codegen/syntax/TraitUseAliasItem.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2a13db192b3d143ed1641971bab0d13b>>
+ * @generated SignedSource<<00837caa9775cfa0da396c49bf9318fa>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class TraitUseAliasItem extends EditableNode {
   }
 
   /**
-   * @returns ScopeResolutionExpression | SimpleTypeSpecifier
+   * @return ScopeResolutionExpression | SimpleTypeSpecifier
    */
   public function getAliasingName(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_aliasing_name);
   }
 
   /**
-   * @returns ScopeResolutionExpression | SimpleTypeSpecifier
+   * @return ScopeResolutionExpression | SimpleTypeSpecifier
    */
   public function getAliasingNamex(): EditableNode {
     return $this->getAliasingName();
@@ -153,14 +153,14 @@ final class TraitUseAliasItem extends EditableNode {
   }
 
   /**
-   * @returns AsToken
+   * @return AsToken
    */
   public function getKeyword(): AsToken {
     return TypeAssert\instance_of(AsToken::class, $this->_keyword);
   }
 
   /**
-   * @returns AsToken
+   * @return AsToken
    */
   public function getKeywordx(): AsToken {
     return $this->getKeyword();
@@ -187,7 +187,7 @@ final class TraitUseAliasItem extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getModifiers(): ?EditableList<EditableNode> {
     if ($this->_modifiers->isMissing()) {
@@ -197,7 +197,7 @@ final class TraitUseAliasItem extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getModifiersx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_modifiers);
@@ -224,7 +224,7 @@ final class TraitUseAliasItem extends EditableNode {
   }
 
   /**
-   * @returns Missing | SimpleTypeSpecifier
+   * @return null | SimpleTypeSpecifier
    */
   public function getAliasedName(): ?SimpleTypeSpecifier {
     if ($this->_aliased_name->isMissing()) {
@@ -235,7 +235,7 @@ final class TraitUseAliasItem extends EditableNode {
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getAliasedNamex(): SimpleTypeSpecifier {
     return

--- a/codegen/syntax/TraitUseConflictResolution.php
+++ b/codegen/syntax/TraitUseConflictResolution.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f995a5961ac2ae282bd0b3c80c0164ef>>
+ * @generated SignedSource<<104863f267c902e235bfbf6f0a444c00>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -133,14 +133,14 @@ final class TraitUseConflictResolution extends EditableNode {
   }
 
   /**
-   * @returns UseToken
+   * @return UseToken
    */
   public function getKeyword(): UseToken {
     return TypeAssert\instance_of(UseToken::class, $this->_keyword);
   }
 
   /**
-   * @returns UseToken
+   * @return UseToken
    */
   public function getKeywordx(): UseToken {
     return $this->getKeyword();
@@ -168,14 +168,14 @@ final class TraitUseConflictResolution extends EditableNode {
   }
 
   /**
-   * @returns EditableList<SimpleTypeSpecifier>
+   * @return EditableList<SimpleTypeSpecifier>
    */
   public function getNames(): EditableList<SimpleTypeSpecifier> {
     return TypeAssert\instance_of(EditableList::class, $this->_names);
   }
 
   /**
-   * @returns EditableList<SimpleTypeSpecifier>
+   * @return EditableList<SimpleTypeSpecifier>
    */
   public function getNamesx(): EditableList<SimpleTypeSpecifier> {
     return $this->getNames();
@@ -203,14 +203,14 @@ final class TraitUseConflictResolution extends EditableNode {
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBracex(): LeftBraceToken {
     return $this->getLeftBrace();
@@ -238,8 +238,8 @@ final class TraitUseConflictResolution extends EditableNode {
   }
 
   /**
-   * @returns EditableList<TraitUseAliasItem> | EditableList<EditableNode> |
-   * EditableList<TraitUsePrecedenceItem> | Missing
+   * @return EditableList<TraitUseAliasItem> | EditableList<EditableNode> |
+   * EditableList<TraitUsePrecedenceItem> | null
    */
   public function getClauses(): ?EditableList<EditableNode> {
     if ($this->_clauses->isMissing()) {
@@ -249,7 +249,7 @@ final class TraitUseConflictResolution extends EditableNode {
   }
 
   /**
-   * @returns EditableList<TraitUseAliasItem> | EditableList<EditableNode> |
+   * @return EditableList<TraitUseAliasItem> | EditableList<EditableNode> |
    * EditableList<TraitUsePrecedenceItem>
    */
   public function getClausesx(): EditableList<EditableNode> {
@@ -278,14 +278,14 @@ final class TraitUseConflictResolution extends EditableNode {
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBrace(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBracex(): RightBraceToken {
     return $this->getRightBrace();

--- a/codegen/syntax/TraitUsePrecedenceItem.php
+++ b/codegen/syntax/TraitUsePrecedenceItem.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<55cf773eff1a2640f2467e1573f96111>>
+ * @generated SignedSource<<ca38f92190905ac87833cba3ec407d87>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,7 +101,7 @@ final class TraitUsePrecedenceItem extends EditableNode {
   }
 
   /**
-   * @returns ScopeResolutionExpression
+   * @return ScopeResolutionExpression
    */
   public function getName(): ScopeResolutionExpression {
     return
@@ -109,7 +109,7 @@ final class TraitUsePrecedenceItem extends EditableNode {
   }
 
   /**
-   * @returns ScopeResolutionExpression
+   * @return ScopeResolutionExpression
    */
   public function getNamex(): ScopeResolutionExpression {
     return $this->getName();
@@ -131,14 +131,14 @@ final class TraitUsePrecedenceItem extends EditableNode {
   }
 
   /**
-   * @returns InsteadofToken
+   * @return InsteadofToken
    */
   public function getKeyword(): InsteadofToken {
     return TypeAssert\instance_of(InsteadofToken::class, $this->_keyword);
   }
 
   /**
-   * @returns InsteadofToken
+   * @return InsteadofToken
    */
   public function getKeywordx(): InsteadofToken {
     return $this->getKeyword();
@@ -160,14 +160,14 @@ final class TraitUsePrecedenceItem extends EditableNode {
   }
 
   /**
-   * @returns EditableList<SimpleTypeSpecifier>
+   * @return EditableList<SimpleTypeSpecifier>
    */
   public function getRemovedNames(): EditableList<SimpleTypeSpecifier> {
     return TypeAssert\instance_of(EditableList::class, $this->_removed_names);
   }
 
   /**
-   * @returns EditableList<SimpleTypeSpecifier>
+   * @return EditableList<SimpleTypeSpecifier>
    */
   public function getRemovedNamesx(): EditableList<SimpleTypeSpecifier> {
     return $this->getRemovedNames();

--- a/codegen/syntax/TryStatement.php
+++ b/codegen/syntax/TryStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<68e176bb40c360cf188a6e3e84cc62dd>>
+ * @generated SignedSource<<1f1bd9b81b0d372c9919b802ceeee5c1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -130,14 +130,14 @@ final class TryStatement extends EditableNode {
   }
 
   /**
-   * @returns TryToken
+   * @return TryToken
    */
   public function getKeyword(): TryToken {
     return TypeAssert\instance_of(TryToken::class, $this->_keyword);
   }
 
   /**
-   * @returns TryToken
+   * @return TryToken
    */
   public function getKeywordx(): TryToken {
     return $this->getKeyword();
@@ -164,7 +164,7 @@ final class TryStatement extends EditableNode {
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getCompoundStatement(): CompoundStatement {
     return TypeAssert\instance_of(
@@ -174,7 +174,7 @@ final class TryStatement extends EditableNode {
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getCompoundStatementx(): CompoundStatement {
     return $this->getCompoundStatement();
@@ -201,7 +201,7 @@ final class TryStatement extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getCatchClauses(): ?EditableList<EditableNode> {
     if ($this->_catch_clauses->isMissing()) {
@@ -211,7 +211,7 @@ final class TryStatement extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getCatchClausesx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_catch_clauses);
@@ -238,7 +238,7 @@ final class TryStatement extends EditableNode {
   }
 
   /**
-   * @returns FinallyClause | Missing
+   * @return FinallyClause | null
    */
   public function getFinallyClause(): ?FinallyClause {
     if ($this->_finally_clause->isMissing()) {
@@ -248,7 +248,7 @@ final class TryStatement extends EditableNode {
   }
 
   /**
-   * @returns FinallyClause
+   * @return FinallyClause
    */
   public function getFinallyClausex(): FinallyClause {
     return TypeAssert\instance_of(FinallyClause::class, $this->_finally_clause);

--- a/codegen/syntax/TupleExpression.php
+++ b/codegen/syntax/TupleExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1e1acd17552711df94d875ff2f3dbf36>>
+ * @generated SignedSource<<243fcaf723250580bcec8f852e99d23f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class TupleExpression extends EditableNode {
   }
 
   /**
-   * @returns TupleToken
+   * @return TupleToken
    */
   public function getKeyword(): TupleToken {
     return TypeAssert\instance_of(TupleToken::class, $this->_keyword);
   }
 
   /**
-   * @returns TupleToken
+   * @return TupleToken
    */
   public function getKeywordx(): TupleToken {
     return $this->getKeyword();
@@ -149,14 +149,14 @@ final class TupleExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -183,11 +183,10 @@ final class TupleExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> |
+   * @return EditableList<EditableNode> |
    * EditableList<ArrayIntrinsicExpression> | EditableList<BinaryExpression> |
    * EditableList<CastExpression> | EditableList<FunctionCallExpression> |
-   * EditableList<LiteralExpression> | EditableList<VariableExpression> |
-   * Missing
+   * EditableList<LiteralExpression> | EditableList<VariableExpression> | null
    */
   public function getItems(): ?EditableList<EditableNode> {
     if ($this->_items->isMissing()) {
@@ -197,7 +196,7 @@ final class TupleExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> |
+   * @return EditableList<EditableNode> |
    * EditableList<ArrayIntrinsicExpression> | EditableList<BinaryExpression> |
    * EditableList<CastExpression> | EditableList<FunctionCallExpression> |
    * EditableList<LiteralExpression> | EditableList<VariableExpression>
@@ -223,14 +222,14 @@ final class TupleExpression extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();

--- a/codegen/syntax/TupleTypeExplicitSpecifier.php
+++ b/codegen/syntax/TupleTypeExplicitSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<31ac9fb78f456234d592a59cf0694755>>
+ * @generated SignedSource<<4b296360e3ce94bc89b2a78649e53d1b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class TupleTypeExplicitSpecifier extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getKeyword(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_keyword);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getKeywordx(): EditableNode {
     return $this->getKeyword();
@@ -149,14 +149,14 @@ final class TupleTypeExplicitSpecifier extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getLeftAngle(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_angle);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getLeftAnglex(): EditableNode {
     return $this->getLeftAngle();
@@ -183,14 +183,14 @@ final class TupleTypeExplicitSpecifier extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getTypes(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_types);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getTypesx(): EditableNode {
     return $this->getTypes();
@@ -213,14 +213,14 @@ final class TupleTypeExplicitSpecifier extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getRightAngle(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_angle);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getRightAnglex(): EditableNode {
     return $this->getRightAngle();

--- a/codegen/syntax/TupleTypeSpecifier.php
+++ b/codegen/syntax/TupleTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b3f7e6f720869406e1462903e7f50b09>>
+ * @generated SignedSource<<79406efcd056d15059ff7f493269f75b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class TupleTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -130,7 +130,7 @@ final class TupleTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | EditableList<SimpleTypeSpecifier> |
+   * @return EditableList<EditableNode> | EditableList<SimpleTypeSpecifier> |
    * EditableList<VectorArrayTypeSpecifier> | EditableList<VectorTypeSpecifier>
    */
   public function getTypes(): EditableList<EditableNode> {
@@ -138,7 +138,7 @@ final class TupleTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | EditableList<SimpleTypeSpecifier> |
+   * @return EditableList<EditableNode> | EditableList<SimpleTypeSpecifier> |
    * EditableList<VectorArrayTypeSpecifier> | EditableList<VectorTypeSpecifier>
    */
   public function getTypesx(): EditableList<EditableNode> {
@@ -161,14 +161,14 @@ final class TupleTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();

--- a/codegen/syntax/TypeArguments.php
+++ b/codegen/syntax/TypeArguments.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7e46cdbe17ecc6c425606c7c58c3e3a3>>
+ * @generated SignedSource<<be644a89c38be3a518900972103a7636>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class TypeArguments extends EditableNode {
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAnglex(): LessThanToken {
     return $this->getLeftAngle();
@@ -130,7 +130,7 @@ final class TypeArguments extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ClassnameTypeSpecifier> |
+   * @return EditableList<ClassnameTypeSpecifier> |
    * EditableList<ClosureTypeSpecifier> | EditableList<DictionaryTypeSpecifier>
    * | EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
    * EditableList<MapArrayTypeSpecifier> | EditableList<NullableTypeSpecifier>
@@ -143,7 +143,7 @@ final class TypeArguments extends EditableNode {
   }
 
   /**
-   * @returns EditableList<ClassnameTypeSpecifier> |
+   * @return EditableList<ClassnameTypeSpecifier> |
    * EditableList<ClosureTypeSpecifier> | EditableList<DictionaryTypeSpecifier>
    * | EditableList<GenericTypeSpecifier> | EditableList<EditableNode> |
    * EditableList<MapArrayTypeSpecifier> | EditableList<NullableTypeSpecifier>
@@ -171,7 +171,7 @@ final class TypeArguments extends EditableNode {
   }
 
   /**
-   * @returns Missing | GreaterThanToken
+   * @return null | GreaterThanToken
    */
   public function getRightAngle(): ?GreaterThanToken {
     if ($this->_right_angle->isMissing()) {
@@ -181,7 +181,7 @@ final class TypeArguments extends EditableNode {
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAnglex(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);

--- a/codegen/syntax/TypeConstDeclaration.php
+++ b/codegen/syntax/TypeConstDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3c879b204c1c4bd03a5b565af6461a41>>
+ * @generated SignedSource<<d241e0f0d408ce55acf7ddc60b3e5f22>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -209,7 +209,7 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | AbstractToken
+   * @return null | AbstractToken
    */
   public function getAbstract(): ?AbstractToken {
     if ($this->_abstract->isMissing()) {
@@ -219,7 +219,7 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns AbstractToken
+   * @return AbstractToken
    */
   public function getAbstractx(): AbstractToken {
     return TypeAssert\instance_of(AbstractToken::class, $this->_abstract);
@@ -251,14 +251,14 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ConstToken
+   * @return ConstToken
    */
   public function getKeyword(): ConstToken {
     return TypeAssert\instance_of(ConstToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ConstToken
+   * @return ConstToken
    */
   public function getKeywordx(): ConstToken {
     return $this->getKeyword();
@@ -290,14 +290,14 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns TypeToken
+   * @return TypeToken
    */
   public function getTypeKeyword(): TypeToken {
     return TypeAssert\instance_of(TypeToken::class, $this->_type_keyword);
   }
 
   /**
-   * @returns TypeToken
+   * @return TypeToken
    */
   public function getTypeKeywordx(): TypeToken {
     return $this->getTypeKeyword();
@@ -329,14 +329,14 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getNamex(): NameToken {
     return $this->getName();
@@ -368,7 +368,7 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getTypeParameters(): ?EditableNode {
     if ($this->_type_parameters->isMissing()) {
@@ -378,7 +378,7 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getTypeParametersx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type_parameters);
@@ -410,7 +410,7 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | TypeConstraint
+   * @return null | TypeConstraint
    */
   public function getTypeConstraint(): ?TypeConstraint {
     if ($this->_type_constraint->isMissing()) {
@@ -421,7 +421,7 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns TypeConstraint
+   * @return TypeConstraint
    */
   public function getTypeConstraintx(): TypeConstraint {
     return
@@ -454,7 +454,7 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns Missing | EqualToken
+   * @return null | EqualToken
    */
   public function getEqual(): ?EqualToken {
     if ($this->_equal->isMissing()) {
@@ -464,7 +464,7 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EqualToken
+   * @return EqualToken
    */
   public function getEqualx(): EqualToken {
     return TypeAssert\instance_of(EqualToken::class, $this->_equal);
@@ -496,10 +496,10 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | DictionaryTypeSpecifier |
-   * GenericTypeSpecifier | KeysetTypeSpecifier | Missing |
-   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
-   * TupleTypeSpecifier | TypeConstant | VectorTypeSpecifier
+   * @return ClosureTypeSpecifier | DictionaryTypeSpecifier |
+   * GenericTypeSpecifier | KeysetTypeSpecifier | null | NullableTypeSpecifier
+   * | ShapeTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier |
+   * TypeConstant | VectorTypeSpecifier
    */
   public function getTypeSpecifier(): ?EditableNode {
     if ($this->_type_specifier->isMissing()) {
@@ -509,7 +509,7 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | DictionaryTypeSpecifier |
+   * @return ClosureTypeSpecifier | DictionaryTypeSpecifier |
    * GenericTypeSpecifier | KeysetTypeSpecifier | NullableTypeSpecifier |
    * ShapeTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier |
    * TypeConstant | VectorTypeSpecifier
@@ -544,14 +544,14 @@ final class TypeConstDeclaration extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/TypeConstant.php
+++ b/codegen/syntax/TypeConstant.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4d6e2db00b0b43187a1e2d66fd84ef7e>>
+ * @generated SignedSource<<75a0195bb89ea93cea689a610e73fa8b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class TypeConstant extends EditableNode {
   }
 
   /**
-   * @returns NameToken | ParentToken | SelfToken | ThisToken | TypeConstant
+   * @return NameToken | ParentToken | SelfToken | ThisToken | TypeConstant
    */
   public function getLeftType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_type);
   }
 
   /**
-   * @returns NameToken | ParentToken | SelfToken | ThisToken | TypeConstant
+   * @return NameToken | ParentToken | SelfToken | ThisToken | TypeConstant
    */
   public function getLeftTypex(): EditableNode {
     return $this->getLeftType();
@@ -130,14 +130,14 @@ final class TypeConstant extends EditableNode {
   }
 
   /**
-   * @returns ColonColonToken
+   * @return ColonColonToken
    */
   public function getSeparator(): ColonColonToken {
     return TypeAssert\instance_of(ColonColonToken::class, $this->_separator);
   }
 
   /**
-   * @returns ColonColonToken
+   * @return ColonColonToken
    */
   public function getSeparatorx(): ColonColonToken {
     return $this->getSeparator();
@@ -159,14 +159,14 @@ final class TypeConstant extends EditableNode {
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getRightType(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_right_type);
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getRightTypex(): NameToken {
     return $this->getRightType();

--- a/codegen/syntax/TypeConstraint.php
+++ b/codegen/syntax/TypeConstraint.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a7d9e29fae7909141ace401acdd4dc1b>>
+ * @generated SignedSource<<f4bc0b2d2052add8123e11a042107bd7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class TypeConstraint extends EditableNode {
   }
 
   /**
-   * @returns AsToken | SuperToken
+   * @return AsToken | SuperToken
    */
   public function getKeyword(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_keyword);
   }
 
   /**
-   * @returns AsToken | SuperToken
+   * @return AsToken | SuperToken
    */
   public function getKeywordx(): EditableToken {
     return $this->getKeyword();
@@ -111,7 +111,7 @@ final class TypeConstraint extends EditableNode {
   }
 
   /**
-   * @returns ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
    * DictionaryTypeSpecifier | GenericTypeSpecifier | KeysetTypeSpecifier |
    * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
    * TypeConstant | VectorArrayTypeSpecifier | VectorTypeSpecifier
@@ -121,7 +121,7 @@ final class TypeConstraint extends EditableNode {
   }
 
   /**
-   * @returns ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
    * DictionaryTypeSpecifier | GenericTypeSpecifier | KeysetTypeSpecifier |
    * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
    * TypeConstant | VectorArrayTypeSpecifier | VectorTypeSpecifier

--- a/codegen/syntax/TypeParameter.php
+++ b/codegen/syntax/TypeParameter.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<323322927a58fd400bce0ddfd7fb01ca>>
+ * @generated SignedSource<<e7cd16d96d0d88bf26e9c0833c3328a4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -115,7 +115,7 @@ final class TypeParameter extends EditableNode {
   }
 
   /**
-   * @returns Missing | ReifiedToken
+   * @return null | ReifiedToken
    */
   public function getReified(): ?ReifiedToken {
     if ($this->_reified->isMissing()) {
@@ -125,7 +125,7 @@ final class TypeParameter extends EditableNode {
   }
 
   /**
-   * @returns ReifiedToken
+   * @return ReifiedToken
    */
   public function getReifiedx(): ReifiedToken {
     return TypeAssert\instance_of(ReifiedToken::class, $this->_reified);
@@ -148,7 +148,7 @@ final class TypeParameter extends EditableNode {
   }
 
   /**
-   * @returns Missing | PlusToken | MinusToken
+   * @return null | PlusToken | MinusToken
    */
   public function getVariance(): ?EditableToken {
     if ($this->_variance->isMissing()) {
@@ -158,7 +158,7 @@ final class TypeParameter extends EditableNode {
   }
 
   /**
-   * @returns PlusToken | MinusToken
+   * @return PlusToken | MinusToken
    */
   public function getVariancex(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_variance);
@@ -185,14 +185,14 @@ final class TypeParameter extends EditableNode {
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getName(): NameToken {
     return TypeAssert\instance_of(NameToken::class, $this->_name);
   }
 
   /**
-   * @returns NameToken
+   * @return NameToken
    */
   public function getNamex(): NameToken {
     return $this->getName();
@@ -214,7 +214,7 @@ final class TypeParameter extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getConstraints(): ?EditableList<EditableNode> {
     if ($this->_constraints->isMissing()) {
@@ -224,7 +224,7 @@ final class TypeParameter extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getConstraintsx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_constraints);

--- a/codegen/syntax/TypeParameters.php
+++ b/codegen/syntax/TypeParameters.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0d48297f6224a80d50a461959e0ecbe5>>
+ * @generated SignedSource<<7cd6c09e2ad0885aa2670e018b4f1ab3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class TypeParameters extends EditableNode {
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAnglex(): LessThanToken {
     return $this->getLeftAngle();
@@ -130,14 +130,14 @@ final class TypeParameters extends EditableNode {
   }
 
   /**
-   * @returns EditableList<TypeParameter>
+   * @return EditableList<TypeParameter>
    */
   public function getParameters(): EditableList<TypeParameter> {
     return TypeAssert\instance_of(EditableList::class, $this->_parameters);
   }
 
   /**
-   * @returns EditableList<TypeParameter>
+   * @return EditableList<TypeParameter>
    */
   public function getParametersx(): EditableList<TypeParameter> {
     return $this->getParameters();
@@ -159,14 +159,14 @@ final class TypeParameters extends EditableNode {
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAnglex(): GreaterThanToken {
     return $this->getRightAngle();

--- a/codegen/syntax/UnsetStatement.php
+++ b/codegen/syntax/UnsetStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<40980bfa4a4584dee2e8135ef9e49a98>>
+ * @generated SignedSource<<c407cf717680a6576a74d2d64a7744bc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -135,14 +135,14 @@ final class UnsetStatement extends EditableNode {
   }
 
   /**
-   * @returns UnsetToken
+   * @return UnsetToken
    */
   public function getKeyword(): UnsetToken {
     return TypeAssert\instance_of(UnsetToken::class, $this->_keyword);
   }
 
   /**
-   * @returns UnsetToken
+   * @return UnsetToken
    */
   public function getKeywordx(): UnsetToken {
     return $this->getKeyword();
@@ -170,14 +170,14 @@ final class UnsetStatement extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -205,7 +205,7 @@ final class UnsetStatement extends EditableNode {
   }
 
   /**
-   * @returns EditableList<MemberSelectionExpression> |
+   * @return EditableList<MemberSelectionExpression> |
    * EditableList<EditableNode> | EditableList<PrefixUnaryExpression> |
    * EditableList<SafeMemberSelectionExpression> |
    * EditableList<ScopeResolutionExpression> |
@@ -216,7 +216,7 @@ final class UnsetStatement extends EditableNode {
   }
 
   /**
-   * @returns EditableList<MemberSelectionExpression> |
+   * @return EditableList<MemberSelectionExpression> |
    * EditableList<EditableNode> | EditableList<PrefixUnaryExpression> |
    * EditableList<SafeMemberSelectionExpression> |
    * EditableList<ScopeResolutionExpression> |
@@ -248,14 +248,14 @@ final class UnsetStatement extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -283,14 +283,14 @@ final class UnsetStatement extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/UsingStatementBlockScoped.php
+++ b/codegen/syntax/UsingStatementBlockScoped.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<eb6b6e673a313df22fe6711c08c9ed7b>>
+ * @generated SignedSource<<8e25714d0605012f8a9fb18c5518345e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -161,7 +161,7 @@ final class UsingStatementBlockScoped extends EditableNode {
   }
 
   /**
-   * @returns Missing | AwaitToken
+   * @return null | AwaitToken
    */
   public function getAwaitKeyword(): ?AwaitToken {
     if ($this->_await_keyword->isMissing()) {
@@ -171,7 +171,7 @@ final class UsingStatementBlockScoped extends EditableNode {
   }
 
   /**
-   * @returns AwaitToken
+   * @return AwaitToken
    */
   public function getAwaitKeywordx(): AwaitToken {
     return TypeAssert\instance_of(AwaitToken::class, $this->_await_keyword);
@@ -200,14 +200,14 @@ final class UsingStatementBlockScoped extends EditableNode {
   }
 
   /**
-   * @returns UsingToken
+   * @return UsingToken
    */
   public function getUsingKeyword(): UsingToken {
     return TypeAssert\instance_of(UsingToken::class, $this->_using_keyword);
   }
 
   /**
-   * @returns UsingToken
+   * @return UsingToken
    */
   public function getUsingKeywordx(): UsingToken {
     return $this->getUsingKeyword();
@@ -236,14 +236,14 @@ final class UsingStatementBlockScoped extends EditableNode {
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -272,8 +272,8 @@ final class UsingStatementBlockScoped extends EditableNode {
   }
 
   /**
-   * @returns EditableList<AnonymousFunction> | EditableList<BinaryExpression>
-   * | EditableList<LambdaExpression> | EditableList<LiteralExpression> |
+   * @return EditableList<AnonymousFunction> | EditableList<BinaryExpression> |
+   * EditableList<LambdaExpression> | EditableList<LiteralExpression> |
    * EditableList<ObjectCreationExpression> | EditableList<EditableNode> |
    * EditableList<PrefixUnaryExpression> | EditableList<VariableExpression>
    */
@@ -282,8 +282,8 @@ final class UsingStatementBlockScoped extends EditableNode {
   }
 
   /**
-   * @returns EditableList<AnonymousFunction> | EditableList<BinaryExpression>
-   * | EditableList<LambdaExpression> | EditableList<LiteralExpression> |
+   * @return EditableList<AnonymousFunction> | EditableList<BinaryExpression> |
+   * EditableList<LambdaExpression> | EditableList<LiteralExpression> |
    * EditableList<ObjectCreationExpression> | EditableList<EditableNode> |
    * EditableList<PrefixUnaryExpression> | EditableList<VariableExpression>
    */
@@ -314,14 +314,14 @@ final class UsingStatementBlockScoped extends EditableNode {
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -350,14 +350,14 @@ final class UsingStatementBlockScoped extends EditableNode {
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getBody(): CompoundStatement {
     return TypeAssert\instance_of(CompoundStatement::class, $this->_body);
   }
 
   /**
-   * @returns CompoundStatement
+   * @return CompoundStatement
    */
   public function getBodyx(): CompoundStatement {
     return $this->getBody();

--- a/codegen/syntax/UsingStatementFunctionScoped.php
+++ b/codegen/syntax/UsingStatementFunctionScoped.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<162b4a5d19b01f9e8fe2459720bab0d3>>
+ * @generated SignedSource<<6cf6c16a1b8f522fcc26cb68a31f6c05>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,7 +119,7 @@ final class UsingStatementFunctionScoped extends EditableNode {
   }
 
   /**
-   * @returns Missing | AwaitToken
+   * @return null | AwaitToken
    */
   public function getAwaitKeyword(): ?AwaitToken {
     if ($this->_await_keyword->isMissing()) {
@@ -129,7 +129,7 @@ final class UsingStatementFunctionScoped extends EditableNode {
   }
 
   /**
-   * @returns AwaitToken
+   * @return AwaitToken
    */
   public function getAwaitKeywordx(): AwaitToken {
     return TypeAssert\instance_of(AwaitToken::class, $this->_await_keyword);
@@ -156,14 +156,14 @@ final class UsingStatementFunctionScoped extends EditableNode {
   }
 
   /**
-   * @returns UsingToken
+   * @return UsingToken
    */
   public function getUsingKeyword(): UsingToken {
     return TypeAssert\instance_of(UsingToken::class, $this->_using_keyword);
   }
 
   /**
-   * @returns UsingToken
+   * @return UsingToken
    */
   public function getUsingKeywordx(): UsingToken {
     return $this->getUsingKeyword();
@@ -190,7 +190,7 @@ final class UsingStatementFunctionScoped extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression | LambdaExpression | ObjectCreationExpression |
+   * @return BinaryExpression | LambdaExpression | ObjectCreationExpression |
    * ParenthesizedExpression | PrefixUnaryExpression | VariableExpression
    */
   public function getExpression(): EditableNode {
@@ -198,7 +198,7 @@ final class UsingStatementFunctionScoped extends EditableNode {
   }
 
   /**
-   * @returns BinaryExpression | LambdaExpression | ObjectCreationExpression |
+   * @return BinaryExpression | LambdaExpression | ObjectCreationExpression |
    * ParenthesizedExpression | PrefixUnaryExpression | VariableExpression
    */
   public function getExpressionx(): EditableNode {
@@ -226,14 +226,14 @@ final class UsingStatementFunctionScoped extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/VariableExpression.php
+++ b/codegen/syntax/VariableExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<284cabdc4efe7a17057edc1b97771e1a>>
+ * @generated SignedSource<<0b8687d7028c46182a918a8fb434972e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -71,14 +71,14 @@ final class VariableExpression extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getExpressionx(): EditableNode {
     return $this->getExpression();

--- a/codegen/syntax/VariadicParameter.php
+++ b/codegen/syntax/VariadicParameter.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2856f5d46ecf2c1b97b2b4789df4ba6c>>
+ * @generated SignedSource<<b72721ecae227204e9c77ab745e6c3a6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,7 +101,7 @@ final class VariadicParameter extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getCallConvention(): ?EditableNode {
     if ($this->_call_convention->isMissing()) {
@@ -111,7 +111,7 @@ final class VariadicParameter extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getCallConventionx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_call_convention);
@@ -133,7 +133,7 @@ final class VariadicParameter extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | Missing | SimpleTypeSpecifier |
+   * @return ClosureTypeSpecifier | null | SimpleTypeSpecifier |
    * TupleTypeSpecifier
    */
   public function getType(): ?EditableNode {
@@ -144,7 +144,7 @@ final class VariadicParameter extends EditableNode {
   }
 
   /**
-   * @returns ClosureTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier
+   * @return ClosureTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier
    */
   public function getTypex(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
@@ -166,14 +166,14 @@ final class VariadicParameter extends EditableNode {
   }
 
   /**
-   * @returns DotDotDotToken
+   * @return DotDotDotToken
    */
   public function getEllipsis(): DotDotDotToken {
     return TypeAssert\instance_of(DotDotDotToken::class, $this->_ellipsis);
   }
 
   /**
-   * @returns DotDotDotToken
+   * @return DotDotDotToken
    */
   public function getEllipsisx(): DotDotDotToken {
     return $this->getEllipsis();

--- a/codegen/syntax/VarrayIntrinsicExpression.php
+++ b/codegen/syntax/VarrayIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2a77c11295da4300c7b449ef6da03cc6>>
+ * @generated SignedSource<<a796a8ef44e27f673f0ff975741c563e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -145,14 +145,14 @@ final class VarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns VarrayToken
+   * @return VarrayToken
    */
   public function getKeyword(): VarrayToken {
     return TypeAssert\instance_of(VarrayToken::class, $this->_keyword);
   }
 
   /**
-   * @returns VarrayToken
+   * @return VarrayToken
    */
   public function getKeywordx(): VarrayToken {
     return $this->getKeyword();
@@ -180,7 +180,7 @@ final class VarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getExplicitType(): ?EditableNode {
     if ($this->_explicit_type->isMissing()) {
@@ -190,7 +190,7 @@ final class VarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getExplicitTypex(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_explicit_type);
@@ -218,7 +218,7 @@ final class VarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBracketToken
+   * @return LeftBracketToken
    */
   public function getLeftBracket(): LeftBracketToken {
     return
@@ -226,7 +226,7 @@ final class VarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBracketToken
+   * @return LeftBracketToken
    */
   public function getLeftBracketx(): LeftBracketToken {
     return $this->getLeftBracket();
@@ -254,13 +254,13 @@ final class VarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> |
+   * @return EditableList<EditableNode> |
    * EditableList<ArrayIntrinsicExpression> |
    * EditableList<DarrayIntrinsicExpression> |
    * EditableList<FunctionCallExpression> | EditableList<LiteralExpression> |
    * EditableList<ScopeResolutionExpression> | EditableList<NameToken> |
    * EditableList<VariableExpression> | EditableList<VarrayIntrinsicExpression>
-   * | EditableList<VectorIntrinsicExpression> | Missing
+   * | EditableList<VectorIntrinsicExpression> | null
    */
   public function getMembers(): ?EditableList<EditableNode> {
     if ($this->_members->isMissing()) {
@@ -270,7 +270,7 @@ final class VarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> |
+   * @return EditableList<EditableNode> |
    * EditableList<ArrayIntrinsicExpression> |
    * EditableList<DarrayIntrinsicExpression> |
    * EditableList<FunctionCallExpression> | EditableList<LiteralExpression> |
@@ -304,7 +304,7 @@ final class VarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBracketToken
+   * @return RightBracketToken
    */
   public function getRightBracket(): RightBracketToken {
     return
@@ -312,7 +312,7 @@ final class VarrayIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBracketToken
+   * @return RightBracketToken
    */
   public function getRightBracketx(): RightBracketToken {
     return $this->getRightBracket();

--- a/codegen/syntax/VarrayTypeSpecifier.php
+++ b/codegen/syntax/VarrayTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c8c7169d0d6b9041cd16604b4c3ea398>>
+ * @generated SignedSource<<4b0f0a108eeb256d44cea82da5f52f43>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -135,14 +135,14 @@ final class VarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns VarrayToken
+   * @return VarrayToken
    */
   public function getKeyword(): VarrayToken {
     return TypeAssert\instance_of(VarrayToken::class, $this->_keyword);
   }
 
   /**
-   * @returns VarrayToken
+   * @return VarrayToken
    */
   public function getKeywordx(): VarrayToken {
     return $this->getKeyword();
@@ -170,14 +170,14 @@ final class VarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAnglex(): LessThanToken {
     return $this->getLeftAngle();
@@ -205,7 +205,7 @@ final class VarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns DarrayTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier
+   * @return DarrayTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier
    * | VarrayTypeSpecifier | VectorArrayTypeSpecifier
    */
   public function getType(): EditableNode {
@@ -213,7 +213,7 @@ final class VarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns DarrayTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier
+   * @return DarrayTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier
    * | VarrayTypeSpecifier | VectorArrayTypeSpecifier
    */
   public function getTypex(): EditableNode {
@@ -242,7 +242,7 @@ final class VarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getTrailingComma(): ?EditableNode {
     if ($this->_trailing_comma->isMissing()) {
@@ -252,7 +252,7 @@ final class VarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getTrailingCommax(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_trailing_comma);
@@ -280,14 +280,14 @@ final class VarrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAnglex(): GreaterThanToken {
     return $this->getRightAngle();

--- a/codegen/syntax/VectorArrayTypeSpecifier.php
+++ b/codegen/syntax/VectorArrayTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a1cc74550b618468b76dcf5942aae1e0>>
+ * @generated SignedSource<<5d872c6207bf339ac832c9b48ece4aa9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -115,14 +115,14 @@ final class VectorArrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ArrayToken
+   * @return ArrayToken
    */
   public function getKeyword(): ArrayToken {
     return TypeAssert\instance_of(ArrayToken::class, $this->_keyword);
   }
 
   /**
-   * @returns ArrayToken
+   * @return ArrayToken
    */
   public function getKeywordx(): ArrayToken {
     return $this->getKeyword();
@@ -145,14 +145,14 @@ final class VectorArrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAnglex(): LessThanToken {
     return $this->getLeftAngle();
@@ -179,18 +179,18 @@ final class VectorArrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns DarrayTypeSpecifier | GenericTypeSpecifier |
-   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
-   * TupleTypeSpecifier | VarrayTypeSpecifier | VectorArrayTypeSpecifier
+   * @return DarrayTypeSpecifier | GenericTypeSpecifier | NullableTypeSpecifier
+   * | ShapeTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier |
+   * VarrayTypeSpecifier | VectorArrayTypeSpecifier
    */
   public function getType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_type);
   }
 
   /**
-   * @returns DarrayTypeSpecifier | GenericTypeSpecifier |
-   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
-   * TupleTypeSpecifier | VarrayTypeSpecifier | VectorArrayTypeSpecifier
+   * @return DarrayTypeSpecifier | GenericTypeSpecifier | NullableTypeSpecifier
+   * | ShapeTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier |
+   * VarrayTypeSpecifier | VectorArrayTypeSpecifier
    */
   public function getTypex(): EditableNode {
     return $this->getType();
@@ -213,14 +213,14 @@ final class VectorArrayTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAnglex(): GreaterThanToken {
     return $this->getRightAngle();

--- a/codegen/syntax/VectorIntrinsicExpression.php
+++ b/codegen/syntax/VectorIntrinsicExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<36a911fe5ab7a8d71d2002ddb9804c17>>
+ * @generated SignedSource<<c5ed0fa5ffda078f79297c0ebee81110>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -145,14 +145,14 @@ final class VectorIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns VecToken
+   * @return VecToken
    */
   public function getKeyword(): VecToken {
     return TypeAssert\instance_of(VecToken::class, $this->_keyword);
   }
 
   /**
-   * @returns VecToken
+   * @return VecToken
    */
   public function getKeywordx(): VecToken {
     return $this->getKeyword();
@@ -180,7 +180,7 @@ final class VectorIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getExplicitType(): ?EditableNode {
     if ($this->_explicit_type->isMissing()) {
@@ -190,7 +190,7 @@ final class VectorIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getExplicitTypex(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_explicit_type);
@@ -218,7 +218,7 @@ final class VectorIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBracketToken
+   * @return LeftBracketToken
    */
   public function getLeftBracket(): LeftBracketToken {
     return
@@ -226,7 +226,7 @@ final class VectorIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns LeftBracketToken
+   * @return LeftBracketToken
    */
   public function getLeftBracketx(): LeftBracketToken {
     return $this->getLeftBracket();
@@ -254,7 +254,7 @@ final class VectorIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | EditableList<BinaryExpression> |
+   * @return EditableList<EditableNode> | EditableList<BinaryExpression> |
    * EditableList<CollectionLiteralExpression> |
    * EditableList<ConditionalExpression> |
    * EditableList<DictionaryIntrinsicExpression> |
@@ -264,7 +264,7 @@ final class VectorIntrinsicExpression extends EditableNode {
    * EditableList<ScopeResolutionExpression> | EditableList<ShapeExpression> |
    * EditableList<NameToken> | EditableList<TupleExpression> |
    * EditableList<VariableExpression> | EditableList<VectorIntrinsicExpression>
-   * | EditableList<XHPExpression> | Missing
+   * | EditableList<XHPExpression> | null
    */
   public function getMembers(): ?EditableList<EditableNode> {
     if ($this->_members->isMissing()) {
@@ -274,7 +274,7 @@ final class VectorIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | EditableList<BinaryExpression> |
+   * @return EditableList<EditableNode> | EditableList<BinaryExpression> |
    * EditableList<CollectionLiteralExpression> |
    * EditableList<ConditionalExpression> |
    * EditableList<DictionaryIntrinsicExpression> |
@@ -312,7 +312,7 @@ final class VectorIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBracketToken
+   * @return RightBracketToken
    */
   public function getRightBracket(): RightBracketToken {
     return
@@ -320,7 +320,7 @@ final class VectorIntrinsicExpression extends EditableNode {
   }
 
   /**
-   * @returns RightBracketToken
+   * @return RightBracketToken
    */
   public function getRightBracketx(): RightBracketToken {
     return $this->getRightBracket();

--- a/codegen/syntax/VectorTypeSpecifier.php
+++ b/codegen/syntax/VectorTypeSpecifier.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bf068e4e73715c90b44ef9e73bc8ec91>>
+ * @generated SignedSource<<ff14d0c011fc5e5aac7f993cc557c6ec>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -135,14 +135,14 @@ final class VectorTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns VecToken
+   * @return VecToken
    */
   public function getKeyword(): VecToken {
     return TypeAssert\instance_of(VecToken::class, $this->_keyword);
   }
 
   /**
-   * @returns VecToken
+   * @return VecToken
    */
   public function getKeywordx(): VecToken {
     return $this->getKeyword();
@@ -170,14 +170,14 @@ final class VectorTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAnglex(): LessThanToken {
     return $this->getLeftAngle();
@@ -205,7 +205,7 @@ final class VectorTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
    * NullableTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier |
    * VectorTypeSpecifier
    */
@@ -214,7 +214,7 @@ final class VectorTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
    * NullableTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier |
    * VectorTypeSpecifier
    */
@@ -244,7 +244,7 @@ final class VectorTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getTrailingComma(): ?EditableNode {
     if ($this->_trailing_comma->isMissing()) {
@@ -254,7 +254,7 @@ final class VectorTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getTrailingCommax(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_trailing_comma);
@@ -282,14 +282,14 @@ final class VectorTypeSpecifier extends EditableNode {
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAngle(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAnglex(): GreaterThanToken {
     return $this->getRightAngle();

--- a/codegen/syntax/WhereClause.php
+++ b/codegen/syntax/WhereClause.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<43aff8c12ee3eaf77324c4f77b29fddd>>
+ * @generated SignedSource<<5f3d7404dfdaea70da39ffc1641c4a5a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,14 +85,14 @@ final class WhereClause extends EditableNode {
   }
 
   /**
-   * @returns WhereToken
+   * @return WhereToken
    */
   public function getKeyword(): WhereToken {
     return TypeAssert\instance_of(WhereToken::class, $this->_keyword);
   }
 
   /**
-   * @returns WhereToken
+   * @return WhereToken
    */
   public function getKeywordx(): WhereToken {
     return $this->getKeyword();
@@ -114,14 +114,14 @@ final class WhereClause extends EditableNode {
   }
 
   /**
-   * @returns EditableList<WhereConstraint>
+   * @return EditableList<WhereConstraint>
    */
   public function getConstraints(): EditableList<WhereConstraint> {
     return TypeAssert\instance_of(EditableList::class, $this->_constraints);
   }
 
   /**
-   * @returns EditableList<WhereConstraint>
+   * @return EditableList<WhereConstraint>
    */
   public function getConstraintsx(): EditableList<WhereConstraint> {
     return $this->getConstraints();

--- a/codegen/syntax/WhereConstraint.php
+++ b/codegen/syntax/WhereConstraint.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<63617ef9d43f9124cd21ff8efb0bdc81>>
+ * @generated SignedSource<<5b330a55a89774ef8062323437174825>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class WhereConstraint extends EditableNode {
   }
 
   /**
-   * @returns GenericTypeSpecifier | SimpleTypeSpecifier | TypeConstant
+   * @return GenericTypeSpecifier | SimpleTypeSpecifier | TypeConstant
    */
   public function getLeftType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_type);
   }
 
   /**
-   * @returns GenericTypeSpecifier | SimpleTypeSpecifier | TypeConstant
+   * @return GenericTypeSpecifier | SimpleTypeSpecifier | TypeConstant
    */
   public function getLeftTypex(): EditableNode {
     return $this->getLeftType();
@@ -130,14 +130,14 @@ final class WhereConstraint extends EditableNode {
   }
 
   /**
-   * @returns EqualToken | AsToken | SuperToken
+   * @return EqualToken | AsToken | SuperToken
    */
   public function getOperator(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_operator);
   }
 
   /**
-   * @returns EqualToken | AsToken | SuperToken
+   * @return EqualToken | AsToken | SuperToken
    */
   public function getOperatorx(): EditableToken {
     return $this->getOperator();
@@ -159,16 +159,16 @@ final class WhereConstraint extends EditableNode {
   }
 
   /**
-   * @returns GenericTypeSpecifier | NullableTypeSpecifier |
-   * SimpleTypeSpecifier | TypeConstant | VectorTypeSpecifier
+   * @return GenericTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier
+   * | TypeConstant | VectorTypeSpecifier
    */
   public function getRightType(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_type);
   }
 
   /**
-   * @returns GenericTypeSpecifier | NullableTypeSpecifier |
-   * SimpleTypeSpecifier | TypeConstant | VectorTypeSpecifier
+   * @return GenericTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier
+   * | TypeConstant | VectorTypeSpecifier
    */
   public function getRightTypex(): EditableNode {
     return $this->getRightType();

--- a/codegen/syntax/WhileStatement.php
+++ b/codegen/syntax/WhileStatement.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<51b0bb21fbcb9ffe79e7f2390cf769ec>>
+ * @generated SignedSource<<6645c4dc9b119f248280bc0235340c8d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -135,14 +135,14 @@ final class WhileStatement
   }
 
   /**
-   * @returns WhileToken
+   * @return WhileToken
    */
   public function getKeyword(): WhileToken {
     return TypeAssert\instance_of(WhileToken::class, $this->_keyword);
   }
 
   /**
-   * @returns WhileToken
+   * @return WhileToken
    */
   public function getKeywordx(): WhileToken {
     return $this->getKeyword();
@@ -170,14 +170,14 @@ final class WhileStatement
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParen(): LeftParenToken {
     return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @returns LeftParenToken
+   * @return LeftParenToken
    */
   public function getLeftParenx(): LeftParenToken {
     return $this->getLeftParen();
@@ -205,8 +205,8 @@ final class WhileStatement
   }
 
   /**
-   * @returns BinaryExpression | FunctionCallExpression | InstanceofExpression
-   * | IssetExpression | LiteralExpression | MemberSelectionExpression |
+   * @return BinaryExpression | FunctionCallExpression | InstanceofExpression |
+   * IssetExpression | LiteralExpression | MemberSelectionExpression |
    * ParenthesizedExpression | PostfixUnaryExpression | PrefixUnaryExpression |
    * VariableExpression
    */
@@ -215,8 +215,8 @@ final class WhileStatement
   }
 
   /**
-   * @returns BinaryExpression | FunctionCallExpression | InstanceofExpression
-   * | IssetExpression | LiteralExpression | MemberSelectionExpression |
+   * @return BinaryExpression | FunctionCallExpression | InstanceofExpression |
+   * IssetExpression | LiteralExpression | MemberSelectionExpression |
    * ParenthesizedExpression | PostfixUnaryExpression | PrefixUnaryExpression |
    * VariableExpression
    */
@@ -246,14 +246,14 @@ final class WhileStatement
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParen(): RightParenToken {
     return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @returns RightParenToken
+   * @return RightParenToken
    */
   public function getRightParenx(): RightParenToken {
     return $this->getRightParen();
@@ -281,7 +281,7 @@ final class WhileStatement
   }
 
   /**
-   * @returns AlternateLoopStatement | CompoundStatement | ContinueStatement |
+   * @return AlternateLoopStatement | CompoundStatement | ContinueStatement |
    * EchoStatement | ExpressionStatement
    */
   public function getBody(): EditableNode {
@@ -289,7 +289,7 @@ final class WhileStatement
   }
 
   /**
-   * @returns AlternateLoopStatement | CompoundStatement | ContinueStatement |
+   * @return AlternateLoopStatement | CompoundStatement | ContinueStatement |
    * EchoStatement | ExpressionStatement
    */
   public function getBodyx(): EditableNode {

--- a/codegen/syntax/XHPCategoryDeclaration.php
+++ b/codegen/syntax/XHPCategoryDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<86645b02403c1c68e9c662d5b5c1637e>>
+ * @generated SignedSource<<f511c419930f77c6d7940931337d7814>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class XHPCategoryDeclaration extends EditableNode {
   }
 
   /**
-   * @returns CategoryToken
+   * @return CategoryToken
    */
   public function getKeyword(): CategoryToken {
     return TypeAssert\instance_of(CategoryToken::class, $this->_keyword);
   }
 
   /**
-   * @returns CategoryToken
+   * @return CategoryToken
    */
   public function getKeywordx(): CategoryToken {
     return $this->getKeyword();
@@ -130,14 +130,14 @@ final class XHPCategoryDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<XHPCategoryNameToken>
+   * @return EditableList<XHPCategoryNameToken>
    */
   public function getCategories(): EditableList<XHPCategoryNameToken> {
     return TypeAssert\instance_of(EditableList::class, $this->_categories);
   }
 
   /**
-   * @returns EditableList<XHPCategoryNameToken>
+   * @return EditableList<XHPCategoryNameToken>
    */
   public function getCategoriesx(): EditableList<XHPCategoryNameToken> {
     return $this->getCategories();
@@ -159,14 +159,14 @@ final class XHPCategoryDeclaration extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/XHPChildrenDeclaration.php
+++ b/codegen/syntax/XHPChildrenDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5e277fd59db12925c65364b45d2f5ea2>>
+ * @generated SignedSource<<f08c4289e3f127fa10615c5cfa5b14b7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class XHPChildrenDeclaration extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getKeyword(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_keyword);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getKeywordx(): EditableNode {
     return $this->getKeyword();
@@ -130,14 +130,14 @@ final class XHPChildrenDeclaration extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getExpressionx(): EditableNode {
     return $this->getExpression();
@@ -159,14 +159,14 @@ final class XHPChildrenDeclaration extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getSemicolon(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_semicolon);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getSemicolonx(): EditableNode {
     return $this->getSemicolon();

--- a/codegen/syntax/XHPChildrenParenthesizedList.php
+++ b/codegen/syntax/XHPChildrenParenthesizedList.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<45205ee6dbb85aa08d61a64d3de85dfc>>
+ * @generated SignedSource<<273ffcaf0a259ac05808f0f01a07f750>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class XHPChildrenParenthesizedList extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getLeftParen(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_left_paren);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getLeftParenx(): EditableNode {
     return $this->getLeftParen();
@@ -130,14 +130,14 @@ final class XHPChildrenParenthesizedList extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getXhpChildren(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_xhp_children);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getXhpChildrenx(): EditableNode {
     return $this->getXhpChildren();
@@ -159,14 +159,14 @@ final class XHPChildrenParenthesizedList extends EditableNode {
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getRightParen(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_right_paren);
   }
 
   /**
-   * @returns unknown
+   * @return unknown
    */
   public function getRightParenx(): EditableNode {
     return $this->getRightParen();

--- a/codegen/syntax/XHPClassAttribute.php
+++ b/codegen/syntax/XHPClassAttribute.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b98e2989c1ed07e53f3e08e0cbace69a>>
+ * @generated SignedSource<<fd033f8de6409e2ed7f6a5e807a1a164>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -115,7 +115,7 @@ final class XHPClassAttribute extends EditableNode {
   }
 
   /**
-   * @returns GenericTypeSpecifier | MapArrayTypeSpecifier |
+   * @return GenericTypeSpecifier | MapArrayTypeSpecifier |
    * NullableTypeSpecifier | SimpleTypeSpecifier | VectorArrayTypeSpecifier |
    * XHPEnumType
    */
@@ -124,7 +124,7 @@ final class XHPClassAttribute extends EditableNode {
   }
 
   /**
-   * @returns GenericTypeSpecifier | MapArrayTypeSpecifier |
+   * @return GenericTypeSpecifier | MapArrayTypeSpecifier |
    * NullableTypeSpecifier | SimpleTypeSpecifier | VectorArrayTypeSpecifier |
    * XHPEnumType
    */
@@ -149,14 +149,14 @@ final class XHPClassAttribute extends EditableNode {
   }
 
   /**
-   * @returns XHPElementNameToken
+   * @return XHPElementNameToken
    */
   public function getName(): XHPElementNameToken {
     return TypeAssert\instance_of(XHPElementNameToken::class, $this->_name);
   }
 
   /**
-   * @returns XHPElementNameToken
+   * @return XHPElementNameToken
    */
   public function getNamex(): XHPElementNameToken {
     return $this->getName();
@@ -178,7 +178,7 @@ final class XHPClassAttribute extends EditableNode {
   }
 
   /**
-   * @returns Missing | SimpleInitializer
+   * @return null | SimpleInitializer
    */
   public function getInitializer(): ?SimpleInitializer {
     if ($this->_initializer->isMissing()) {
@@ -189,7 +189,7 @@ final class XHPClassAttribute extends EditableNode {
   }
 
   /**
-   * @returns SimpleInitializer
+   * @return SimpleInitializer
    */
   public function getInitializerx(): SimpleInitializer {
     return
@@ -212,7 +212,7 @@ final class XHPClassAttribute extends EditableNode {
   }
 
   /**
-   * @returns Missing | XHPRequired
+   * @return null | XHPRequired
    */
   public function getRequired(): ?XHPRequired {
     if ($this->_required->isMissing()) {
@@ -222,7 +222,7 @@ final class XHPClassAttribute extends EditableNode {
   }
 
   /**
-   * @returns XHPRequired
+   * @return XHPRequired
    */
   public function getRequiredx(): XHPRequired {
     return TypeAssert\instance_of(XHPRequired::class, $this->_required);

--- a/codegen/syntax/XHPClassAttributeDeclaration.php
+++ b/codegen/syntax/XHPClassAttributeDeclaration.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d88a12c1fa96faa2031dc1e5cd890e80>>
+ * @generated SignedSource<<f1fdb0d4e9b3b659625b84e67a38e451>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class XHPClassAttributeDeclaration extends EditableNode {
   }
 
   /**
-   * @returns AttributeToken
+   * @return AttributeToken
    */
   public function getKeyword(): AttributeToken {
     return TypeAssert\instance_of(AttributeToken::class, $this->_keyword);
   }
 
   /**
-   * @returns AttributeToken
+   * @return AttributeToken
    */
   public function getKeywordx(): AttributeToken {
     return $this->getKeyword();
@@ -130,7 +130,7 @@ final class XHPClassAttributeDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<XHPClassAttribute> | EditableList<EditableNode> |
+   * @return EditableList<XHPClassAttribute> | EditableList<EditableNode> |
    * EditableList<XHPSimpleClassAttribute>
    */
   public function getAttributes(): EditableList<EditableNode> {
@@ -138,7 +138,7 @@ final class XHPClassAttributeDeclaration extends EditableNode {
   }
 
   /**
-   * @returns EditableList<XHPClassAttribute> | EditableList<EditableNode> |
+   * @return EditableList<XHPClassAttribute> | EditableList<EditableNode> |
    * EditableList<XHPSimpleClassAttribute>
    */
   public function getAttributesx(): EditableList<EditableNode> {
@@ -161,14 +161,14 @@ final class XHPClassAttributeDeclaration extends EditableNode {
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolon(): SemicolonToken {
     return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @returns SemicolonToken
+   * @return SemicolonToken
    */
   public function getSemicolonx(): SemicolonToken {
     return $this->getSemicolon();

--- a/codegen/syntax/XHPClose.php
+++ b/codegen/syntax/XHPClose.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0fc1b5764771ab8971c5c529c9066112>>
+ * @generated SignedSource<<0c82d41aa1d8d7ded8e5669bafe9575f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class XHPClose extends EditableNode {
   }
 
   /**
-   * @returns LessThanToken | LessThanSlashToken | EndOfFileToken
+   * @return LessThanToken | LessThanSlashToken | EndOfFileToken
    */
   public function getLeftAngle(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_left_angle);
   }
 
   /**
-   * @returns LessThanToken | LessThanSlashToken | EndOfFileToken
+   * @return LessThanToken | LessThanSlashToken | EndOfFileToken
    */
   public function getLeftAnglex(): EditableToken {
     return $this->getLeftAngle();
@@ -130,7 +130,7 @@ final class XHPClose extends EditableNode {
   }
 
   /**
-   * @returns Missing | XHPElementNameToken
+   * @return null | XHPElementNameToken
    */
   public function getName(): ?XHPElementNameToken {
     if ($this->_name->isMissing()) {
@@ -140,7 +140,7 @@ final class XHPClose extends EditableNode {
   }
 
   /**
-   * @returns XHPElementNameToken
+   * @return XHPElementNameToken
    */
   public function getNamex(): XHPElementNameToken {
     return TypeAssert\instance_of(XHPElementNameToken::class, $this->_name);
@@ -162,7 +162,7 @@ final class XHPClose extends EditableNode {
   }
 
   /**
-   * @returns Missing | GreaterThanToken
+   * @return null | GreaterThanToken
    */
   public function getRightAngle(): ?GreaterThanToken {
     if ($this->_right_angle->isMissing()) {
@@ -172,7 +172,7 @@ final class XHPClose extends EditableNode {
   }
 
   /**
-   * @returns GreaterThanToken
+   * @return GreaterThanToken
    */
   public function getRightAnglex(): GreaterThanToken {
     return TypeAssert\instance_of(GreaterThanToken::class, $this->_right_angle);

--- a/codegen/syntax/XHPEnumType.php
+++ b/codegen/syntax/XHPEnumType.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<63b1b67bd97ff9e9af6cb6751d821db6>>
+ * @generated SignedSource<<8f735c3b9856fa6c95abe9d4f9708260>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -133,7 +133,7 @@ final class XHPEnumType extends EditableNode {
   }
 
   /**
-   * @returns Missing
+   * @return null
    */
   public function getOptional(): ?EditableNode {
     if ($this->_optional->isMissing()) {
@@ -143,7 +143,7 @@ final class XHPEnumType extends EditableNode {
   }
 
   /**
-   * @returns
+   * @return
    */
   public function getOptionalx(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_optional);
@@ -171,14 +171,14 @@ final class XHPEnumType extends EditableNode {
   }
 
   /**
-   * @returns EnumToken
+   * @return EnumToken
    */
   public function getKeyword(): EnumToken {
     return TypeAssert\instance_of(EnumToken::class, $this->_keyword);
   }
 
   /**
-   * @returns EnumToken
+   * @return EnumToken
    */
   public function getKeywordx(): EnumToken {
     return $this->getKeyword();
@@ -206,14 +206,14 @@ final class XHPEnumType extends EditableNode {
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBracex(): LeftBraceToken {
     return $this->getLeftBrace();
@@ -241,14 +241,14 @@ final class XHPEnumType extends EditableNode {
   }
 
   /**
-   * @returns EditableList<LiteralExpression>
+   * @return EditableList<LiteralExpression>
    */
   public function getValues(): EditableList<LiteralExpression> {
     return TypeAssert\instance_of(EditableList::class, $this->_values);
   }
 
   /**
-   * @returns EditableList<LiteralExpression>
+   * @return EditableList<LiteralExpression>
    */
   public function getValuesx(): EditableList<LiteralExpression> {
     return $this->getValues();
@@ -276,14 +276,14 @@ final class XHPEnumType extends EditableNode {
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBrace(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBracex(): RightBraceToken {
     return $this->getRightBrace();

--- a/codegen/syntax/XHPExpression.php
+++ b/codegen/syntax/XHPExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e4bedfc5bea6f7a3f55fd95f901c40e1>>
+ * @generated SignedSource<<5029007fc66dc195883cb200b72807db>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class XHPExpression extends EditableNode {
   }
 
   /**
-   * @returns XHPOpen
+   * @return XHPOpen
    */
   public function getOpen(): XHPOpen {
     return TypeAssert\instance_of(XHPOpen::class, $this->_open);
   }
 
   /**
-   * @returns XHPOpen
+   * @return XHPOpen
    */
   public function getOpenx(): XHPOpen {
     return $this->getOpen();
@@ -130,7 +130,7 @@ final class XHPExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getBody(): ?EditableList<EditableNode> {
     if ($this->_body->isMissing()) {
@@ -140,7 +140,7 @@ final class XHPExpression extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getBodyx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_body);
@@ -162,7 +162,7 @@ final class XHPExpression extends EditableNode {
   }
 
   /**
-   * @returns Missing | XHPClose
+   * @return null | XHPClose
    */
   public function getClose(): ?XHPClose {
     if ($this->_close->isMissing()) {
@@ -172,7 +172,7 @@ final class XHPExpression extends EditableNode {
   }
 
   /**
-   * @returns XHPClose
+   * @return XHPClose
    */
   public function getClosex(): XHPClose {
     return TypeAssert\instance_of(XHPClose::class, $this->_close);

--- a/codegen/syntax/XHPOpen.php
+++ b/codegen/syntax/XHPOpen.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9e8b13a41d02b94eae0eab6a59a4996f>>
+ * @generated SignedSource<<55e9c005b2451c616f2ab7a22b0c181f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -115,14 +115,14 @@ final class XHPOpen extends EditableNode {
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAngle(): LessThanToken {
     return TypeAssert\instance_of(LessThanToken::class, $this->_left_angle);
   }
 
   /**
-   * @returns LessThanToken
+   * @return LessThanToken
    */
   public function getLeftAnglex(): LessThanToken {
     return $this->getLeftAngle();
@@ -149,14 +149,14 @@ final class XHPOpen extends EditableNode {
   }
 
   /**
-   * @returns XHPElementNameToken
+   * @return XHPElementNameToken
    */
   public function getName(): XHPElementNameToken {
     return TypeAssert\instance_of(XHPElementNameToken::class, $this->_name);
   }
 
   /**
-   * @returns XHPElementNameToken
+   * @return XHPElementNameToken
    */
   public function getNamex(): XHPElementNameToken {
     return $this->getName();
@@ -179,7 +179,7 @@ final class XHPOpen extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode> | Missing
+   * @return EditableList<EditableNode> | null
    */
   public function getAttributes(): ?EditableList<EditableNode> {
     if ($this->_attributes->isMissing()) {
@@ -189,7 +189,7 @@ final class XHPOpen extends EditableNode {
   }
 
   /**
-   * @returns EditableList<EditableNode>
+   * @return EditableList<EditableNode>
    */
   public function getAttributesx(): EditableList<EditableNode> {
     return TypeAssert\instance_of(EditableList::class, $this->_attributes);
@@ -212,7 +212,7 @@ final class XHPOpen extends EditableNode {
   }
 
   /**
-   * @returns Missing | SlashGreaterThanToken | GreaterThanToken
+   * @return null | SlashGreaterThanToken | GreaterThanToken
    */
   public function getRightAngle(): ?EditableToken {
     if ($this->_right_angle->isMissing()) {
@@ -222,7 +222,7 @@ final class XHPOpen extends EditableNode {
   }
 
   /**
-   * @returns SlashGreaterThanToken | GreaterThanToken
+   * @return SlashGreaterThanToken | GreaterThanToken
    */
   public function getRightAnglex(): EditableToken {
     return TypeAssert\instance_of(EditableToken::class, $this->_right_angle);

--- a/codegen/syntax/XHPRequired.php
+++ b/codegen/syntax/XHPRequired.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ad9bc060af97cef9f55ad959bef34ab8>>
+ * @generated SignedSource<<7de13b3e1e58f71e0375b56d59008061>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class XHPRequired extends EditableNode {
   }
 
   /**
-   * @returns AtToken
+   * @return AtToken
    */
   public function getAt(): AtToken {
     return TypeAssert\instance_of(AtToken::class, $this->_at);
   }
 
   /**
-   * @returns AtToken
+   * @return AtToken
    */
   public function getAtx(): AtToken {
     return $this->getAt();
@@ -111,14 +111,14 @@ final class XHPRequired extends EditableNode {
   }
 
   /**
-   * @returns RequiredToken
+   * @return RequiredToken
    */
   public function getKeyword(): RequiredToken {
     return TypeAssert\instance_of(RequiredToken::class, $this->_keyword);
   }
 
   /**
-   * @returns RequiredToken
+   * @return RequiredToken
    */
   public function getKeywordx(): RequiredToken {
     return $this->getKeyword();

--- a/codegen/syntax/XHPSimpleAttribute.php
+++ b/codegen/syntax/XHPSimpleAttribute.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<44bf35f6a4e060c8e778f6029be67c1a>>
+ * @generated SignedSource<<f2bf5048a1b6a54920f62b169889a36a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class XHPSimpleAttribute extends EditableNode {
   }
 
   /**
-   * @returns XHPElementNameToken
+   * @return XHPElementNameToken
    */
   public function getName(): XHPElementNameToken {
     return TypeAssert\instance_of(XHPElementNameToken::class, $this->_name);
   }
 
   /**
-   * @returns XHPElementNameToken
+   * @return XHPElementNameToken
    */
   public function getNamex(): XHPElementNameToken {
     return $this->getName();
@@ -130,14 +130,14 @@ final class XHPSimpleAttribute extends EditableNode {
   }
 
   /**
-   * @returns EqualToken
+   * @return EqualToken
    */
   public function getEqual(): EqualToken {
     return TypeAssert\instance_of(EqualToken::class, $this->_equal);
   }
 
   /**
-   * @returns EqualToken
+   * @return EqualToken
    */
   public function getEqualx(): EqualToken {
     return $this->getEqual();
@@ -159,14 +159,14 @@ final class XHPSimpleAttribute extends EditableNode {
   }
 
   /**
-   * @returns BracedExpression | XHPStringLiteralToken
+   * @return BracedExpression | XHPStringLiteralToken
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
   /**
-   * @returns BracedExpression | XHPStringLiteralToken
+   * @return BracedExpression | XHPStringLiteralToken
    */
   public function getExpressionx(): EditableNode {
     return $this->getExpression();

--- a/codegen/syntax/XHPSimpleClassAttribute.php
+++ b/codegen/syntax/XHPSimpleClassAttribute.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4b017b0d98ac3e88116d3f133dcf6940>>
+ * @generated SignedSource<<2e9c7ea3792ff3bcc7d8955a6d35c51f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -71,14 +71,14 @@ final class XHPSimpleClassAttribute extends EditableNode {
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getType(): SimpleTypeSpecifier {
     return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_type);
   }
 
   /**
-   * @returns SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier
    */
   public function getTypex(): SimpleTypeSpecifier {
     return $this->getType();

--- a/codegen/syntax/XHPSpreadAttribute.php
+++ b/codegen/syntax/XHPSpreadAttribute.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<32a406ddb605e6d4e369f6ff14f90774>>
+ * @generated SignedSource<<08b588245b3ec90bb0c2d7b60b132a18>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -119,14 +119,14 @@ final class XHPSpreadAttribute extends EditableNode {
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBrace(): LeftBraceToken {
     return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
   /**
-   * @returns LeftBraceToken
+   * @return LeftBraceToken
    */
   public function getLeftBracex(): LeftBraceToken {
     return $this->getLeftBrace();
@@ -153,7 +153,7 @@ final class XHPSpreadAttribute extends EditableNode {
   }
 
   /**
-   * @returns DotDotDotToken
+   * @return DotDotDotToken
    */
   public function getSpreadOperator(): DotDotDotToken {
     return
@@ -161,7 +161,7 @@ final class XHPSpreadAttribute extends EditableNode {
   }
 
   /**
-   * @returns DotDotDotToken
+   * @return DotDotDotToken
    */
   public function getSpreadOperatorx(): DotDotDotToken {
     return $this->getSpreadOperator();
@@ -188,14 +188,14 @@ final class XHPSpreadAttribute extends EditableNode {
   }
 
   /**
-   * @returns VariableExpression | XHPExpression
+   * @return VariableExpression | XHPExpression
    */
   public function getExpression(): EditableNode {
     return TypeAssert\instance_of(EditableNode::class, $this->_expression);
   }
 
   /**
-   * @returns VariableExpression | XHPExpression
+   * @return VariableExpression | XHPExpression
    */
   public function getExpressionx(): EditableNode {
     return $this->getExpression();
@@ -222,14 +222,14 @@ final class XHPSpreadAttribute extends EditableNode {
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBrace(): RightBraceToken {
     return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
   }
 
   /**
-   * @returns RightBraceToken
+   * @return RightBraceToken
    */
   public function getRightBracex(): RightBraceToken {
     return $this->getRightBrace();

--- a/codegen/syntax/YieldExpression.php
+++ b/codegen/syntax/YieldExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a26e1b549982cd290973e44d82f5e752>>
+ * @generated SignedSource<<f2a0865818f7fe893a1ad777c66e9c51>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,14 +82,14 @@ final class YieldExpression extends EditableNode {
   }
 
   /**
-   * @returns YieldToken
+   * @return YieldToken
    */
   public function getKeyword(): YieldToken {
     return TypeAssert\instance_of(YieldToken::class, $this->_keyword);
   }
 
   /**
-   * @returns YieldToken
+   * @return YieldToken
    */
   public function getKeywordx(): YieldToken {
     return $this->getKeyword();
@@ -111,9 +111,9 @@ final class YieldExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | BinaryExpression | ElementInitializer |
+   * @return AnonymousFunction | BinaryExpression | ElementInitializer |
    * FunctionCallExpression | LambdaExpression | LiteralExpression |
-   * MemberSelectionExpression | Missing | ObjectCreationExpression |
+   * MemberSelectionExpression | null | ObjectCreationExpression |
    * ParenthesizedExpression | PostfixUnaryExpression | PrefixUnaryExpression |
    * SubscriptExpression | BreakToken | NameToken | TupleExpression |
    * VariableExpression
@@ -126,7 +126,7 @@ final class YieldExpression extends EditableNode {
   }
 
   /**
-   * @returns AnonymousFunction | BinaryExpression | ElementInitializer |
+   * @return AnonymousFunction | BinaryExpression | ElementInitializer |
    * FunctionCallExpression | LambdaExpression | LiteralExpression |
    * MemberSelectionExpression | ObjectCreationExpression |
    * ParenthesizedExpression | PostfixUnaryExpression | PrefixUnaryExpression |

--- a/codegen/syntax/YieldFromExpression.php
+++ b/codegen/syntax/YieldFromExpression.php
@@ -2,7 +2,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<00647d20bf77b9010554b131680a31a1>>
+ * @generated SignedSource<<602a1310ce34aad6cabbce2a6b490384>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,14 +101,14 @@ final class YieldFromExpression extends EditableNode {
   }
 
   /**
-   * @returns YieldToken
+   * @return YieldToken
    */
   public function getYieldKeyword(): YieldToken {
     return TypeAssert\instance_of(YieldToken::class, $this->_yield_keyword);
   }
 
   /**
-   * @returns YieldToken
+   * @return YieldToken
    */
   public function getYieldKeywordx(): YieldToken {
     return $this->getYieldKeyword();
@@ -130,14 +130,14 @@ final class YieldFromExpression extends EditableNode {
   }
 
   /**
-   * @returns FromToken
+   * @return FromToken
    */
   public function getFromKeyword(): FromToken {
     return TypeAssert\instance_of(FromToken::class, $this->_from_keyword);
   }
 
   /**
-   * @returns FromToken
+   * @return FromToken
    */
   public function getFromKeywordx(): FromToken {
     return $this->getFromKeyword();
@@ -159,7 +159,7 @@ final class YieldFromExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayCreationExpression | FunctionCallExpression |
+   * @return ArrayCreationExpression | FunctionCallExpression |
    * LiteralExpression | ParenthesizedExpression | VariableExpression
    */
   public function getOperand(): EditableNode {
@@ -167,7 +167,7 @@ final class YieldFromExpression extends EditableNode {
   }
 
   /**
-   * @returns ArrayCreationExpression | FunctionCallExpression |
+   * @return ArrayCreationExpression | FunctionCallExpression |
    * LiteralExpression | ParenthesizedExpression | VariableExpression
    */
   public function getOperandx(): EditableNode {

--- a/src/__Private/codegen/CodegenSyntax.php
+++ b/src/__Private/codegen/CodegenSyntax.php
@@ -180,7 +180,7 @@ final class CodegenSyntax extends CodegenBase {
     if (!$spec['nullable']) {
       yield $cg
         ->codegenMethodf('get%s', $upper_camel)
-        ->setDocBlock('@returns '.Str\join($types, ' | '))
+        ->setDocBlock('@return '.Str\join($types, ' | '))
         ->setReturnType($type)
         ->setBodyf(
           'return TypeAssert\instance_of(%s::class, $this->_%s);',
@@ -191,7 +191,7 @@ final class CodegenSyntax extends CodegenBase {
       // nullable in a previous version
       yield $cg
         ->codegenMethodf('get%sx', $upper_camel)
-        ->setDocBlock('@returns '.Str\join($types, ' | '))
+        ->setDocBlock('@return '.Str\join($types, ' | '))
         ->setReturnType($type)
         ->setBodyf('return $this->get%s();', $upper_camel);
      return;
@@ -199,7 +199,9 @@ final class CodegenSyntax extends CodegenBase {
 
     yield $cg
       ->codegenMethodf('get%s', $upper_camel)
-      ->setDocBlock('@returns '.Str\join($types, ' | '))
+      ->setDocBlock(Vec\map($types, $type ==> $type === 'Missing' ? 'null' : $type)
+        |> Str\join($$, ' | ')
+        |> '@return '.$$)
       ->setReturnType($type)
       ->setBody(
         $cg
@@ -219,7 +221,7 @@ final class CodegenSyntax extends CodegenBase {
       ->codegenMethodf('get%sx', $upper_camel)
       ->setDocBlock(Vec\filter($types, $type ==> $type !== 'Missing')
         |> Str\join($$, ' | ')
-        |> '@returns '.$$)
+        |> '@return '.$$)
       ->setReturnType($spec['class'])
       ->setBodyf(
         'return TypeAssert\instance_of(%s::class, $this->_%s);',


### PR DESCRIPTION
The current codegen generates `@returns` docblocks. I know you're not following PSR-*, but I also don't see reference to `@returns` vs `@return` in other documentation, so I assume it's a typo.

This also replaces `Missing` with `null` in the docblock where the method has an explicit `isMissing` check.