### PR TITLE
fix integer division and missing quote in SchemaVersionError

### DIFF
--- a/src/SchemaVersionError.php
+++ b/src/SchemaVersionError.php
@@ -20,8 +20,8 @@ final class SchemaVersionError extends ParseError {
       Str\format(
         "AST version mismatch: expected '%s' (%d.%d.%d), but got '%s'",
         SCHEMA_VERSION,
-        intdiv(HHVM_VERSION_ID, 10000) as int,
-        intdiv(HHVM_VERSION_ID, 100) as int % 100,
+        \intdiv(HHVM_VERSION_ID, 10000),
+        \intdiv(HHVM_VERSION_ID, 100) % 100,
         HHVM_VERSION_ID % 100,
         $version,
       ),

--- a/src/SchemaVersionError.php
+++ b/src/SchemaVersionError.php
@@ -18,10 +18,10 @@ final class SchemaVersionError extends ParseError {
       $targetFile,
       null,
       Str\format(
-        "AST version mismatch: expected '%s' (%d.%d.%d), but got '%s",
+        "AST version mismatch: expected '%s' (%d.%d.%d), but got '%s'",
         SCHEMA_VERSION,
-        (HHVM_VERSION_ID / 10000) as int,
-        (HHVM_VERSION_ID / 100) as int % 100,
+        intdiv(HHVM_VERSION_ID, 10000) as int,
+        intdiv(HHVM_VERSION_ID, 100) as int % 100,
         HHVM_VERSION_ID % 100,
         $version,
       ),


### PR DESCRIPTION
Schema version errors currently throw a pretty cryptic exception due to `as int` being used on a float. This fixes to use intdiv, and also fixes a missing quote in the exception string.

## Before
```
  Exception: TypeAssertionException
  Message: Expected int, got float
  Trace:
    #0 /Users/ssandler/Documents/dev/webapp/vendor/splinter/vendor/hhvm/hhast/src/entrypoints.php(21): Facebook\HHAST\SchemaVersionError->__construct()
    #1 /Users/ssandler/Documents/dev/webapp/vendor/splinter/vendor/hhvm/hhast/src/entrypoints.php(124): Facebook\HHAST\from_json()
```

## After
```
  Exception: Facebook\HHAST\SchemaVersionError
  Message: In file "! no file !": AST version mismatch: expected '2018-07-19-0001' (3.29.0), but got '2018-10-30-0001'
  Trace:
    #0 /Users/ssandler/Documents/dev/webapp/vendor/splinter/vendor/hhvm/hhast/src/entrypoints.php(124): Facebook\HHAST\from_json()
```