### PR TITLE
Implement NoElseifLinter

### DIFF
--- a/src/Linters/NoElseifLinter.hack
+++ b/src/Linters/NoElseifLinter.hack
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\Linters;
+
+use type Facebook\HHAST\{
+  ElseifToken,
+  ElseToken,
+  IfToken,
+  EditableList,
+  EditableNode,
+  WhiteSpace,
+};
+use function Facebook\HHAST\Missing;
+
+final class NoElseifLinter
+  extends AutoFixingASTLinter<ElseifToken> {
+  <<__Override>>
+  protected static function getTargetType(): classname<ElseifToken> {
+    return ElseifToken::class;
+  }
+
+  <<__Override>>
+  public function getLintErrorForNode(
+    ElseifToken $expr,
+    vec<EditableNode> $_parents,
+  ): ?ASTLintError<ElseifToken> {
+    return new ASTLintError(
+      $this,
+      'Do not use "elseif", use "else if" instead.',
+      $expr,
+    );
+  }
+
+  <<__Override>>
+  public function getFixedNode(ElseifToken $expr): EditableNode {
+    return new EditableList(vec[
+      new ElseToken($expr->getLeading(), new WhiteSpace(' ')),
+      new IfToken(Missing(), $expr->getTrailing()),
+    ]);
+  }
+}

--- a/src/__Private/LintRunCLIEventHandler.hack
+++ b/src/__Private/LintRunCLIEventHandler.hack
@@ -178,7 +178,7 @@ final class LintRunCLIEventHandler implements LintRunEventHandler {
         ->getStdout()
         ->writeAsync(
           "\e[94mWould you like to apply this fix?\e[0m\n".
-          "  \e[37m[y]es/[N]o/yes to [a]ll/n[o] to all:\e[0m ",
+          "  \e[37m[y]es/[n]o/yes to [a]ll/n[o] to all:\e[0m ",
         );
       $response = await $this->terminal->getStdin()->readLineAsync();
       $response = Str\trim($response);

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -69,6 +69,7 @@ final class LintRunConfig {
     Linters\MethodCallOnConstructorLinter::class,
     Linters\MustUseBracesForControlFlowLinter::class,
     Linters\MustUseOverrideAttributeLinter::class,
+    Linters\NoElseifLinter::class,
     Linters\NoPHPEqualityLinter::class,
     Linters\UnusedParameterLinter::class,
     Linters\UnusedUseClauseLinter::class,

--- a/tests/NoElseifLinterTest.hack
+++ b/tests/NoElseifLinterTest.hack
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class NoElseifLinterTest extends TestCase {
+  use AutoFixingLinterTestTrait<Linters\ASTLintError<ElseifToken>>;
+
+  protected function getLinter(
+    string $file,
+  ): Linters\NoElseifLinter{
+    return Linters\NoElseifLinter::fromPath($file);
+  }
+
+  public function getCleanExamples(): array<array<string>> {
+    return [
+      ['<?hh if (true) {} else if (false) {}'],
+    ];
+  }
+}

--- a/tests/fixtures/NoElseifLinter/elseif.php.autofix.expect
+++ b/tests/fixtures/NoElseifLinter/elseif.php.autofix.expect
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+function foo(): void {
+  if (true) {
+  } else if (false) {
+  } else if (false) {
+  }
+}

--- a/tests/fixtures/NoElseifLinter/elseif.php.expect
+++ b/tests/fixtures/NoElseifLinter/elseif.php.expect
@@ -1,0 +1,7 @@
+[
+    {
+        "blame": "elseif ",
+        "blame_pretty": "elseif ",
+        "description": "Do not use \"elseif\", use \"else if\" instead."
+    }
+]

--- a/tests/fixtures/NoElseifLinter/elseif.php.in
+++ b/tests/fixtures/NoElseifLinter/elseif.php.in
@@ -1,0 +1,16 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+function foo(): void {
+  if (true) {
+  } elseif (false) {
+  } else if (false) {
+  }
+}

--- a/tests/fixtures/NoElseifLinter/elseif_leading_trailing.php.autofix.expect
+++ b/tests/fixtures/NoElseifLinter/elseif_leading_trailing.php.autofix.expect
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+function foo(): void {
+  if (true) {
+  }  else if (false) {
+  } else if  (false) {
+  } /* foo */ else if /* bar */ (false) {
+  }
+}

--- a/tests/fixtures/NoElseifLinter/elseif_leading_trailing.php.expect
+++ b/tests/fixtures/NoElseifLinter/elseif_leading_trailing.php.expect
@@ -1,0 +1,17 @@
+[
+    {
+        "blame": "elseif ",
+        "blame_pretty": "elseif ",
+        "description": "Do not use \"elseif\", use \"else if\" instead."
+    },
+    {
+        "blame": "elseif  ",
+        "blame_pretty": "elseif  ",
+        "description": "Do not use \"elseif\", use \"else if\" instead."
+    },
+    {
+        "blame": "elseif \/* bar *\/ ",
+        "blame_pretty": "elseif \/* bar *\/ ",
+        "description": "Do not use \"elseif\", use \"else if\" instead."
+    }
+]

--- a/tests/fixtures/NoElseifLinter/elseif_leading_trailing.php.in
+++ b/tests/fixtures/NoElseifLinter/elseif_leading_trailing.php.in
@@ -1,0 +1,17 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+function foo(): void {
+  if (true) {
+  }  elseif (false) {
+  } elseif  (false) {
+  } /* foo */ elseif /* bar */ (false) {
+  }
+}


### PR DESCRIPTION
Summary: linter for `elseif` => `else if`.

Fixes #114
