### PR TITLE
Implement NoPHPArrayLiteralsLinter

### DIFF
--- a/src/Linters/NoPHPArrayLiteralsLinter.hack
+++ b/src/Linters/NoPHPArrayLiteralsLinter.hack
@@ -1,0 +1,159 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\Linters;
+
+use type Facebook\HHAST\{
+  ArrayCreationExpression,
+  ArrayIntrinsicExpression,
+  ArrayToken,
+  DictToken,
+  EditableList,
+  EditableNode,
+  ElementInitializer,
+  LeftBracketToken,
+  LeftParenToken,
+  ListItem,
+  RightBracketToken,
+  RightParenToken,
+  VecToken,
+};
+use namespace HH\Lib\{C, Vec};
+use function Facebook\HHAST\Missing;
+
+final class NoPHPArrayLiteralsLinter extends AutoFixingASTLinter<EditableNode> {
+  <<__Override>>
+  protected static function getTargetType(): classname<EditableNode> {
+    return EditableNode::class;
+  }
+
+  <<__Override>>
+  public function getLintErrorForNode(
+    EditableNode $expr,
+    vec<EditableNode> $_parents,
+  ): ?ASTLintError<EditableNode> {
+    if ($expr is ArrayCreationExpression || $expr is ArrayIntrinsicExpression) {
+      return new ASTLintError(
+        $this,
+        'Do not use PHP array literals, use Hack arrays instead.',
+        $expr,
+      );
+    }
+
+    return null;
+  }
+
+  <<__Override>>
+  public function getFixedNode(EditableNode $expr): EditableNode {
+    /**
+     * Cannot use getDescendantsOfType(ElementInitializer::class) because an
+     * associative array inside a list array would return a false positive.
+     */
+    $is_assoc = false;
+    foreach ($expr->getChildren() as $child) {
+      if ($child is EditableList<_>) {
+        foreach ($child->getChildren() as $item) {
+          if ($item is ListItem) {
+            foreach ($item->getChildren() as $initializer) {
+              if ($initializer is ElementInitializer) {
+                $is_assoc = true;
+                break;
+              }
+            }
+          }
+
+          if ($is_assoc) {
+            break;
+          }
+        }
+      }
+
+      if ($is_assoc) {
+        break;
+      }
+    }
+
+    $children = vec($expr->getChildren());
+
+    if (
+      $expr is ArrayCreationExpression &&
+      C\count($children) === 3 &&
+      $children[0] is LeftBracketToken &&
+      $children[1] is EditableList<_> &&
+      $children[2] is RightBracketToken
+    ) {
+      $left = $children[0] as LeftBracketToken;
+      $list = $children[1] as EditableList<_>;
+      $right = $children[2] as RightBracketToken;
+
+      if ($is_assoc) {
+        return new DictToken(
+          $left->getLeading(),
+          new EditableList(Vec\concat(
+            vec[new LeftBracketToken(Missing(), $left->getTrailing())],
+            $list->getChildren(),
+            vec[new RightBracketToken(
+              $right->getLeading(),
+              $right->getTrailing(),
+            )],
+          )),
+        );
+      } else {
+        return new VecToken(
+          $left->getLeading(),
+          new EditableList(Vec\concat(
+            vec[new LeftBracketToken(Missing(), $left->getTrailing())],
+            $list->getChildren(),
+            vec[new RightBracketToken(
+              $right->getLeading(),
+              $right->getTrailing(),
+            )],
+          )),
+        );
+      }
+    }
+
+    if (
+      $expr is ArrayIntrinsicExpression &&
+      C\count($children) === 4 &&
+      $children[0] is ArrayToken &&
+      $children[1] is LeftParenToken &&
+      $children[2] is EditableList<_> &&
+      $children[3] is RightParenToken
+    ) {
+      return $expr->rewriteChildren(
+        ($node, $_parents) ==> {
+          if ($node is ArrayToken) {
+            if ($is_assoc) {
+              return new DictToken($node->getLeading(), $node->getTrailing());
+            } else {
+              return new VecToken($node->getLeading(), $node->getTrailing());
+            }
+          }
+          if ($node is LeftParenToken) {
+            return new LeftBracketToken(
+              $node->getLeading(),
+              $node->getTrailing(),
+            );
+          }
+          if ($node is RightParenToken) {
+            return new RightBracketToken(
+              $node->getLeading(),
+              $node->getTrailing(),
+            );
+          }
+          return $node;
+        },
+        vec[],
+      );
+    }
+
+    return $expr;
+  }
+}

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -78,6 +78,7 @@ final class LintRunConfig {
   ];
 
   const vec<classname<BaseLinter>> NON_DEFAULT_LINTERS = vec[
+    Linters\NoPHPArrayLiteralsLinter::class,
     Linters\NoStringInterpolationLinter::class,
     Linters\StrictModeOnlyLinter::class,
     Linters\UseStatementWithAsLinter::class,
@@ -136,13 +137,17 @@ final class LintRunConfig {
   }
 
   public function getRoots(): vec<string> {
-    return
-      Vec\map($this->configFile['roots'], $dir ==> $this->projectRoot.'/'.$dir);
+    return Vec\map(
+      $this->configFile['roots'],
+      $dir ==> $this->projectRoot.'/'.$dir,
+    );
   }
 
   public function getConfigForFile(string $file_path): self::TFileConfig {
-    $roots =
-      Vec\map($this->configFile['roots'], $s ==> Str\strip_suffix($s, '/').'/');
+    $roots = Vec\map(
+      $this->configFile['roots'],
+      $s ==> Str\strip_suffix($s, '/').'/',
+    );
     $file_path = Str\strip_prefix($file_path, $this->projectRoot.'/');
     if (
       $roots !== vec[] &&
@@ -153,8 +158,8 @@ final class LintRunConfig {
         'autoFixBlacklist' => keyset[],
       );
     }
-    $builtin_linters =
-      $this->configFile['builtinLinters'] ?? NamedLinterGroup::DEFAULT_BUILTINS;
+    $builtin_linters = $this->configFile['builtinLinters'] ??
+      NamedLinterGroup::DEFAULT_BUILTINS;
     $linters = $this->configFile['extraLinters'] ?? vec[];
     $blacklist = $this->configFile['disabledLinters'] ?? vec[];
     $autofix_blacklist = $this->configFile['disabledAutoFixes'] ?? vec[];
@@ -180,12 +185,16 @@ final class LintRunConfig {
         $builtin_linters = $override['builtinLinters'];
       }
       $linters = Vec\concat($linters, $override['extraLinters'] ?? vec[]);
-      $blacklist =
-        Vec\concat($blacklist, $override['disabledLinters'] ?? vec[]);
-      $autofix_blacklist =
-        Vec\concat($autofix_blacklist, $override['disabledAutoFixes'] ?? vec[]);
-      $no_autofixes =
-        $no_autofixes || ($override['disableAllAutoFixes'] ?? false);
+      $blacklist = Vec\concat(
+        $blacklist,
+        $override['disabledLinters'] ?? vec[],
+      );
+      $autofix_blacklist = Vec\concat(
+        $autofix_blacklist,
+        $override['disabledAutoFixes'] ?? vec[],
+      );
+      $no_autofixes = $no_autofixes ||
+        ($override['disableAllAutoFixes'] ?? false);
     }
 
     $normalize = (vec<string> $list) ==> Keyset\map(
@@ -197,8 +206,10 @@ final class LintRunConfig {
     $blacklist = $normalize($blacklist);
     $autofix_blacklist = $normalize($autofix_blacklist);
 
-    $linters =
-      Keyset\union($linters, self::getNamedLinterGroup($builtin_linters));
+    $linters = Keyset\union(
+      $linters,
+      self::getNamedLinterGroup($builtin_linters),
+    );
 
     $linters = Keyset\diff($linters, $blacklist);
     if ($no_autofixes) {

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -78,7 +78,6 @@ final class LintRunConfig {
   ];
 
   const vec<classname<BaseLinter>> NON_DEFAULT_LINTERS = vec[
-    Linters\NoPHPArrayLiteralsLinter::class,
     Linters\NoStringInterpolationLinter::class,
     Linters\StrictModeOnlyLinter::class,
     Linters\UseStatementWithAsLinter::class,

--- a/tests/NoPHPArrayLiteralsLinterTest.hack
+++ b/tests/NoPHPArrayLiteralsLinterTest.hack
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class NoPHPArrayLiteralsLinterTest extends TestCase {
+  use AutoFixingLinterTestTrait<Linters\ASTLintError<EditableNode>>;
+
+  protected function getLinter(string $file): Linters\NoPHPArrayLiteralsLinter {
+    return Linters\NoPHPArrayLiteralsLinter::fromPath($file);
+  }
+
+  public function getCleanExamples(): array<array<string>> {
+    return [
+      ['<?hh $a = vec[];'],
+      ['<?hh $a = vec[1, 2];'],
+      ['<?hh $a = dict[];'],
+      ['<?hh $a = dict["a" => 1, "b" => 2];'],
+      ['<?hh $a = vec[dict["a" => vec[], "b" => vec[1, 2]]];'],
+    ];
+  }
+}

--- a/tests/fixtures/NoPHPArrayLiteralsLinter/arrays.php.autofix.expect
+++ b/tests/fixtures/NoPHPArrayLiteralsLinter/arrays.php.autofix.expect
@@ -1,0 +1,60 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+function foo(): void {
+  $a = array();
+  $a = vec[1];
+  $a = vec[1, 2, 3, 4, 5];
+  $a = dict['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5];
+  $a = vec[
+    array(),
+    vec[1, 2, 3, 4, 5],
+    dict['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5],
+  ];
+
+  $a = [];
+  $a = vec[1];
+  $a = vec[1, 2, 3, 4, 5];
+  $a = dict['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5];
+  $a = vec[
+    [],
+    vec[1, 2, 3, 4, 5],
+    dict['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5],
+  ];
+
+  $a = dict[
+    'a' => vec[vec[1, 2], [], vec['a', 'b'], dict[1 => 'a', 2 => 'b']],
+    'b' => dict[
+      'a' => [],
+      'b' => vec[1, 2],
+      'c' => dict['a' => 'b', 'b' => 'b'],
+    ],
+    'c' => vec[vec[vec[vec[[]]]]],
+    'd' => vec[vec[vec[vec[1, 2]]]],
+    'e' => vec[vec[vec[dict['a' => 1, 'b' => 2]]]],
+  ];
+
+  $a = /*foo*/ dict[ // bar
+    /*baz*/ 'a' => /*hip*/ vec[
+      vec[1, 2],
+      [/*hop*/],
+      vec['a', 'b'],
+      dict[1 => /*hhvm*/ 'a', 2 => 'b'],
+    ] /*hack*/ , // lang
+    'b' => /*yet*/ dict[
+      'a' => [], // an
+      'b' => vec[1, 2], /* other */
+      /* comment */'c' => dict['a' => 'b', 'b' => 'b'],
+    ],
+    'c' => vec[/*for*/vec[/*testing*/vec[vec[[]]]]],
+    'd' => vec[vec[vec[vec[1, /*leading*/ 2]]]],
+    'e' /*trailing*/ => vec[vec[vec[dict['a' => 1, 'b' => 2]]]],
+  ]; // trivia
+}

--- a/tests/fixtures/NoPHPArrayLiteralsLinter/arrays.php.expect
+++ b/tests/fixtures/NoPHPArrayLiteralsLinter/arrays.php.expect
@@ -1,0 +1,312 @@
+[
+    {
+        "blame": "array()",
+        "blame_pretty": "array()",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array(1)",
+        "blame_pretty": "array(1)",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array(1, 2, 3, 4, 5)",
+        "blame_pretty": "array(1, 2, 3, 4, 5)",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5)",
+        "blame_pretty": "array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5)",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array(\n    array(),\n    array(1, 2, 3, 4, 5),\n    array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5),\n  )",
+        "blame_pretty": "array(\n    array(),\n    array(1, 2, 3, 4, 5),\n    array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5),\n  )",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "    array()",
+        "blame_pretty": "    array()",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "    array(1, 2, 3, 4, 5)",
+        "blame_pretty": "    array(1, 2, 3, 4, 5)",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "    array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5)",
+        "blame_pretty": "    array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5)",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[]",
+        "blame_pretty": "[]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[1]",
+        "blame_pretty": "[1]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[1, 2, 3, 4, 5]",
+        "blame_pretty": "[1, 2, 3, 4, 5]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5]",
+        "blame_pretty": "['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[\n    [],\n    [1, 2, 3, 4, 5],\n    ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5],\n  ]",
+        "blame_pretty": "[\n    [],\n    [1, 2, 3, 4, 5],\n    ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5],\n  ]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "    []",
+        "blame_pretty": "    []",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "    [1, 2, 3, 4, 5]",
+        "blame_pretty": "    [1, 2, 3, 4, 5]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "    ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5]",
+        "blame_pretty": "    ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array(\n    'a' => [array(1, 2), [], array('a', 'b'), array(1 => 'a', 2 => 'b')],\n    'b' => array(\n      'a' => [],\n      'b' => array(1, 2),\n      'c' => array('a' => 'b', 'b' => 'b'),\n    ),\n    'c' => [array([array([])])],\n    'd' => array([array([1, 2])]),\n    'e' => array([array(['a' => 1, 'b' => 2])]),\n  )",
+        "blame_pretty": "array(\n    'a' => [array(1, 2), [], array('a', 'b'), array(1 => 'a', 2 => 'b')],\n    'b' => array(\n      'a' => [],\n      'b' => array(1, 2),\n      'c' => array('a' => 'b', 'b' => 'b'),\n    ),\n    'c' => [array([array([])])],\n    'd' => array([array([1, 2])]),\n    'e' => array([array(['a' => 1, 'b' => 2])]),\n  )",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[array(1, 2), [], array('a', 'b'), array(1 => 'a', 2 => 'b')]",
+        "blame_pretty": "[array(1, 2), [], array('a', 'b'), array(1 => 'a', 2 => 'b')]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array(1, 2)",
+        "blame_pretty": "array(1, 2)",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[]",
+        "blame_pretty": "[]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array('a', 'b')",
+        "blame_pretty": "array('a', 'b')",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array(1 => 'a', 2 => 'b')",
+        "blame_pretty": "array(1 => 'a', 2 => 'b')",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array(\n      'a' => [],\n      'b' => array(1, 2),\n      'c' => array('a' => 'b', 'b' => 'b'),\n    )",
+        "blame_pretty": "array(\n      'a' => [],\n      'b' => array(1, 2),\n      'c' => array('a' => 'b', 'b' => 'b'),\n    )",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[]",
+        "blame_pretty": "[]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array(1, 2)",
+        "blame_pretty": "array(1, 2)",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array('a' => 'b', 'b' => 'b')",
+        "blame_pretty": "array('a' => 'b', 'b' => 'b')",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[array([array([])])]",
+        "blame_pretty": "[array([array([])])]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array([array([])])",
+        "blame_pretty": "array([array([])])",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[array([])]",
+        "blame_pretty": "[array([])]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array([])",
+        "blame_pretty": "array([])",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[]",
+        "blame_pretty": "[]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array([array([1, 2])])",
+        "blame_pretty": "array([array([1, 2])])",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[array([1, 2])]",
+        "blame_pretty": "[array([1, 2])]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array([1, 2])",
+        "blame_pretty": "array([1, 2])",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[1, 2]",
+        "blame_pretty": "[1, 2]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array([array(['a' => 1, 'b' => 2])])",
+        "blame_pretty": "array([array(['a' => 1, 'b' => 2])])",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[array(['a' => 1, 'b' => 2])]",
+        "blame_pretty": "[array(['a' => 1, 'b' => 2])]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array(['a' => 1, 'b' => 2])",
+        "blame_pretty": "array(['a' => 1, 'b' => 2])",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "['a' => 1, 'b' => 2]",
+        "blame_pretty": "['a' => 1, 'b' => 2]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array( \/\/ bar\n    \/*baz*\/ 'a' => \/*hip*\/ [\n      array(1, 2),\n      [\/*hop*\/],\n      array('a', 'b'),\n      array(1 => \/*hhvm*\/ 'a', 2 => 'b'),\n    ] \/*hack*\/ , \/\/ lang\n    'b' => \/*yet*\/ array(\n      'a' => [], \/\/ an\n      'b' => array(1, 2), \/* other *\/\n      \/* comment *\/'c' => array('a' => 'b', 'b' => 'b'),\n    ),\n    'c' => [\/*for*\/array(\/*testing*\/[array([])])],\n    'd' => array([array([1, \/*leading*\/ 2])]),\n    'e' \/*trailing*\/ => array([array(['a' => 1, 'b' => 2])]),\n  )",
+        "blame_pretty": "array( \/\/ bar\n    \/*baz*\/ 'a' => \/*hip*\/ [\n      array(1, 2),\n      [\/*hop*\/],\n      array('a', 'b'),\n      array(1 => \/*hhvm*\/ 'a', 2 => 'b'),\n    ] \/*hack*\/ , \/\/ lang\n    'b' => \/*yet*\/ array(\n      'a' => [], \/\/ an\n      'b' => array(1, 2), \/* other *\/\n      \/* comment *\/'c' => array('a' => 'b', 'b' => 'b'),\n    ),\n    'c' => [\/*for*\/array(\/*testing*\/[array([])])],\n    'd' => array([array([1, \/*leading*\/ 2])]),\n    'e' \/*trailing*\/ => array([array(['a' => 1, 'b' => 2])]),\n  )",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[\n      array(1, 2),\n      [\/*hop*\/],\n      array('a', 'b'),\n      array(1 => \/*hhvm*\/ 'a', 2 => 'b'),\n    ] \/*hack*\/ ",
+        "blame_pretty": "[\n      array(1, 2),\n      [\/*hop*\/],\n      array('a', 'b'),\n      array(1 => \/*hhvm*\/ 'a', 2 => 'b'),\n    ] \/*hack*\/ ",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "      array(1, 2)",
+        "blame_pretty": "      array(1, 2)",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "      [\/*hop*\/]",
+        "blame_pretty": "      [\/*hop*\/]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "      array('a', 'b')",
+        "blame_pretty": "      array('a', 'b')",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "      array(1 => \/*hhvm*\/ 'a', 2 => 'b')",
+        "blame_pretty": "      array(1 => \/*hhvm*\/ 'a', 2 => 'b')",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array(\n      'a' => [], \/\/ an\n      'b' => array(1, 2), \/* other *\/\n      \/* comment *\/'c' => array('a' => 'b', 'b' => 'b'),\n    )",
+        "blame_pretty": "array(\n      'a' => [], \/\/ an\n      'b' => array(1, 2), \/* other *\/\n      \/* comment *\/'c' => array('a' => 'b', 'b' => 'b'),\n    )",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[]",
+        "blame_pretty": "[]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array(1, 2)",
+        "blame_pretty": "array(1, 2)",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array('a' => 'b', 'b' => 'b')",
+        "blame_pretty": "array('a' => 'b', 'b' => 'b')",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[\/*for*\/array(\/*testing*\/[array([])])]",
+        "blame_pretty": "[\/*for*\/array(\/*testing*\/[array([])])]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array(\/*testing*\/[array([])])",
+        "blame_pretty": "array(\/*testing*\/[array([])])",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[array([])]",
+        "blame_pretty": "[array([])]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array([])",
+        "blame_pretty": "array([])",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[]",
+        "blame_pretty": "[]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array([array([1, \/*leading*\/ 2])])",
+        "blame_pretty": "array([array([1, \/*leading*\/ 2])])",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[array([1, \/*leading*\/ 2])]",
+        "blame_pretty": "[array([1, \/*leading*\/ 2])]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array([1, \/*leading*\/ 2])",
+        "blame_pretty": "array([1, \/*leading*\/ 2])",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[1, \/*leading*\/ 2]",
+        "blame_pretty": "[1, \/*leading*\/ 2]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array([array(['a' => 1, 'b' => 2])])",
+        "blame_pretty": "array([array(['a' => 1, 'b' => 2])])",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "[array(['a' => 1, 'b' => 2])]",
+        "blame_pretty": "[array(['a' => 1, 'b' => 2])]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "array(['a' => 1, 'b' => 2])",
+        "blame_pretty": "array(['a' => 1, 'b' => 2])",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    },
+    {
+        "blame": "['a' => 1, 'b' => 2]",
+        "blame_pretty": "['a' => 1, 'b' => 2]",
+        "description": "Do not use PHP array literals, use Hack arrays instead."
+    }
+]

--- a/tests/fixtures/NoPHPArrayLiteralsLinter/arrays.php.in
+++ b/tests/fixtures/NoPHPArrayLiteralsLinter/arrays.php.in
@@ -1,0 +1,60 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+function foo(): void {
+  $a = array();
+  $a = array(1);
+  $a = array(1, 2, 3, 4, 5);
+  $a = array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5);
+  $a = array(
+    array(),
+    array(1, 2, 3, 4, 5),
+    array('a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5),
+  );
+
+  $a = [];
+  $a = [1];
+  $a = [1, 2, 3, 4, 5];
+  $a = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5];
+  $a = [
+    [],
+    [1, 2, 3, 4, 5],
+    ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5],
+  ];
+
+  $a = array(
+    'a' => [array(1, 2), [], array('a', 'b'), array(1 => 'a', 2 => 'b')],
+    'b' => array(
+      'a' => [],
+      'b' => array(1, 2),
+      'c' => array('a' => 'b', 'b' => 'b'),
+    ),
+    'c' => [array([array([])])],
+    'd' => array([array([1, 2])]),
+    'e' => array([array(['a' => 1, 'b' => 2])]),
+  );
+
+  $a = /*foo*/ array( // bar
+    /*baz*/ 'a' => /*hip*/ [
+      array(1, 2),
+      [/*hop*/],
+      array('a', 'b'),
+      array(1 => /*hhvm*/ 'a', 2 => 'b'),
+    ] /*hack*/ , // lang
+    'b' => /*yet*/ array(
+      'a' => [], // an
+      'b' => array(1, 2), /* other */
+      /* comment */'c' => array('a' => 'b', 'b' => 'b'),
+    ),
+    'c' => [/*for*/array(/*testing*/[array([])])],
+    'd' => array([array([1, /*leading*/ 2])]),
+    'e' /*trailing*/ => array([array(['a' => 1, 'b' => 2])]),
+  ); // trivia
+}


### PR DESCRIPTION
Summary: try to guess when possible if it should be fixed to a vec or a
dict. Not enabled by default. Examples:

$a = array(1, 2); // should be a vec[]
$a = ['a' => 1, 'b' => 2]; // should be a dict[]
$a = []; // no fix

Fixes #81
