### PR TITLE
Limit descendants to namespace name

### DIFF
--- a/src/nodes/NamespaceDeclaration.hack
+++ b/src/nodes/NamespaceDeclaration.hack
@@ -18,7 +18,11 @@ final class NamespaceDeclaration extends NamespaceDeclarationGeneratedBase {
       return $name->getText();
     }
 
-    return $this->getDescendantsOfType(NameToken::class)
+    if ($name === null) {
+      return '';
+    }
+
+    return $name->getDescendantsOfType(NameToken::class)
       |> Vec\map($$, $t ==> $t->getText())
       |> Str\join($$, "\\");
   }

--- a/tests/ResolutionTest.hack
+++ b/tests/ResolutionTest.hack
@@ -25,9 +25,9 @@ final class ResolutionTest extends TestCase {
     $code = '<?hh namespace MyNS\\SubNS { class Foo {}; class Bar {} }';
     $ast = from_code($code);
     $namespaces = $ast->getDescendantsOfType(NamespaceDeclaration::class);
-    $class_names = $ast->getDescendantsOfType(NamespaceDeclaration::class)
+    $namespace_names = $ast->getDescendantsOfType(NamespaceDeclaration::class)
       |> Vec\map($$, $namespace ==> $namespace->getQualifiedNameAsString());
-    expect($class_names)->toBeSame(vec[
+    expect($namespace_names)->toBeSame(vec[
       "MyNS\\SubNS",
     ]);
   }

--- a/tests/ResolutionTest.hack
+++ b/tests/ResolutionTest.hack
@@ -13,11 +13,23 @@ namespace Facebook\HHAST;
 use function Facebook\FBExpect\expect;
 use namespace Facebook\HHAST\__Private\Resolution;
 use type Facebook\HackTest\DataProvider;
+use namespace HH\Lib\Vec;
 
 final class ResolutionTest extends TestCase {
   public function testWithoutNamespaces(): void {
     list($node, $parents) = self::getNodeAndParents('<?hh class Foo {}');
     expect(Resolution\get_current_namespace($node, $parents))->toBeNull();
+  }
+
+  public function testMultipleClassesInNamespaceBlock(): void {
+    $code = '<?hh namespace MyNS\\SubNS { class Foo {}; class Bar {} }';
+    $ast = from_code($code);
+    $namespaces = $ast->getDescendantsOfType(NamespaceDeclaration::class);
+    $class_names = $ast->getDescendantsOfType(NamespaceDeclaration::class)
+      |> Vec\map($$, $namespace ==> $namespace->getQualifiedNameAsString());
+    expect($class_names)->toBeSame(vec[
+      "MyNS\\SubNS",
+    ]);
   }
 
   public function testWithNamespaceStatement(): void {


### PR DESCRIPTION
This prevents an error with

```php
namespace Name\Space {
    class A {
    }
    class B {
    }
}
```

where the given namespace is `Name\Space\A\B`

Happy to make a test if you want.