### PR TITLE
Fix autoloading issue 

### DIFF
--- a/bin/hhast-migrate
+++ b/bin/hhast-migrate
@@ -11,6 +11,34 @@
 
 namespace Facebook\HHAST\__Private;
 
-require_once(__DIR__.'/../vendor/hh_autoload.php');
+<<__EntryPoint>>
+async function hhast_migrate_main_async(): Awaitable<noreturn> {
+    $root = realpath(__DIR__.'/..');
+    $found_autoloader = false;
 
-MigrationCLI::main();
+    while (true) {
+        $autoloader = $root.'/vendor/hh_autoload.php';
+
+        if (file_exists($autoloader)) {
+            $found_autoloader = true;
+            require_once($autoloader);
+            break;
+        }
+
+        if ($root === '') {
+          break;
+        }
+
+        $parts = explode('/', $root);
+        array_pop(&$parts);
+        $root = implode('/', $parts);
+      }
+
+      if (!$found_autoloader) {
+        fprintf(STDERR, "Failed to find autoloader.\n");
+        exit(1);
+    }
+
+    $result = await MigrationCLI::runAsync();
+    exit($result);
+}

--- a/bin/hhast-migrate
+++ b/bin/hhast-migrate
@@ -1,5 +1,5 @@
 #!/usr/bin/env hhvm
-<?hh
+<?hh strict
 /*
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.

--- a/bin/hhast-migrate
+++ b/bin/hhast-migrate
@@ -1,5 +1,5 @@
 #!/usr/bin/env hhvm
-<?hh strict
+<?hh // strict
 /*
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.


### PR DESCRIPTION
- Fix issue while trying to run hhast-migration from composer binary folder.
```
➜  waffle git:(master) ✗ ./vendor/bin/hhast-migrate 

Fatal error: Uncaught Error: require_once(/home/saif/projects/waffle/vendor/hhvm/hhast/bin/../vendor/hh_autoload.php): File not found in /home/saif/projects/waffle/vendor/hhvm/hhast/bin/hhast-migrate:14
Stack trace:
#0 {main}
➜  waffle git:(master) ✗ 

```

- use `runAsync` instead of the deprecated method `main` 

see : https://github.com/hhvm/hh-clilib/blob/master/src/CLIBase.hh#L148