### PR TITLE
Lambda and lval

### DIFF
--- a/src/Migrations/AssertToExpectMigration.hack
+++ b/src/Migrations/AssertToExpectMigration.hack
@@ -237,25 +237,37 @@ final class AssertToExpectMigration extends StepBasedMigration {
   <<__Override>>
   public function getSteps(): Traversable<IMigrationStep> {
     $this->useExpectFunctionNeeded = false;
-    $make_step_add = ($name, $impl) ==> new TypedMigrationStep(
+    $make_step_add = (
+      string $name,
+      (function(NamespaceUseDeclaration): NamespaceUseDeclaration) $impl,
+    ) ==> new TypedMigrationStep(
       $name,
       NamespaceUseDeclaration::class,
       NamespaceUseDeclaration::class,
       $impl,
     );
-    $make_step_add_namespace = ($name, $impl) ==> new TypedMigrationStep(
+    $make_step_add_namespace = (
+      string $name,
+      (function(NamespaceDeclaration): NamespaceDeclaration) $impl,
+    ) ==> new TypedMigrationStep(
       $name,
       NamespaceDeclaration::class,
       NamespaceDeclaration::class,
       $impl,
     );
-    $make_step_add_comment = ($name, $impl) ==> new TypedMigrationStep(
+    $make_step_add_comment = (
+      string $name,
+      (function(DelimitedComment): EditableNode) $impl,
+    ) ==> new TypedMigrationStep(
       $name,
       DelimitedComment::class,
       EditableNode::class,
       $impl,
     );
-    $make_step_expect = ($name, $impl) ==> new TypedMigrationStep(
+    $make_step_expect = (
+      string $name,
+      (function(FunctionCallExpression): FunctionCallExpression) $impl,
+    ) ==> new TypedMigrationStep(
       $name,
       FunctionCallExpression::class,
       FunctionCallExpression::class,

--- a/src/Migrations/ImplicitShapeSubtypesMigration.hack
+++ b/src/Migrations/ImplicitShapeSubtypesMigration.hack
@@ -88,7 +88,10 @@ final class ImplicitShapeSubtypesMigration extends StepBasedMigration {
   <<__Override>>
   final public function getSteps(
   ): Traversable<IMigrationStep> {
-    $make_step = ($name, $impl) ==> new TypedMigrationStep(
+    $make_step = (
+      string $name,
+      (function(HHAST\ShapeTypeSpecifier): HHAST\ShapeTypeSpecifier) $impl,
+    ) ==> new TypedMigrationStep(
       $name,
       HHAST\ShapeTypeSpecifier::class,
       HHAST\ShapeTypeSpecifier::class,

--- a/src/__Private/Asio/AsyncConditionNode.hack
+++ b/src/__Private/Asio/AsyncConditionNode.hack
@@ -17,7 +17,8 @@ final class AsyncConditionNode<T> extends AsyncCondition<T> {
 
   public function addNext(): AsyncConditionNode<T> {
     invariant($this->next === null, 'The next node already exists');
-    return $this->next = new AsyncConditionNode();
+    $this->next = new AsyncConditionNode();
+    return $this->next;
   }
   public function getNext(): ?AsyncConditionNode<T> {
     return $this->next;

--- a/src/__Private/LSPImpl/ExecuteCommandCommand.hack
+++ b/src/__Private/LSPImpl/ExecuteCommandCommand.hack
@@ -52,6 +52,8 @@ final class ExecuteCommandCommand extends LSPLib\ExecuteCommandCommand {
   private static int $idCounter = 0;
 
   private static function generateID(): string {
-    return __CLASS__.'!'.self::$idCounter++;
+    $id = __CLASS__.'!'.self::$idCounter;
+    self::$idCounter++;
+    return $id;
   }
 }

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -188,7 +188,7 @@ final class LintRunConfig {
         $no_autofixes || ($override['disableAllAutoFixes'] ?? false);
     }
 
-    $normalize = $list ==> Keyset\map(
+    $normalize = (vec<string> $list) ==> Keyset\map(
       $list,
       $linter ==> $this->getFullyQualifiedLinterName($linter),
     );
@@ -205,7 +205,7 @@ final class LintRunConfig {
       $autofix_blacklist = $linters;
     }
 
-    $assert_types = $list ==> Keyset\map(
+    $assert_types = (keyset<string> $list) ==> Keyset\map(
       $list,
       $str ==> TypeAssert\classname_of(BaseLinter::class, $str),
     );

--- a/src/__Private/XHProf.hack
+++ b/src/__Private/XHProf.hack
@@ -103,7 +103,7 @@ final abstract class XHProf {
       if ($data['inclusive'] < $cull) {
         continue;
       }
-      $this_id = $node_count++;
+      $this_id = $node_count;
       $node_ids[$name] = $this_id;
       $out .= Str\format(
         "node_%d [ label=\"%s\nInclusive: %.5fs\nExclusive: %.5fs\" penwidth=%.1f %s]\n",
@@ -118,6 +118,7 @@ final abstract class XHProf {
       foreach ($callees as $callee => $wall) {
         $edges[] = tuple($this_id, $callee, $wall / $scale);
       }
+      $node_count++;
     }
     $max = Vec\map($edges, $edge ==> $edge[2]) |> Math\max($$) as nonnull;
     $cull = $cull_rate * $max;

--- a/src/__Private/codegen/CodegenSyntax.hack
+++ b/src/__Private/codegen/CodegenSyntax.hack
@@ -392,7 +392,7 @@ final class CodegenSyntax extends CodegenBase {
               $field ==> Str\format('$%s === $this->_%s &&', $field, $field),
             )
               |> (
-                $lines ==> {
+                (vec<string> $lines) ==> {
                   $idx = C\last_keyx($lines);
                   $lines[$idx] = Str\strip_suffix($lines[$idx], ' &&');
                   return $lines;
@@ -449,7 +449,7 @@ final class CodegenSyntax extends CodegenBase {
               $field ==> Str\format('$%s === $this->_%s &&', $field, $field),
             )
               |> (
-                $lines ==> {
+                (vec<string> $lines) ==> {
                   $idx = C\last_keyx($lines);
                   $lines[$idx] = Str\strip_suffix($lines[$idx], ' &&');
                   return $lines;

--- a/src/__Private/codegen/CodegenTokens.hack
+++ b/src/__Private/codegen/CodegenTokens.hack
@@ -290,7 +290,7 @@ final class CodegenTokens extends CodegenBase {
               ),
             )
             |> (
-              $lines ==> {
+              (vec<string> $lines) ==> {
                 $idx = C\last_keyx($lines);
                 $lines[$idx] = Str\strip_suffix($lines[$idx], ' &&');
                 return $lines;

--- a/src/nodes/EditableNode.hack
+++ b/src/nodes/EditableNode.hack
@@ -57,7 +57,9 @@ abstract class EditableNode {
 
   <<__Memoize>>
   private function getUniqueID(): int {
-    return self::$_maxID++;
+    $id = self::$_maxID;
+    self::$_maxID++;
+    return $id;
   }
 
   public function isAncestorOf(EditableNode $other): bool {

--- a/tests/FixtureRewritingTest.hack
+++ b/tests/FixtureRewritingTest.hack
@@ -39,7 +39,10 @@ final class FixtureRewritingTest extends TestCase {
   }
 
   public function testRewriteComments(): void {
-    $rewriter = (HHAST\EditableNode $node, $_parents) ==> {
+    $rewriter = (
+      HHAST\EditableNode $node,
+      ?vec<HHAST\EditableNode> $_parents,
+    ) ==> {
       if ($node instanceof HHAST\SingleLineComment) {
         return $node->withText('// blah blah blah');
       }

--- a/tests/MigrationsTest.hack
+++ b/tests/MigrationsTest.hack
@@ -147,7 +147,8 @@ final class MigrationsTest extends TestCase {
     Migrations\IMigrationStep $step,
     string $fixture,
   ): void {
-    $rewrite = $ast ==> $ast->rewrite(($n, $_) ==> $step->rewrite($n));
+    $rewrite = (HHAST\EditableNode $ast) ==>
+      $ast->rewrite(($n, $_) ==> $step->rewrite($n));
 
     $ast = HHAST\from_file(__DIR__.'/fixtures/'.$fixture.'.in')
       |> $rewrite($$);


### PR DESCRIPTION
Summary: required for .hhconfig disable_lval_as_an_expression and disallow_ambiguous_lambda.