### PR TITLE
Wrap NameToken/QualifiedName in List<ListItem<IExpression>>

### DIFF
--- a/codegen/node_from_json.hack
+++ b/codegen/node_from_json.hack
@@ -1,24 +1,26 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8f34279a4c1a6fd21bbc06653547c514>>
+ * @generated SignedSource<<5c6ffcc311022b149d0fb1337c916ebb>>
  */
 namespace Facebook\HHAST\__Private;
 use namespace Facebook\HHAST;
 
-function node_from_json(
+function node_from_json_unwrapped(
   dict<string, mixed> $json,
   string $file,
   int $offset,
   string $source,
+  string $type_hint,
 ): HHAST\Node {
   $kind = $json["kind"] as string;
   if ($kind === "token") {
     return HHAST\Token::fromJSON(
-      $json['token'] as dict<_, _>,
+      /* HH_FIXME[4110] */ $json['token'],
       $file,
       $offset,
       $source,
+      $type_hint,
     );
   }
   $kind_to_class = dict[
@@ -225,7 +227,7 @@ function node_from_json(
   ];
   $class = $kind_to_class[$kind] ?? null;
   if ($class is nonnull) {
-    return $class::fromJSON($json, $file, $offset, $source);
+    return $class::fromJSON($json, $file, $offset, $source, $type_hint);
   }
   throw new HHAST\UnsupportedASTNodeError(
     $file,

--- a/codegen/syntax/AliasDeclaration.hack
+++ b/codegen/syntax/AliasDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<659957077cac828841d48c035d55c0cf>>
+ * @generated SignedSource<<ea875e05464076527aa9addbba8ef702>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -48,6 +48,7 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute_spec = Node::fromJSON(
@@ -55,6 +56,7 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'AttributeSpecification',
     );
     $offset += $attribute_spec->getWidth();
     $keyword = Node::fromJSON(
@@ -62,6 +64,7 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $keyword->getWidth();
     $name = Node::fromJSON(
@@ -69,6 +72,7 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'NameToken',
     );
     $offset += $name->getWidth();
     $generic_parameter = Node::fromJSON(
@@ -76,6 +80,7 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'TypeParameters',
     );
     $offset += $generic_parameter->getWidth();
     $constraint = Node::fromJSON(
@@ -83,6 +88,7 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'TypeConstraint',
     );
     $offset += $constraint->getWidth();
     $equal = Node::fromJSON(
@@ -90,6 +96,7 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'EqualToken',
     );
     $offset += $equal->getWidth();
     $type = Node::fromJSON(
@@ -97,6 +104,7 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $semicolon = Node::fromJSON(
@@ -104,6 +112,7 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/AlternateElseClause.hack
+++ b/codegen/syntax/AlternateElseClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8e1fa44ede08f9ea391c5bf42d6aba29>>
+ * @generated SignedSource<<edcd3d79c5b8752b17bd3fddc1bf00d1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class AlternateElseClause extends Node implements IControlFlowStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -40,6 +41,7 @@ final class AlternateElseClause extends Node implements IControlFlowStatement {
       $file,
       $offset,
       $source,
+      'ElseToken',
     );
     $offset += $keyword->getWidth();
     $colon = Node::fromJSON(
@@ -47,6 +49,7 @@ final class AlternateElseClause extends Node implements IControlFlowStatement {
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $colon->getWidth();
     $statement = Node::fromJSON(
@@ -54,6 +57,7 @@ final class AlternateElseClause extends Node implements IControlFlowStatement {
       $file,
       $offset,
       $source,
+      'NodeList<IStatement>',
     );
     $offset += $statement->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/AlternateElseifClause.hack
+++ b/codegen/syntax/AlternateElseifClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0ed95cb8772325e67f9fb29a8bb665a7>>
+ * @generated SignedSource<<7a33afc3140267fd5b3f1326d361a811>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -44,6 +44,7 @@ final class AlternateElseifClause
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -51,6 +52,7 @@ final class AlternateElseifClause
       $file,
       $offset,
       $source,
+      'ElseifToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -58,6 +60,7 @@ final class AlternateElseifClause
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $condition = Node::fromJSON(
@@ -65,6 +68,7 @@ final class AlternateElseifClause
       $file,
       $offset,
       $source,
+      'BinaryExpression',
     );
     $offset += $condition->getWidth();
     $right_paren = Node::fromJSON(
@@ -72,6 +76,7 @@ final class AlternateElseifClause
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $colon = Node::fromJSON(
@@ -79,6 +84,7 @@ final class AlternateElseifClause
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $colon->getWidth();
     $statement = Node::fromJSON(
@@ -86,6 +92,7 @@ final class AlternateElseifClause
       $file,
       $offset,
       $source,
+      'NodeList<ExpressionStatement>',
     );
     $offset += $statement->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/AlternateIfStatement.hack
+++ b/codegen/syntax/AlternateIfStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<410bc17ce82f53eb8d9bbf5837941404>>
+ * @generated SignedSource<<2117b89c7410cd75c05ab5f06fa9f825>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,6 +56,7 @@ final class AlternateIfStatement
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -63,6 +64,7 @@ final class AlternateIfStatement
       $file,
       $offset,
       $source,
+      'IfToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -70,6 +72,7 @@ final class AlternateIfStatement
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $condition = Node::fromJSON(
@@ -77,6 +80,7 @@ final class AlternateIfStatement
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $condition->getWidth();
     $right_paren = Node::fromJSON(
@@ -84,6 +88,7 @@ final class AlternateIfStatement
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $colon = Node::fromJSON(
@@ -91,6 +96,7 @@ final class AlternateIfStatement
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $colon->getWidth();
     $statement = Node::fromJSON(
@@ -98,6 +104,7 @@ final class AlternateIfStatement
       $file,
       $offset,
       $source,
+      'NodeList<IStatement>',
     );
     $offset += $statement->getWidth();
     $elseif_clauses = Node::fromJSON(
@@ -105,6 +112,7 @@ final class AlternateIfStatement
       $file,
       $offset,
       $source,
+      'NodeList<AlternateElseifClause>',
     );
     $offset += $elseif_clauses->getWidth();
     $else_clause = Node::fromJSON(
@@ -112,6 +120,7 @@ final class AlternateIfStatement
       $file,
       $offset,
       $source,
+      'AlternateElseClause',
     );
     $offset += $else_clause->getWidth();
     $endif_keyword = Node::fromJSON(
@@ -119,6 +128,7 @@ final class AlternateIfStatement
       $file,
       $offset,
       $source,
+      'EndifToken',
     );
     $offset += $endif_keyword->getWidth();
     $semicolon = Node::fromJSON(
@@ -126,6 +136,7 @@ final class AlternateIfStatement
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(
@@ -318,9 +329,8 @@ final class AlternateIfStatement
   /**
    * @return BinaryExpression | VariableExpression
    */
-  <<__Memoize>>
   public function getCondition(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_condition);
+    return TypeAssert\instance_of(IExpression::class, $this->_condition);
   }
 
   /**

--- a/codegen/syntax/AlternateLoopStatement.hack
+++ b/codegen/syntax/AlternateLoopStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<db93d43724f973c329c15c83405d54c5>>
+ * @generated SignedSource<<ca0999a331f99a06138a78d6baf58413>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -38,6 +38,7 @@ abstract class AlternateLoopStatementGeneratedBase
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $opening_colon = Node::fromJSON(
@@ -45,6 +46,7 @@ abstract class AlternateLoopStatementGeneratedBase
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $opening_colon->getWidth();
     $statements = Node::fromJSON(
@@ -52,6 +54,7 @@ abstract class AlternateLoopStatementGeneratedBase
       $file,
       $offset,
       $source,
+      'NodeList<IStatement>',
     );
     $offset += $statements->getWidth();
     $closing_keyword = Node::fromJSON(
@@ -59,6 +62,7 @@ abstract class AlternateLoopStatementGeneratedBase
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $closing_keyword->getWidth();
     $closing_semicolon = Node::fromJSON(
@@ -66,6 +70,7 @@ abstract class AlternateLoopStatementGeneratedBase
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $closing_semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/AlternateSwitchStatement.hack
+++ b/codegen/syntax/AlternateSwitchStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3b1effc3f028c9b752a414040ef1b83e>>
+ * @generated SignedSource<<e00fdb285c59235a5cc549d62735d797>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -50,6 +50,7 @@ final class AlternateSwitchStatement
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -57,6 +58,7 @@ final class AlternateSwitchStatement
       $file,
       $offset,
       $source,
+      'SwitchToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -64,6 +66,7 @@ final class AlternateSwitchStatement
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $expression = Node::fromJSON(
@@ -71,6 +74,7 @@ final class AlternateSwitchStatement
       $file,
       $offset,
       $source,
+      'VariableExpression',
     );
     $offset += $expression->getWidth();
     $right_paren = Node::fromJSON(
@@ -78,6 +82,7 @@ final class AlternateSwitchStatement
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $opening_colon = Node::fromJSON(
@@ -85,6 +90,7 @@ final class AlternateSwitchStatement
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $opening_colon->getWidth();
     $sections = Node::fromJSON(
@@ -92,6 +98,7 @@ final class AlternateSwitchStatement
       $file,
       $offset,
       $source,
+      'NodeList<SwitchSection>',
     );
     $offset += $sections->getWidth();
     $closing_endswitch = Node::fromJSON(
@@ -99,6 +106,7 @@ final class AlternateSwitchStatement
       $file,
       $offset,
       $source,
+      'EndswitchToken',
     );
     $offset += $closing_endswitch->getWidth();
     $closing_semicolon = Node::fromJSON(
@@ -106,6 +114,7 @@ final class AlternateSwitchStatement
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $closing_semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/AnonymousClass.hack
+++ b/codegen/syntax/AnonymousClass.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1744346ea77dc69f90f51b34ebdc03ac>>
+ * @generated SignedSource<<c3c90018a412cfce5b535373831850c1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -51,6 +51,7 @@ final class AnonymousClass extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $class_keyword = Node::fromJSON(
@@ -58,6 +59,7 @@ final class AnonymousClass extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $class_keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -65,6 +67,7 @@ final class AnonymousClass extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $left_paren->getWidth();
     $argument_list = Node::fromJSON(
@@ -72,6 +75,7 @@ final class AnonymousClass extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $argument_list->getWidth();
     $right_paren = Node::fromJSON(
@@ -79,6 +83,7 @@ final class AnonymousClass extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $right_paren->getWidth();
     $extends_keyword = Node::fromJSON(
@@ -86,6 +91,7 @@ final class AnonymousClass extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $extends_keyword->getWidth();
     $extends_list = Node::fromJSON(
@@ -93,6 +99,7 @@ final class AnonymousClass extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $extends_list->getWidth();
     $implements_keyword = Node::fromJSON(
@@ -100,6 +107,7 @@ final class AnonymousClass extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $implements_keyword->getWidth();
     $implements_list = Node::fromJSON(
@@ -107,6 +115,7 @@ final class AnonymousClass extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $implements_list->getWidth();
     $body = Node::fromJSON(
@@ -114,6 +123,7 @@ final class AnonymousClass extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $body->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/AnonymousFunction.hack
+++ b/codegen/syntax/AnonymousFunction.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<041dba44baf6fe1e20ac4ac364ec05d6>>
+ * @generated SignedSource<<f56da4ad3e8b298db24afc8587ff2a87>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -62,6 +62,7 @@ final class AnonymousFunction
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute_spec = Node::fromJSON(
@@ -69,6 +70,7 @@ final class AnonymousFunction
       $file,
       $offset,
       $source,
+      'AttributeSpecification',
     );
     $offset += $attribute_spec->getWidth();
     $static_keyword = Node::fromJSON(
@@ -76,6 +78,7 @@ final class AnonymousFunction
       $file,
       $offset,
       $source,
+      'StaticToken',
     );
     $offset += $static_keyword->getWidth();
     $async_keyword = Node::fromJSON(
@@ -83,6 +86,7 @@ final class AnonymousFunction
       $file,
       $offset,
       $source,
+      'AsyncToken',
     );
     $offset += $async_keyword->getWidth();
     $coroutine_keyword = Node::fromJSON(
@@ -90,6 +94,7 @@ final class AnonymousFunction
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $coroutine_keyword->getWidth();
     $function_keyword = Node::fromJSON(
@@ -97,6 +102,7 @@ final class AnonymousFunction
       $file,
       $offset,
       $source,
+      'FunctionToken',
     );
     $offset += $function_keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -104,6 +110,7 @@ final class AnonymousFunction
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $parameters = Node::fromJSON(
@@ -111,6 +118,7 @@ final class AnonymousFunction
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IParameter>>',
     );
     $offset += $parameters->getWidth();
     $right_paren = Node::fromJSON(
@@ -118,6 +126,7 @@ final class AnonymousFunction
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $colon = Node::fromJSON(
@@ -125,6 +134,7 @@ final class AnonymousFunction
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $colon->getWidth();
     $type = Node::fromJSON(
@@ -132,6 +142,7 @@ final class AnonymousFunction
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $use = Node::fromJSON(
@@ -139,6 +150,7 @@ final class AnonymousFunction
       $file,
       $offset,
       $source,
+      'AnonymousFunctionUseClause',
     );
     $offset += $use->getWidth();
     $body = Node::fromJSON(
@@ -146,6 +158,7 @@ final class AnonymousFunction
       $file,
       $offset,
       $source,
+      'CompoundStatement',
     );
     $offset += $body->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/AnonymousFunctionUseClause.hack
+++ b/codegen/syntax/AnonymousFunctionUseClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b2862ec76cb0768ccba8b9c45076c07f>>
+ * @generated SignedSource<<a3c1c4731b395bf60dfccaed640916da>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class AnonymousFunctionUseClause extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class AnonymousFunctionUseClause extends Node {
       $file,
       $offset,
       $source,
+      'UseToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -50,6 +52,7 @@ final class AnonymousFunctionUseClause extends Node {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $variables = Node::fromJSON(
@@ -57,6 +60,7 @@ final class AnonymousFunctionUseClause extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<VariableToken>>',
     );
     $offset += $variables->getWidth();
     $right_paren = Node::fromJSON(
@@ -64,6 +68,7 @@ final class AnonymousFunctionUseClause extends Node {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ArrayCreationExpression.hack
+++ b/codegen/syntax/ArrayCreationExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a408bb589e45a547ef7500c3ee65e8a8>>
+ * @generated SignedSource<<135f8f8dcc91620ad67053164d805cff>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class ArrayCreationExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_bracket = Node::fromJSON(
@@ -42,6 +43,7 @@ final class ArrayCreationExpression
       $file,
       $offset,
       $source,
+      'LeftBracketToken',
     );
     $offset += $left_bracket->getWidth();
     $members = Node::fromJSON(
@@ -49,6 +51,7 @@ final class ArrayCreationExpression
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<Node>>',
     );
     $offset += $members->getWidth();
     $right_bracket = Node::fromJSON(
@@ -56,6 +59,7 @@ final class ArrayCreationExpression
       $file,
       $offset,
       $source,
+      'RightBracketToken',
     );
     $offset += $right_bracket->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ArrayIntrinsicExpression.hack
+++ b/codegen/syntax/ArrayIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fc8134054d44f553de73ac4d01c5e5cc>>
+ * @generated SignedSource<<e5e98a08705b1919e4047250cb9a6d70>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -38,6 +38,7 @@ final class ArrayIntrinsicExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -45,6 +46,7 @@ final class ArrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'ArrayToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -52,6 +54,7 @@ final class ArrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $members = Node::fromJSON(
@@ -59,6 +62,7 @@ final class ArrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<Node>>',
     );
     $offset += $members->getWidth();
     $right_paren = Node::fromJSON(
@@ -66,6 +70,7 @@ final class ArrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/AsExpression.hack
+++ b/codegen/syntax/AsExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8e46cf03bb63ea226188932de42f6cf8>>
+ * @generated SignedSource<<8d08c5ddf3a0e4fd2787224d01198a13>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class AsExpression extends Node implements ILambdaBody, IExpression {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_operand = Node::fromJSON(
@@ -40,6 +41,7 @@ final class AsExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $left_operand->getWidth();
     $operator = Node::fromJSON(
@@ -47,6 +49,7 @@ final class AsExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'AsToken',
     );
     $offset += $operator->getWidth();
     $right_operand = Node::fromJSON(
@@ -54,6 +57,7 @@ final class AsExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $right_operand->getWidth();
     $source_ref = shape(
@@ -113,9 +117,8 @@ final class AsExpression extends Node implements ILambdaBody, IExpression {
    * MemberSelectionExpression | ParenthesizedExpression | TupleExpression |
    * VariableExpression
    */
-  <<__Memoize>>
   public function getLeftOperand(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_left_operand);
+    return TypeAssert\instance_of(IExpression::class, $this->_left_operand);
   }
 
   /**

--- a/codegen/syntax/AttributeSpecification.hack
+++ b/codegen/syntax/AttributeSpecification.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e785f9d139d966c69b11799056f547d5>>
+ * @generated SignedSource<<826c6be9221e76c155a9811cbb3d1e3d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class AttributeSpecification extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_double_angle = Node::fromJSON(
@@ -40,6 +41,7 @@ final class AttributeSpecification extends Node {
       $file,
       $offset,
       $source,
+      'LessThanLessThanToken',
     );
     $offset += $left_double_angle->getWidth();
     $attributes = Node::fromJSON(
@@ -47,6 +49,7 @@ final class AttributeSpecification extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ConstructorCall>>',
     );
     $offset += $attributes->getWidth();
     $right_double_angle = Node::fromJSON(
@@ -54,6 +57,7 @@ final class AttributeSpecification extends Node {
       $file,
       $offset,
       $source,
+      'GreaterThanGreaterThanToken',
     );
     $offset += $right_double_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/AwaitableCreationExpression.hack
+++ b/codegen/syntax/AwaitableCreationExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<325d3bcfd27c55600c6e1e0fc28b8ee2>>
+ * @generated SignedSource<<878bf8d7184554d6ad473da32bb0ee0e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -38,6 +38,7 @@ abstract class AwaitableCreationExpressionGeneratedBase
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute_spec = Node::fromJSON(
@@ -45,6 +46,7 @@ abstract class AwaitableCreationExpressionGeneratedBase
       $file,
       $offset,
       $source,
+      'AttributeSpecification',
     );
     $offset += $attribute_spec->getWidth();
     $async = Node::fromJSON(
@@ -52,6 +54,7 @@ abstract class AwaitableCreationExpressionGeneratedBase
       $file,
       $offset,
       $source,
+      'AsyncToken',
     );
     $offset += $async->getWidth();
     $coroutine = Node::fromJSON(
@@ -59,6 +62,7 @@ abstract class AwaitableCreationExpressionGeneratedBase
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $coroutine->getWidth();
     $compound_statement = Node::fromJSON(
@@ -66,6 +70,7 @@ abstract class AwaitableCreationExpressionGeneratedBase
       $file,
       $offset,
       $source,
+      'CompoundStatement',
     );
     $offset += $compound_statement->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/BinaryExpression.hack
+++ b/codegen/syntax/BinaryExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6fc0b894a860543fd5449a0e83b8dda1>>
+ * @generated SignedSource<<3434f09673771772f178fb9d1dd7df68>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class BinaryExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_operand = Node::fromJSON(
@@ -42,6 +43,7 @@ final class BinaryExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $left_operand->getWidth();
     $operator = Node::fromJSON(
@@ -49,6 +51,7 @@ final class BinaryExpression
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $operator->getWidth();
     $right_operand = Node::fromJSON(
@@ -56,6 +59,7 @@ final class BinaryExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $right_operand->getWidth();
     $source_ref = shape(
@@ -123,9 +127,8 @@ final class BinaryExpression
    * SubscriptExpression | NameToken | VariableExpression |
    * VarrayIntrinsicExpression | VectorIntrinsicExpression
    */
-  <<__Memoize>>
   public function getLeftOperand(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_left_operand);
+    return TypeAssert\instance_of(IExpression::class, $this->_left_operand);
   }
 
   /**
@@ -228,9 +231,8 @@ final class BinaryExpression
    * VariableExpression | VarrayIntrinsicExpression | VectorIntrinsicExpression
    * | XHPExpression | YieldExpression | YieldFromExpression
    */
-  <<__Memoize>>
   public function getRightOperand(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_right_operand);
+    return TypeAssert\instance_of(IExpression::class, $this->_right_operand);
   }
 
   /**

--- a/codegen/syntax/BracedExpression.hack
+++ b/codegen/syntax/BracedExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<347f565eb162fc34361095e05bc5722f>>
+ * @generated SignedSource<<b6d5a8bacc08f747f7fe1436b29cd988>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class BracedExpression extends Node implements ILambdaBody, IExpression {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_brace = Node::fromJSON(
@@ -40,6 +41,7 @@ final class BracedExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'LeftBraceToken',
     );
     $offset += $left_brace->getWidth();
     $expression = Node::fromJSON(
@@ -47,6 +49,7 @@ final class BracedExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $expression->getWidth();
     $right_brace = Node::fromJSON(
@@ -54,6 +57,7 @@ final class BracedExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'RightBraceToken',
     );
     $offset += $right_brace->getWidth();
     $source_ref = shape(
@@ -143,9 +147,8 @@ final class BracedExpression extends Node implements ILambdaBody, IExpression {
    * MemberSelectionExpression | ObjectCreationExpression | NameToken |
    * VariableExpression
    */
-  <<__Memoize>>
   public function getExpression(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_expression);
+    return TypeAssert\instance_of(IExpression::class, $this->_expression);
   }
 
   /**

--- a/codegen/syntax/BreakStatement.hack
+++ b/codegen/syntax/BreakStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<55aee4e0aac5739d712fa0917e8abed7>>
+ * @generated SignedSource<<9f5c2bf60cb3ad5db75f6ad6499e6c33>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class BreakStatement extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -40,6 +41,7 @@ final class BreakStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'BreakToken',
     );
     $offset += $keyword->getWidth();
     $level = Node::fromJSON(
@@ -47,6 +49,7 @@ final class BreakStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'LiteralExpression',
     );
     $offset += $level->getWidth();
     $semicolon = Node::fromJSON(
@@ -54,6 +57,7 @@ final class BreakStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/CaseLabel.hack
+++ b/codegen/syntax/CaseLabel.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2e8f534a44a4592ce3b7d1aa58a31eb8>>
+ * @generated SignedSource<<729f95cc40736b197663eb12e737393c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class CaseLabel extends Node implements ISwitchLabel {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -40,6 +41,7 @@ final class CaseLabel extends Node implements ISwitchLabel {
       $file,
       $offset,
       $source,
+      'CaseToken',
     );
     $offset += $keyword->getWidth();
     $expression = Node::fromJSON(
@@ -47,6 +49,7 @@ final class CaseLabel extends Node implements ISwitchLabel {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $expression->getWidth();
     $colon = Node::fromJSON(
@@ -54,6 +57,7 @@ final class CaseLabel extends Node implements ISwitchLabel {
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $colon->getWidth();
     $source_ref = shape(
@@ -143,9 +147,8 @@ final class CaseLabel extends Node implements ISwitchLabel {
    * PrefixUnaryExpression | ScopeResolutionExpression | NameToken |
    * VariableExpression
    */
-  <<__Memoize>>
   public function getExpression(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_expression);
+    return TypeAssert\instance_of(IExpression::class, $this->_expression);
   }
 
   /**

--- a/codegen/syntax/CastExpression.hack
+++ b/codegen/syntax/CastExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<08a8dd01470b702b214e75762d7f6549>>
+ * @generated SignedSource<<6cbfb29de23d00ebf73f300b6ec371b0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class CastExpression extends Node implements ILambdaBody, IExpression {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_paren = Node::fromJSON(
@@ -43,6 +44,7 @@ final class CastExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $type = Node::fromJSON(
@@ -50,6 +52,7 @@ final class CastExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $type->getWidth();
     $right_paren = Node::fromJSON(
@@ -57,6 +60,7 @@ final class CastExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $operand = Node::fromJSON(
@@ -64,6 +68,7 @@ final class CastExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $operand->getWidth();
     $source_ref = shape(
@@ -241,9 +246,8 @@ final class CastExpression extends Node implements ILambdaBody, IExpression {
    * PostfixUnaryExpression | PrefixUnaryExpression | ScopeResolutionExpression
    * | SubscriptExpression | NameToken | VariableExpression | XHPExpression
    */
-  <<__Memoize>>
   public function getOperand(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_operand);
+    return TypeAssert\instance_of(IExpression::class, $this->_operand);
   }
 
   /**

--- a/codegen/syntax/CatchClause.hack
+++ b/codegen/syntax/CatchClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<43f53b520cfed33e9a1603310764d122>>
+ * @generated SignedSource<<5d064c191ef6f878d81b8e64bb39c928>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -42,6 +42,7 @@ final class CatchClause extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -49,6 +50,7 @@ final class CatchClause extends Node {
       $file,
       $offset,
       $source,
+      'CatchToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -56,6 +58,7 @@ final class CatchClause extends Node {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $type = Node::fromJSON(
@@ -63,6 +66,7 @@ final class CatchClause extends Node {
       $file,
       $offset,
       $source,
+      'SimpleTypeSpecifier',
     );
     $offset += $type->getWidth();
     $variable = Node::fromJSON(
@@ -70,6 +74,7 @@ final class CatchClause extends Node {
       $file,
       $offset,
       $source,
+      'VariableToken',
     );
     $offset += $variable->getWidth();
     $right_paren = Node::fromJSON(
@@ -77,6 +82,7 @@ final class CatchClause extends Node {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $body = Node::fromJSON(
@@ -84,6 +90,7 @@ final class CatchClause extends Node {
       $file,
       $offset,
       $source,
+      'CompoundStatement',
     );
     $offset += $body->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ClassishBody.hack
+++ b/codegen/syntax/ClassishBody.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6558c22af6e2283fe48b8d74f3d91fc3>>
+ * @generated SignedSource<<80d952c366c9abf0c03a44ed44e6fd11>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class ClassishBody extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_brace = Node::fromJSON(
@@ -40,6 +41,7 @@ final class ClassishBody extends Node {
       $file,
       $offset,
       $source,
+      'LeftBraceToken',
     );
     $offset += $left_brace->getWidth();
     $elements = Node::fromJSON(
@@ -47,6 +49,7 @@ final class ClassishBody extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<IClassBodyDeclaration>',
     );
     $offset += $elements->getWidth();
     $right_brace = Node::fromJSON(
@@ -54,6 +57,7 @@ final class ClassishBody extends Node {
       $file,
       $offset,
       $source,
+      'RightBraceToken',
     );
     $offset += $right_brace->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ClassishDeclaration.hack
+++ b/codegen/syntax/ClassishDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<71ea432759231ca3aa9de36157081da8>>
+ * @generated SignedSource<<10190cba6bfca7243e771d50a0e735bd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,6 +56,7 @@ abstract class ClassishDeclarationGeneratedBase
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute = Node::fromJSON(
@@ -63,6 +64,7 @@ abstract class ClassishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'AttributeSpecification',
     );
     $offset += $attribute->getWidth();
     $modifiers = Node::fromJSON(
@@ -70,6 +72,7 @@ abstract class ClassishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'NodeList<Token>',
     );
     $offset += $modifiers->getWidth();
     $keyword = Node::fromJSON(
@@ -77,6 +80,7 @@ abstract class ClassishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $keyword->getWidth();
     $name = Node::fromJSON(
@@ -84,6 +88,7 @@ abstract class ClassishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $name->getWidth();
     $type_parameters = Node::fromJSON(
@@ -91,6 +96,7 @@ abstract class ClassishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'TypeParameters',
     );
     $offset += $type_parameters->getWidth();
     $extends_keyword = Node::fromJSON(
@@ -98,6 +104,7 @@ abstract class ClassishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'ExtendsToken',
     );
     $offset += $extends_keyword->getWidth();
     $extends_list = Node::fromJSON(
@@ -105,6 +112,7 @@ abstract class ClassishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ISimpleCreationSpecifier>>',
     );
     $offset += $extends_list->getWidth();
     $implements_keyword = Node::fromJSON(
@@ -112,6 +120,7 @@ abstract class ClassishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'ImplementsToken',
     );
     $offset += $implements_keyword->getWidth();
     $implements_list = Node::fromJSON(
@@ -119,6 +128,7 @@ abstract class ClassishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ISimpleCreationSpecifier>>',
     );
     $offset += $implements_list->getWidth();
     $body = Node::fromJSON(
@@ -126,6 +136,7 @@ abstract class ClassishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'ClassishBody',
     );
     $offset += $body->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ClassnameTypeSpecifier.hack
+++ b/codegen/syntax/ClassnameTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b20bc15edc82ee954282c22328dce36a>>
+ * @generated SignedSource<<c9d0d144b57d194c7b71356c705ec554>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -39,6 +39,7 @@ final class ClassnameTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -46,6 +47,7 @@ final class ClassnameTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ClassnameToken',
     );
     $offset += $keyword->getWidth();
     $left_angle = Node::fromJSON(
@@ -53,6 +55,7 @@ final class ClassnameTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'LessThanToken',
     );
     $offset += $left_angle->getWidth();
     $type = Node::fromJSON(
@@ -60,6 +63,7 @@ final class ClassnameTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $trailing_comma = Node::fromJSON(
@@ -67,6 +71,7 @@ final class ClassnameTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $trailing_comma->getWidth();
     $right_angle = Node::fromJSON(
@@ -74,6 +79,7 @@ final class ClassnameTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'GreaterThanToken',
     );
     $offset += $right_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ClosureParameterTypeSpecifier.hack
+++ b/codegen/syntax/ClosureParameterTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3e56e686820eef9aa508709deb961bf4>>
+ * @generated SignedSource<<a2e66269c1f2f1b60fdc33f66e1acd15>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -32,6 +32,7 @@ final class ClosureParameterTypeSpecifier
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $call_convention = Node::fromJSON(
@@ -39,6 +40,7 @@ final class ClosureParameterTypeSpecifier
       $file,
       $offset,
       $source,
+      'InoutToken',
     );
     $offset += $call_convention->getWidth();
     $type = Node::fromJSON(
@@ -46,6 +48,7 @@ final class ClosureParameterTypeSpecifier
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ClosureTypeSpecifier.hack
+++ b/codegen/syntax/ClosureTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<dcea8eae32ea7b388a76d113ed488fe4>>
+ * @generated SignedSource<<6d49f0e51a518ba316c3531f225d06e8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -51,6 +51,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $outer_left_paren = Node::fromJSON(
@@ -58,6 +59,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $outer_left_paren->getWidth();
     $coroutine = Node::fromJSON(
@@ -65,6 +67,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $coroutine->getWidth();
     $function_keyword = Node::fromJSON(
@@ -72,6 +75,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'FunctionToken',
     );
     $offset += $function_keyword->getWidth();
     $inner_left_paren = Node::fromJSON(
@@ -79,6 +83,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $inner_left_paren->getWidth();
     $parameter_list = Node::fromJSON(
@@ -86,6 +91,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ITypeSpecifier>>',
     );
     $offset += $parameter_list->getWidth();
     $inner_right_paren = Node::fromJSON(
@@ -93,6 +99,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $inner_right_paren->getWidth();
     $colon = Node::fromJSON(
@@ -100,6 +107,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $colon->getWidth();
     $return_type = Node::fromJSON(
@@ -107,6 +115,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $return_type->getWidth();
     $outer_right_paren = Node::fromJSON(
@@ -114,6 +123,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $outer_right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/CollectionLiteralExpression.hack
+++ b/codegen/syntax/CollectionLiteralExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0043a07bd0f6609dd2008f0886f74b82>>
+ * @generated SignedSource<<e5263f069a2a4f7f3730fab8e46dd96f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -38,6 +38,7 @@ final class CollectionLiteralExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $name = Node::fromJSON(
@@ -45,6 +46,7 @@ final class CollectionLiteralExpression
       $file,
       $offset,
       $source,
+      'ISimpleCreationSpecifier',
     );
     $offset += $name->getWidth();
     $left_brace = Node::fromJSON(
@@ -52,6 +54,7 @@ final class CollectionLiteralExpression
       $file,
       $offset,
       $source,
+      'LeftBraceToken',
     );
     $offset += $left_brace->getWidth();
     $initializers = Node::fromJSON(
@@ -59,6 +62,7 @@ final class CollectionLiteralExpression
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<Node>>',
     );
     $offset += $initializers->getWidth();
     $right_brace = Node::fromJSON(
@@ -66,6 +70,7 @@ final class CollectionLiteralExpression
       $file,
       $offset,
       $source,
+      'RightBraceToken',
     );
     $offset += $right_brace->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/CompoundStatement.hack
+++ b/codegen/syntax/CompoundStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<921ac59972a7c3c081d182766e9bffdb>>
+ * @generated SignedSource<<842f296696f380b68222e5eb42772e1e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class CompoundStatement extends Node implements ILambdaBody, IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_brace = Node::fromJSON(
@@ -40,6 +41,7 @@ final class CompoundStatement extends Node implements ILambdaBody, IStatement {
       $file,
       $offset,
       $source,
+      'LeftBraceToken',
     );
     $offset += $left_brace->getWidth();
     $statements = Node::fromJSON(
@@ -47,6 +49,7 @@ final class CompoundStatement extends Node implements ILambdaBody, IStatement {
       $file,
       $offset,
       $source,
+      'NodeList<IStatement>',
     );
     $offset += $statements->getWidth();
     $right_brace = Node::fromJSON(
@@ -54,6 +57,7 @@ final class CompoundStatement extends Node implements ILambdaBody, IStatement {
       $file,
       $offset,
       $source,
+      'RightBraceToken',
     );
     $offset += $right_brace->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ConcurrentStatement.hack
+++ b/codegen/syntax/ConcurrentStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4b868c9b98947cca3cdde4e453232e79>>
+ * @generated SignedSource<<a0039ac54603f5f7785ba20f60ee6f97>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class ConcurrentStatement extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -37,6 +38,7 @@ final class ConcurrentStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'ConcurrentToken',
     );
     $offset += $keyword->getWidth();
     $statement = Node::fromJSON(
@@ -44,6 +46,7 @@ final class ConcurrentStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'CompoundStatement',
     );
     $offset += $statement->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ConditionalExpression.hack
+++ b/codegen/syntax/ConditionalExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0bea6749ad282b20a3ce20c943ba9b0e>>
+ * @generated SignedSource<<51644b6632ff31ec16be2054b8b1e19e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -41,6 +41,7 @@ final class ConditionalExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $test = Node::fromJSON(
@@ -48,6 +49,7 @@ final class ConditionalExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $test->getWidth();
     $question = Node::fromJSON(
@@ -55,6 +57,7 @@ final class ConditionalExpression
       $file,
       $offset,
       $source,
+      'QuestionToken',
     );
     $offset += $question->getWidth();
     $consequence = Node::fromJSON(
@@ -62,6 +65,7 @@ final class ConditionalExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $consequence->getWidth();
     $colon = Node::fromJSON(
@@ -69,6 +73,7 @@ final class ConditionalExpression
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $colon->getWidth();
     $alternative = Node::fromJSON(
@@ -76,6 +81,7 @@ final class ConditionalExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $alternative->getWidth();
     $source_ref = shape(
@@ -157,9 +163,8 @@ final class ConditionalExpression
    * ScopeResolutionExpression | SubscriptExpression | NameToken |
    * VariableExpression
    */
-  <<__Memoize>>
   public function getTest(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_test);
+    return TypeAssert\instance_of(IExpression::class, $this->_test);
   }
 
   /**
@@ -239,12 +244,11 @@ final class ConditionalExpression
    * ScopeResolutionExpression | ShapeExpression | SubscriptExpression |
    * NameToken | VariableExpression
    */
-  <<__Memoize>>
   public function getConsequence(): ?IExpression {
     if ($this->_consequence->isMissing()) {
       return null;
     }
-    return __Private\Wrap\wrap_IExpression($this->_consequence);
+    return TypeAssert\instance_of(IExpression::class, $this->_consequence);
   }
 
   /**
@@ -325,9 +329,8 @@ final class ConditionalExpression
    * | ScopeResolutionExpression | SubscriptExpression | NameToken |
    * VariableExpression
    */
-  <<__Memoize>>
   public function getAlternative(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_alternative);
+    return TypeAssert\instance_of(IExpression::class, $this->_alternative);
   }
 
   /**

--- a/codegen/syntax/ConstDeclaration.hack
+++ b/codegen/syntax/ConstDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5b83391d4a301984615f746d3370aa0a>>
+ * @generated SignedSource<<da542a3dd6a74d762ca043818bf74335>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -42,6 +42,7 @@ final class ConstDeclaration extends Node implements IClassBodyDeclaration {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $visibility = Node::fromJSON(
@@ -49,6 +50,7 @@ final class ConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $visibility->getWidth();
     $abstract = Node::fromJSON(
@@ -56,6 +58,7 @@ final class ConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'AbstractToken',
     );
     $offset += $abstract->getWidth();
     $keyword = Node::fromJSON(
@@ -63,6 +66,7 @@ final class ConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'ConstToken',
     );
     $offset += $keyword->getWidth();
     $type_specifier = Node::fromJSON(
@@ -70,6 +74,7 @@ final class ConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type_specifier->getWidth();
     $declarators = Node::fromJSON(
@@ -77,6 +82,7 @@ final class ConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ConstantDeclarator>>',
     );
     $offset += $declarators->getWidth();
     $semicolon = Node::fromJSON(
@@ -84,6 +90,7 @@ final class ConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ConstantDeclarator.hack
+++ b/codegen/syntax/ConstantDeclarator.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<24f4b143d3fee5f903edcacbbb824776>>
+ * @generated SignedSource<<1e70d4e2ba13265ee4302833eca0ee29>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class ConstantDeclarator extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $name = Node::fromJSON(
@@ -37,6 +38,7 @@ final class ConstantDeclarator extends Node {
       $file,
       $offset,
       $source,
+      'NameToken',
     );
     $offset += $name->getWidth();
     $initializer = Node::fromJSON(
@@ -44,6 +46,7 @@ final class ConstantDeclarator extends Node {
       $file,
       $offset,
       $source,
+      'SimpleInitializer',
     );
     $offset += $initializer->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ConstructorCall.hack
+++ b/codegen/syntax/ConstructorCall.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8259505aba81bc48aeea6931821156d7>>
+ * @generated SignedSource<<250c41c40a038151bed2878a7c855d55>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class ConstructorCall extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $type = Node::fromJSON(
@@ -43,6 +44,7 @@ final class ConstructorCall extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $type->getWidth();
     $left_paren = Node::fromJSON(
@@ -50,6 +52,7 @@ final class ConstructorCall extends Node {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $argument_list = Node::fromJSON(
@@ -57,6 +60,7 @@ final class ConstructorCall extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IExpression>>',
     );
     $offset += $argument_list->getWidth();
     $right_paren = Node::fromJSON(
@@ -64,6 +68,7 @@ final class ConstructorCall extends Node {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ContinueStatement.hack
+++ b/codegen/syntax/ContinueStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ec522902ead4d0bae02d5f138c27045a>>
+ * @generated SignedSource<<de8038ac28b42d02bfb885e759754f04>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class ContinueStatement extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -40,6 +41,7 @@ final class ContinueStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'ContinueToken',
     );
     $offset += $keyword->getWidth();
     $level = Node::fromJSON(
@@ -47,6 +49,7 @@ final class ContinueStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'LiteralExpression',
     );
     $offset += $level->getWidth();
     $semicolon = Node::fromJSON(
@@ -54,6 +57,7 @@ final class ContinueStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/DarrayIntrinsicExpression.hack
+++ b/codegen/syntax/DarrayIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b420b9f5f338c99ad98e9db3a56087d3>>
+ * @generated SignedSource<<63ff928219984605dc9b2062ddae0dfd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -41,6 +41,7 @@ final class DarrayIntrinsicExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -48,6 +49,7 @@ final class DarrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'DarrayToken',
     );
     $offset += $keyword->getWidth();
     $explicit_type = Node::fromJSON(
@@ -55,6 +57,7 @@ final class DarrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'TypeArguments',
     );
     $offset += $explicit_type->getWidth();
     $left_bracket = Node::fromJSON(
@@ -62,6 +65,7 @@ final class DarrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'LeftBracketToken',
     );
     $offset += $left_bracket->getWidth();
     $members = Node::fromJSON(
@@ -69,6 +73,7 @@ final class DarrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ElementInitializer>>',
     );
     $offset += $members->getWidth();
     $right_bracket = Node::fromJSON(
@@ -76,6 +81,7 @@ final class DarrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'RightBracketToken',
     );
     $offset += $right_bracket->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/DarrayTypeSpecifier.hack
+++ b/codegen/syntax/DarrayTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e885be27563003416a58eef94695c508>>
+ * @generated SignedSource<<30da85d5c1ca19c9a1f627c29ca20220>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -45,6 +45,7 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -52,6 +53,7 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'DarrayToken',
     );
     $offset += $keyword->getWidth();
     $left_angle = Node::fromJSON(
@@ -59,6 +61,7 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'LessThanToken',
     );
     $offset += $left_angle->getWidth();
     $key = Node::fromJSON(
@@ -66,6 +69,7 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'SimpleTypeSpecifier',
     );
     $offset += $key->getWidth();
     $comma = Node::fromJSON(
@@ -73,6 +77,7 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'CommaToken',
     );
     $offset += $comma->getWidth();
     $value = Node::fromJSON(
@@ -80,6 +85,7 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $value->getWidth();
     $trailing_comma = Node::fromJSON(
@@ -87,6 +93,7 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $trailing_comma->getWidth();
     $right_angle = Node::fromJSON(
@@ -94,6 +101,7 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'GreaterThanToken',
     );
     $offset += $right_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/DecoratedExpression.hack
+++ b/codegen/syntax/DecoratedExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5367ac34e8cedada04e7fa4b1b101b0f>>
+ * @generated SignedSource<<63013fc119ba4f23be89c5a896d84a1c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -32,6 +32,7 @@ final class DecoratedExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $decorator = Node::fromJSON(
@@ -39,6 +40,7 @@ final class DecoratedExpression
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $decorator->getWidth();
     $expression = Node::fromJSON(
@@ -46,6 +48,7 @@ final class DecoratedExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $expression->getWidth();
     $source_ref = shape(
@@ -130,9 +133,8 @@ final class DecoratedExpression
    * DecoratedExpression | FunctionCallExpression | ScopeResolutionExpression |
    * SubscriptExpression | VariableToken | VariableExpression
    */
-  <<__Memoize>>
   public function getExpression(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_expression);
+    return TypeAssert\instance_of(IExpression::class, $this->_expression);
   }
 
   /**

--- a/codegen/syntax/DefaultLabel.hack
+++ b/codegen/syntax/DefaultLabel.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5bb8838ff1c67a83a00d9e2e0e4a8a8b>>
+ * @generated SignedSource<<5e2f7f283b5fdd95e39c6d6a90fe219c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class DefaultLabel extends Node implements ISwitchLabel {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -37,6 +38,7 @@ final class DefaultLabel extends Node implements ISwitchLabel {
       $file,
       $offset,
       $source,
+      'DefaultToken',
     );
     $offset += $keyword->getWidth();
     $colon = Node::fromJSON(
@@ -44,6 +46,7 @@ final class DefaultLabel extends Node implements ISwitchLabel {
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $colon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/DefineExpression.hack
+++ b/codegen/syntax/DefineExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f5aed472035efba637f3e665d796cedc>>
+ * @generated SignedSource<<bf785d861225663d290c497fdf095a7c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class DefineExpression extends Node implements ILambdaBody, IExpression {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class DefineExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -50,6 +52,7 @@ final class DefineExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $left_paren->getWidth();
     $argument_list = Node::fromJSON(
@@ -57,6 +60,7 @@ final class DefineExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $argument_list->getWidth();
     $right_paren = Node::fromJSON(
@@ -64,6 +68,7 @@ final class DefineExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/DictionaryIntrinsicExpression.hack
+++ b/codegen/syntax/DictionaryIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bbea14d1754a05761ecbdd40b8e53c81>>
+ * @generated SignedSource<<364002e7dc71225f57fc499f37c46c6e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -41,6 +41,7 @@ final class DictionaryIntrinsicExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -48,6 +49,7 @@ final class DictionaryIntrinsicExpression
       $file,
       $offset,
       $source,
+      'DictToken',
     );
     $offset += $keyword->getWidth();
     $explicit_type = Node::fromJSON(
@@ -55,6 +57,7 @@ final class DictionaryIntrinsicExpression
       $file,
       $offset,
       $source,
+      'TypeArguments',
     );
     $offset += $explicit_type->getWidth();
     $left_bracket = Node::fromJSON(
@@ -62,6 +65,7 @@ final class DictionaryIntrinsicExpression
       $file,
       $offset,
       $source,
+      'LeftBracketToken',
     );
     $offset += $left_bracket->getWidth();
     $members = Node::fromJSON(
@@ -69,6 +73,7 @@ final class DictionaryIntrinsicExpression
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ElementInitializer>>',
     );
     $offset += $members->getWidth();
     $right_bracket = Node::fromJSON(
@@ -76,6 +81,7 @@ final class DictionaryIntrinsicExpression
       $file,
       $offset,
       $source,
+      'RightBracketToken',
     );
     $offset += $right_bracket->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/DictionaryTypeSpecifier.hack
+++ b/codegen/syntax/DictionaryTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c8936d41f858f428e73f4da212e45b36>>
+ * @generated SignedSource<<8364839b82a761a57403280578a583c9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class DictionaryTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class DictionaryTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'DictToken',
     );
     $offset += $keyword->getWidth();
     $left_angle = Node::fromJSON(
@@ -50,6 +52,7 @@ final class DictionaryTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'LessThanToken',
     );
     $offset += $left_angle->getWidth();
     $members = Node::fromJSON(
@@ -57,6 +60,7 @@ final class DictionaryTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ITypeSpecifier>>',
     );
     $offset += $members->getWidth();
     $right_angle = Node::fromJSON(
@@ -64,6 +68,7 @@ final class DictionaryTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'GreaterThanToken',
     );
     $offset += $right_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/DoStatement.hack
+++ b/codegen/syntax/DoStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7a926154a006db4185204e7c127c1330>>
+ * @generated SignedSource<<8dc31e20a946786d224ea7f6b2ca4655>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -47,6 +47,7 @@ final class DoStatement
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -54,6 +55,7 @@ final class DoStatement
       $file,
       $offset,
       $source,
+      'DoToken',
     );
     $offset += $keyword->getWidth();
     $body = Node::fromJSON(
@@ -61,6 +63,7 @@ final class DoStatement
       $file,
       $offset,
       $source,
+      'IStatement',
     );
     $offset += $body->getWidth();
     $while_keyword = Node::fromJSON(
@@ -68,6 +71,7 @@ final class DoStatement
       $file,
       $offset,
       $source,
+      'WhileToken',
     );
     $offset += $while_keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -75,6 +79,7 @@ final class DoStatement
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $condition = Node::fromJSON(
@@ -82,6 +87,7 @@ final class DoStatement
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $condition->getWidth();
     $right_paren = Node::fromJSON(
@@ -89,6 +95,7 @@ final class DoStatement
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $semicolon = Node::fromJSON(
@@ -96,6 +103,7 @@ final class DoStatement
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(
@@ -339,9 +347,8 @@ final class DoStatement
    * @return BinaryExpression | FunctionCallExpression | LiteralExpression |
    * PrefixUnaryExpression | SubscriptExpression | VariableExpression
    */
-  <<__Memoize>>
   public function getCondition(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_condition);
+    return TypeAssert\instance_of(IExpression::class, $this->_condition);
   }
 
   /**

--- a/codegen/syntax/EchoStatement.hack
+++ b/codegen/syntax/EchoStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c597b24b32483ea76f7044ea946b97df>>
+ * @generated SignedSource<<77b27e354fc18a4cdfb388dc190c322f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class EchoStatement extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -40,6 +41,7 @@ final class EchoStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'EchoToken',
     );
     $offset += $keyword->getWidth();
     $expressions = Node::fromJSON(
@@ -47,6 +49,7 @@ final class EchoStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IExpression>>',
     );
     $offset += $expressions->getWidth();
     $semicolon = Node::fromJSON(
@@ -54,6 +57,7 @@ final class EchoStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ElementInitializer.hack
+++ b/codegen/syntax/ElementInitializer.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<02af91c1bcd9a97e99962ad03fa71688>>
+ * @generated SignedSource<<eaa44c633341d0a77f93de8048fb69dd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class ElementInitializer extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $key = Node::fromJSON(
@@ -40,6 +41,7 @@ final class ElementInitializer extends Node {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $key->getWidth();
     $arrow = Node::fromJSON(
@@ -47,6 +49,7 @@ final class ElementInitializer extends Node {
       $file,
       $offset,
       $source,
+      'EqualGreaterThanToken',
     );
     $offset += $arrow->getWidth();
     $value = Node::fromJSON(
@@ -54,6 +57,7 @@ final class ElementInitializer extends Node {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $value->getWidth();
     $source_ref = shape(
@@ -116,9 +120,8 @@ final class ElementInitializer extends Node {
    * ScopeResolutionExpression | SubscriptExpression | NameToken |
    * VariableExpression
    */
-  <<__Memoize>>
   public function getKey(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_key);
+    return TypeAssert\instance_of(IExpression::class, $this->_key);
   }
 
   /**
@@ -189,9 +192,8 @@ final class ElementInitializer extends Node {
    * NameToken | TupleExpression | VariableExpression |
    * VarrayIntrinsicExpression | VectorIntrinsicExpression
    */
-  <<__Memoize>>
   public function getValue(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_value);
+    return TypeAssert\instance_of(IExpression::class, $this->_value);
   }
 
   /**

--- a/codegen/syntax/ElseClause.hack
+++ b/codegen/syntax/ElseClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<090388527790386422eb12469af103dc>>
+ * @generated SignedSource<<e6656be91871cd5827eba2edc8631047>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class ElseClause extends Node implements IControlFlowStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -37,6 +38,7 @@ final class ElseClause extends Node implements IControlFlowStatement {
       $file,
       $offset,
       $source,
+      'ElseToken',
     );
     $offset += $keyword->getWidth();
     $statement = Node::fromJSON(
@@ -44,6 +46,7 @@ final class ElseClause extends Node implements IControlFlowStatement {
       $file,
       $offset,
       $source,
+      'IStatement',
     );
     $offset += $statement->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ElseifClause.hack
+++ b/codegen/syntax/ElseifClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e0b8805f7d858f6eb572f7959318f780>>
+ * @generated SignedSource<<d267de316252933283c1e761267097d3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -39,6 +39,7 @@ final class ElseifClause extends Node implements IControlFlowStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -46,6 +47,7 @@ final class ElseifClause extends Node implements IControlFlowStatement {
       $file,
       $offset,
       $source,
+      'ElseifToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -53,6 +55,7 @@ final class ElseifClause extends Node implements IControlFlowStatement {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $condition = Node::fromJSON(
@@ -60,6 +63,7 @@ final class ElseifClause extends Node implements IControlFlowStatement {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $condition->getWidth();
     $right_paren = Node::fromJSON(
@@ -67,6 +71,7 @@ final class ElseifClause extends Node implements IControlFlowStatement {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $statement = Node::fromJSON(
@@ -74,6 +79,7 @@ final class ElseifClause extends Node implements IControlFlowStatement {
       $file,
       $offset,
       $source,
+      'IStatement',
     );
     $offset += $statement->getWidth();
     $source_ref = shape(
@@ -227,9 +233,8 @@ final class ElseifClause extends Node implements IControlFlowStatement {
    * @return BinaryExpression | FunctionCallExpression | LiteralExpression |
    * VariableExpression
    */
-  <<__Memoize>>
   public function getCondition(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_condition);
+    return TypeAssert\instance_of(IExpression::class, $this->_condition);
   }
 
   /**

--- a/codegen/syntax/EmbeddedBracedExpression.hack
+++ b/codegen/syntax/EmbeddedBracedExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<366906cd5886b2ad20b59200bd34f713>>
+ * @generated SignedSource<<2975b528fead91803c8451f619ccc8b7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class EmbeddedBracedExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_brace = Node::fromJSON(
@@ -42,6 +43,7 @@ final class EmbeddedBracedExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $left_brace->getWidth();
     $expression = Node::fromJSON(
@@ -49,6 +51,7 @@ final class EmbeddedBracedExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $expression->getWidth();
     $right_brace = Node::fromJSON(
@@ -56,6 +59,7 @@ final class EmbeddedBracedExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $right_brace->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/EmbeddedMemberSelectionExpression.hack
+++ b/codegen/syntax/EmbeddedMemberSelectionExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8dfc0fccc655bd1550872f5d72a31b62>>
+ * @generated SignedSource<<ff5aa4bb4aaa72ead0d87b4ca9d437cb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class EmbeddedMemberSelectionExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $object = Node::fromJSON(
@@ -42,6 +43,7 @@ final class EmbeddedMemberSelectionExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $object->getWidth();
     $operator = Node::fromJSON(
@@ -49,6 +51,7 @@ final class EmbeddedMemberSelectionExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $operator->getWidth();
     $name = Node::fromJSON(
@@ -56,6 +59,7 @@ final class EmbeddedMemberSelectionExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/EmbeddedSubscriptExpression.hack
+++ b/codegen/syntax/EmbeddedSubscriptExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c5293db3f5c9aa1c28d1dd1d469ae468>>
+ * @generated SignedSource<<a59ad50a4fccce3ce7dfa0ae45409976>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -38,6 +38,7 @@ final class EmbeddedSubscriptExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $receiver = Node::fromJSON(
@@ -45,6 +46,7 @@ final class EmbeddedSubscriptExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $receiver->getWidth();
     $left_bracket = Node::fromJSON(
@@ -52,6 +54,7 @@ final class EmbeddedSubscriptExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $left_bracket->getWidth();
     $index = Node::fromJSON(
@@ -59,6 +62,7 @@ final class EmbeddedSubscriptExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $index->getWidth();
     $right_bracket = Node::fromJSON(
@@ -66,6 +70,7 @@ final class EmbeddedSubscriptExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $right_bracket->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/EndOfFile.hack
+++ b/codegen/syntax/EndOfFile.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<63cdc7100dc8dc828d90a89adb93d805>>
+ * @generated SignedSource<<a79d4fffd42d9e7c7268c6341108e7ed>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -27,6 +27,7 @@ final class EndOfFile extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $token = Node::fromJSON(
@@ -34,6 +35,7 @@ final class EndOfFile extends Node {
       $file,
       $offset,
       $source,
+      'EndOfFileToken',
     );
     $offset += $token->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/EnumDeclaration.hack
+++ b/codegen/syntax/EnumDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3cb2ef422a1dfefcec33b0e300092767>>
+ * @generated SignedSource<<b7cb7aaf0e75bec4254ba8e74b4f1a32>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -51,6 +51,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute_spec = Node::fromJSON(
@@ -58,6 +59,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'AttributeSpecification',
     );
     $offset += $attribute_spec->getWidth();
     $keyword = Node::fromJSON(
@@ -65,6 +67,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'EnumToken',
     );
     $offset += $keyword->getWidth();
     $name = Node::fromJSON(
@@ -72,6 +75,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'NameToken',
     );
     $offset += $name->getWidth();
     $colon = Node::fromJSON(
@@ -79,6 +83,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $colon->getWidth();
     $base = Node::fromJSON(
@@ -86,6 +91,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $base->getWidth();
     $type = Node::fromJSON(
@@ -93,6 +99,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'TypeConstraint',
     );
     $offset += $type->getWidth();
     $left_brace = Node::fromJSON(
@@ -100,6 +107,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'LeftBraceToken',
     );
     $offset += $left_brace->getWidth();
     $enumerators = Node::fromJSON(
@@ -107,6 +115,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'NodeList<Enumerator>',
     );
     $offset += $enumerators->getWidth();
     $right_brace = Node::fromJSON(
@@ -114,6 +123,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
+      'RightBraceToken',
     );
     $offset += $right_brace->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/Enumerator.hack
+++ b/codegen/syntax/Enumerator.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4bee579cf32a5bc1da29738f9040709e>>
+ * @generated SignedSource<<f409a8808a38de3135b483f02c74f612>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class Enumerator extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $name = Node::fromJSON(
@@ -43,6 +44,7 @@ final class Enumerator extends Node {
       $file,
       $offset,
       $source,
+      'NameToken',
     );
     $offset += $name->getWidth();
     $equal = Node::fromJSON(
@@ -50,6 +52,7 @@ final class Enumerator extends Node {
       $file,
       $offset,
       $source,
+      'EqualToken',
     );
     $offset += $equal->getWidth();
     $value = Node::fromJSON(
@@ -57,6 +60,7 @@ final class Enumerator extends Node {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $value->getWidth();
     $semicolon = Node::fromJSON(
@@ -64,6 +68,7 @@ final class Enumerator extends Node {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(
@@ -183,9 +188,8 @@ final class Enumerator extends Node {
    * @return BinaryExpression | LiteralExpression | ScopeResolutionExpression |
    * NameToken
    */
-  <<__Memoize>>
   public function getValue(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_value);
+    return TypeAssert\instance_of(IExpression::class, $this->_value);
   }
 
   /**

--- a/codegen/syntax/ErrorSyntax.hack
+++ b/codegen/syntax/ErrorSyntax.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f9fc9a94b0f3d0efc2e3744419726907>>
+ * @generated SignedSource<<44c099a88227667432fb6ffb346c8502>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -27,6 +27,7 @@ final class ErrorSyntax extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $error = Node::fromJSON(
@@ -34,6 +35,7 @@ final class ErrorSyntax extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $error->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/EvalExpression.hack
+++ b/codegen/syntax/EvalExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cb6a373381404ac5e2e8c8297185916d>>
+ * @generated SignedSource<<882032352082d90f39c0b7cebd00e80e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class EvalExpression extends Node implements ILambdaBody, IExpression {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class EvalExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'EvalToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -50,6 +52,7 @@ final class EvalExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $argument = Node::fromJSON(
@@ -57,6 +60,7 @@ final class EvalExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $argument->getWidth();
     $right_paren = Node::fromJSON(
@@ -64,6 +68,7 @@ final class EvalExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(
@@ -204,9 +209,8 @@ final class EvalExpression extends Node implements ILambdaBody, IExpression {
    * @return BinaryExpression | FunctionCallExpression | LiteralExpression |
    * VariableExpression
    */
-  <<__Memoize>>
   public function getArgument(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_argument);
+    return TypeAssert\instance_of(IExpression::class, $this->_argument);
   }
 
   /**

--- a/codegen/syntax/ExpressionStatement.hack
+++ b/codegen/syntax/ExpressionStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<29ccb52d6a1df80a539a28015edd6d64>>
+ * @generated SignedSource<<6f46d0e50788d2906e212bc865acb907>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class ExpressionStatement extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $expression = Node::fromJSON(
@@ -37,6 +38,7 @@ final class ExpressionStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $expression->getWidth();
     $semicolon = Node::fromJSON(
@@ -44,6 +46,7 @@ final class ExpressionStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(
@@ -107,12 +110,11 @@ final class ExpressionStatement extends Node implements IStatement {
    * VarrayIntrinsicExpression | XHPExpression | YieldExpression |
    * YieldFromExpression
    */
-  <<__Memoize>>
   public function getExpression(): ?IExpression {
     if ($this->_expression->isMissing()) {
       return null;
     }
-    return __Private\Wrap\wrap_IExpression($this->_expression);
+    return TypeAssert\instance_of(IExpression::class, $this->_expression);
   }
 
   /**

--- a/codegen/syntax/FieldInitializer.hack
+++ b/codegen/syntax/FieldInitializer.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f556023f693fc62ad6fc3803cc4bd188>>
+ * @generated SignedSource<<a0fab761aa9ef08401088d4a9d95f174>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class FieldInitializer extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $name = Node::fromJSON(
@@ -40,6 +41,7 @@ final class FieldInitializer extends Node {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $name->getWidth();
     $arrow = Node::fromJSON(
@@ -47,6 +49,7 @@ final class FieldInitializer extends Node {
       $file,
       $offset,
       $source,
+      'EqualGreaterThanToken',
     );
     $offset += $arrow->getWidth();
     $value = Node::fromJSON(
@@ -54,6 +57,7 @@ final class FieldInitializer extends Node {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $value->getWidth();
     $source_ref = shape(
@@ -111,9 +115,8 @@ final class FieldInitializer extends Node {
   /**
    * @return LiteralExpression | ScopeResolutionExpression
    */
-  <<__Memoize>>
   public function getName(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_name);
+    return TypeAssert\instance_of(IExpression::class, $this->_name);
   }
 
   /**
@@ -173,9 +176,8 @@ final class FieldInitializer extends Node {
    * ObjectCreationExpression | ScopeResolutionExpression | SubscriptExpression
    * | VariableExpression
    */
-  <<__Memoize>>
   public function getValue(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_value);
+    return TypeAssert\instance_of(IExpression::class, $this->_value);
   }
 
   /**

--- a/codegen/syntax/FieldSpecifier.hack
+++ b/codegen/syntax/FieldSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<39836ee7cf15cf6750c8383b3b74dafc>>
+ * @generated SignedSource<<66fe0a6d24e32470ed7fc0e9f0059d3f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class FieldSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $question = Node::fromJSON(
@@ -43,6 +44,7 @@ final class FieldSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'QuestionToken',
     );
     $offset += $question->getWidth();
     $name = Node::fromJSON(
@@ -50,6 +52,7 @@ final class FieldSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $name->getWidth();
     $arrow = Node::fromJSON(
@@ -57,6 +60,7 @@ final class FieldSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'EqualGreaterThanToken',
     );
     $offset += $arrow->getWidth();
     $type = Node::fromJSON(
@@ -64,6 +68,7 @@ final class FieldSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $source_ref = shape(
@@ -156,9 +161,8 @@ final class FieldSpecifier extends Node implements ITypeSpecifier {
   /**
    * @return LiteralExpression | ScopeResolutionExpression
    */
-  <<__Memoize>>
   public function getName(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_name);
+    return TypeAssert\instance_of(IExpression::class, $this->_name);
   }
 
   /**

--- a/codegen/syntax/FileAttributeSpecification.hack
+++ b/codegen/syntax/FileAttributeSpecification.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e1ed69eb780525592e9e89c72ed834db>>
+ * @generated SignedSource<<ea886d2dc463cdce81327cd0c408e0c7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -39,6 +39,7 @@ final class FileAttributeSpecification extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_double_angle = Node::fromJSON(
@@ -46,6 +47,7 @@ final class FileAttributeSpecification extends Node {
       $file,
       $offset,
       $source,
+      'LessThanLessThanToken',
     );
     $offset += $left_double_angle->getWidth();
     $keyword = Node::fromJSON(
@@ -53,6 +55,7 @@ final class FileAttributeSpecification extends Node {
       $file,
       $offset,
       $source,
+      'FileToken',
     );
     $offset += $keyword->getWidth();
     $colon = Node::fromJSON(
@@ -60,6 +63,7 @@ final class FileAttributeSpecification extends Node {
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $colon->getWidth();
     $attributes = Node::fromJSON(
@@ -67,6 +71,7 @@ final class FileAttributeSpecification extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ConstructorCall>>',
     );
     $offset += $attributes->getWidth();
     $right_double_angle = Node::fromJSON(
@@ -74,6 +79,7 @@ final class FileAttributeSpecification extends Node {
       $file,
       $offset,
       $source,
+      'GreaterThanGreaterThanToken',
     );
     $offset += $right_double_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/FinallyClause.hack
+++ b/codegen/syntax/FinallyClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<23e1da3161960618c8421c0539b57628>>
+ * @generated SignedSource<<7f5abaecbe53a04e8ad88eb1783590cb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class FinallyClause extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -37,6 +38,7 @@ final class FinallyClause extends Node {
       $file,
       $offset,
       $source,
+      'FinallyToken',
     );
     $offset += $keyword->getWidth();
     $body = Node::fromJSON(
@@ -44,6 +46,7 @@ final class FinallyClause extends Node {
       $file,
       $offset,
       $source,
+      'CompoundStatement',
     );
     $offset += $body->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ForStatement.hack
+++ b/codegen/syntax/ForStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bc564c5d626e713a6c1fdcaa12040bcf>>
+ * @generated SignedSource<<bc969f73143bfe64782fbc4549a54170>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -53,6 +53,7 @@ final class ForStatement
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -60,6 +61,7 @@ final class ForStatement
       $file,
       $offset,
       $source,
+      'ForToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -67,6 +69,7 @@ final class ForStatement
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $initializer = Node::fromJSON(
@@ -74,6 +77,7 @@ final class ForStatement
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IExpression>>',
     );
     $offset += $initializer->getWidth();
     $first_semicolon = Node::fromJSON(
@@ -81,6 +85,7 @@ final class ForStatement
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $first_semicolon->getWidth();
     $control = Node::fromJSON(
@@ -88,6 +93,7 @@ final class ForStatement
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IExpression>>',
     );
     $offset += $control->getWidth();
     $second_semicolon = Node::fromJSON(
@@ -95,6 +101,7 @@ final class ForStatement
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $second_semicolon->getWidth();
     $end_of_loop = Node::fromJSON(
@@ -102,6 +109,7 @@ final class ForStatement
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IExpression>>',
     );
     $offset += $end_of_loop->getWidth();
     $right_paren = Node::fromJSON(
@@ -109,6 +117,7 @@ final class ForStatement
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $body = Node::fromJSON(
@@ -116,6 +125,7 @@ final class ForStatement
       $file,
       $offset,
       $source,
+      'IStatement',
     );
     $offset += $body->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ForeachStatement.hack
+++ b/codegen/syntax/ForeachStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5532a2fe340e80628c50f391692656c3>>
+ * @generated SignedSource<<0aed06c1d62a792de472a50231a32bdb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -56,6 +56,7 @@ final class ForeachStatement
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -63,6 +64,7 @@ final class ForeachStatement
       $file,
       $offset,
       $source,
+      'ForeachToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -70,6 +72,7 @@ final class ForeachStatement
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $collection = Node::fromJSON(
@@ -77,6 +80,7 @@ final class ForeachStatement
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $collection->getWidth();
     $await_keyword = Node::fromJSON(
@@ -84,6 +88,7 @@ final class ForeachStatement
       $file,
       $offset,
       $source,
+      'AwaitToken',
     );
     $offset += $await_keyword->getWidth();
     $as = Node::fromJSON(
@@ -91,6 +96,7 @@ final class ForeachStatement
       $file,
       $offset,
       $source,
+      'AsToken',
     );
     $offset += $as->getWidth();
     $key = Node::fromJSON(
@@ -98,6 +104,7 @@ final class ForeachStatement
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $key->getWidth();
     $arrow = Node::fromJSON(
@@ -105,6 +112,7 @@ final class ForeachStatement
       $file,
       $offset,
       $source,
+      'EqualGreaterThanToken',
     );
     $offset += $arrow->getWidth();
     $value = Node::fromJSON(
@@ -112,6 +120,7 @@ final class ForeachStatement
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $value->getWidth();
     $right_paren = Node::fromJSON(
@@ -119,6 +128,7 @@ final class ForeachStatement
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $body = Node::fromJSON(
@@ -126,6 +136,7 @@ final class ForeachStatement
       $file,
       $offset,
       $source,
+      'IStatement',
     );
     $offset += $body->getWidth();
     $source_ref = shape(
@@ -323,9 +334,8 @@ final class ForeachStatement
    * | ScopeResolutionExpression | SubscriptExpression | NameToken |
    * VariableExpression | VectorIntrinsicExpression
    */
-  <<__Memoize>>
   public function getCollection(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_collection);
+    return TypeAssert\instance_of(IExpression::class, $this->_collection);
   }
 
   /**
@@ -453,12 +463,11 @@ final class ForeachStatement
    * @return ListExpression | MemberSelectionExpression | null |
    * ScopeResolutionExpression | SubscriptExpression | VariableExpression
    */
-  <<__Memoize>>
   public function getKey(): ?IExpression {
     if ($this->_key->isMissing()) {
       return null;
     }
-    return __Private\Wrap\wrap_IExpression($this->_key);
+    return TypeAssert\instance_of(IExpression::class, $this->_key);
   }
 
   /**
@@ -542,9 +551,8 @@ final class ForeachStatement
    * @return ListExpression | MemberSelectionExpression |
    * ScopeResolutionExpression | SubscriptExpression | VariableExpression
    */
-  <<__Memoize>>
   public function getValue(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_value);
+    return TypeAssert\instance_of(IExpression::class, $this->_value);
   }
 
   /**

--- a/codegen/syntax/FunctionCallExpression.hack
+++ b/codegen/syntax/FunctionCallExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<88470f643ba82b71916a3a5b5fd18a0a>>
+ * @generated SignedSource<<d54b1a198f8a7a173a36cd3e76ef3dc9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -41,6 +41,7 @@ final class FunctionCallExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $receiver = Node::fromJSON(
@@ -48,6 +49,7 @@ final class FunctionCallExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $receiver->getWidth();
     $type_args = Node::fromJSON(
@@ -55,6 +57,7 @@ final class FunctionCallExpression
       $file,
       $offset,
       $source,
+      'TypeArguments',
     );
     $offset += $type_args->getWidth();
     $left_paren = Node::fromJSON(
@@ -62,6 +65,7 @@ final class FunctionCallExpression
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $argument_list = Node::fromJSON(
@@ -69,6 +73,7 @@ final class FunctionCallExpression
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IExpression>>',
     );
     $offset += $argument_list->getWidth();
     $right_paren = Node::fromJSON(
@@ -76,6 +81,7 @@ final class FunctionCallExpression
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/FunctionDeclaration.hack
+++ b/codegen/syntax/FunctionDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<14f3a9a7e4fb5750485d4941ff2c3bc1>>
+ * @generated SignedSource<<18efd766b549697d1dadc96261ee7971>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class FunctionDeclaration
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute_spec = Node::fromJSON(
@@ -42,6 +43,7 @@ final class FunctionDeclaration
       $file,
       $offset,
       $source,
+      'AttributeSpecification',
     );
     $offset += $attribute_spec->getWidth();
     $declaration_header = Node::fromJSON(
@@ -49,6 +51,7 @@ final class FunctionDeclaration
       $file,
       $offset,
       $source,
+      'FunctionDeclarationHeader',
     );
     $offset += $declaration_header->getWidth();
     $body = Node::fromJSON(
@@ -56,6 +59,7 @@ final class FunctionDeclaration
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $body->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/FunctionDeclarationHeader.hack
+++ b/codegen/syntax/FunctionDeclarationHeader.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9225194eaaec971791daa8c46b77de4b>>
+ * @generated SignedSource<<68a976e87d6302184ee2703cf306cc04>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -54,6 +54,7 @@ final class FunctionDeclarationHeader extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $modifiers = Node::fromJSON(
@@ -61,6 +62,7 @@ final class FunctionDeclarationHeader extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<Token>',
     );
     $offset += $modifiers->getWidth();
     $keyword = Node::fromJSON(
@@ -68,6 +70,7 @@ final class FunctionDeclarationHeader extends Node {
       $file,
       $offset,
       $source,
+      'FunctionToken',
     );
     $offset += $keyword->getWidth();
     $name = Node::fromJSON(
@@ -75,6 +78,7 @@ final class FunctionDeclarationHeader extends Node {
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $name->getWidth();
     $type_parameter_list = Node::fromJSON(
@@ -82,6 +86,7 @@ final class FunctionDeclarationHeader extends Node {
       $file,
       $offset,
       $source,
+      'TypeParameters',
     );
     $offset += $type_parameter_list->getWidth();
     $left_paren = Node::fromJSON(
@@ -89,6 +94,7 @@ final class FunctionDeclarationHeader extends Node {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $parameter_list = Node::fromJSON(
@@ -96,6 +102,7 @@ final class FunctionDeclarationHeader extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IParameter>>',
     );
     $offset += $parameter_list->getWidth();
     $right_paren = Node::fromJSON(
@@ -103,6 +110,7 @@ final class FunctionDeclarationHeader extends Node {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $colon = Node::fromJSON(
@@ -110,6 +118,7 @@ final class FunctionDeclarationHeader extends Node {
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $colon->getWidth();
     $type = Node::fromJSON(
@@ -117,6 +126,7 @@ final class FunctionDeclarationHeader extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $type->getWidth();
     $where_clause = Node::fromJSON(
@@ -124,6 +134,7 @@ final class FunctionDeclarationHeader extends Node {
       $file,
       $offset,
       $source,
+      'WhereClause',
     );
     $offset += $where_clause->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/GenericTypeSpecifier.hack
+++ b/codegen/syntax/GenericTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9251c4c85f59d81be07131a4fd2f96e1>>
+ * @generated SignedSource<<6e39412924f6aebd44ab7a4e227c1061>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -32,6 +32,7 @@ final class GenericTypeSpecifier
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $class_type = Node::fromJSON(
@@ -39,6 +40,7 @@ final class GenericTypeSpecifier
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $class_type->getWidth();
     $argument_list = Node::fromJSON(
@@ -46,6 +48,7 @@ final class GenericTypeSpecifier
       $file,
       $offset,
       $source,
+      'TypeArguments',
     );
     $offset += $argument_list->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/GotoLabel.hack
+++ b/codegen/syntax/GotoLabel.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<65378173ef7d341793f153ba5db43a06>>
+ * @generated SignedSource<<e44f8fc05aaf91e263c64e72442a39da>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class GotoLabel extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $name = Node::fromJSON(
@@ -37,6 +38,7 @@ final class GotoLabel extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'NameToken',
     );
     $offset += $name->getWidth();
     $colon = Node::fromJSON(
@@ -44,6 +46,7 @@ final class GotoLabel extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $colon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/GotoStatement.hack
+++ b/codegen/syntax/GotoStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<094cf4e944bdaa77586512eb2f882ce0>>
+ * @generated SignedSource<<0f1aa40f6c9ddc5030fec8b4a5fd6db3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class GotoStatement extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -40,6 +41,7 @@ final class GotoStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'GotoToken',
     );
     $offset += $keyword->getWidth();
     $label_name = Node::fromJSON(
@@ -47,6 +49,7 @@ final class GotoStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'NameToken',
     );
     $offset += $label_name->getWidth();
     $semicolon = Node::fromJSON(
@@ -54,6 +57,7 @@ final class GotoStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/HaltCompilerExpression.hack
+++ b/codegen/syntax/HaltCompilerExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<eaf6935e52a7dfe0b87c6ab1bc018cef>>
+ * @generated SignedSource<<d8e26266fb923d9b99eaa4895e028cf1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -38,6 +38,7 @@ final class HaltCompilerExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -45,6 +46,7 @@ final class HaltCompilerExpression
       $file,
       $offset,
       $source,
+      'HaltCompilerToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -52,6 +54,7 @@ final class HaltCompilerExpression
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $argument_list = Node::fromJSON(
@@ -59,6 +62,7 @@ final class HaltCompilerExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $argument_list->getWidth();
     $right_paren = Node::fromJSON(
@@ -66,6 +70,7 @@ final class HaltCompilerExpression
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/IfStatement.hack
+++ b/codegen/syntax/IfStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<37e1848f69eb5eafc31ba6f71c470a21>>
+ * @generated SignedSource<<1bfc73a7aebf0ddb3668ab5a27f73611>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -47,6 +47,7 @@ final class IfStatement
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -54,6 +55,7 @@ final class IfStatement
       $file,
       $offset,
       $source,
+      'IfToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -61,6 +63,7 @@ final class IfStatement
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $condition = Node::fromJSON(
@@ -68,6 +71,7 @@ final class IfStatement
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $condition->getWidth();
     $right_paren = Node::fromJSON(
@@ -75,6 +79,7 @@ final class IfStatement
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $statement = Node::fromJSON(
@@ -82,6 +87,7 @@ final class IfStatement
       $file,
       $offset,
       $source,
+      'IStatement',
     );
     $offset += $statement->getWidth();
     $elseif_clauses = Node::fromJSON(
@@ -89,6 +95,7 @@ final class IfStatement
       $file,
       $offset,
       $source,
+      'NodeList<ElseifClause>',
     );
     $offset += $elseif_clauses->getWidth();
     $else_clause = Node::fromJSON(
@@ -96,6 +103,7 @@ final class IfStatement
       $file,
       $offset,
       $source,
+      'ElseClause',
     );
     $offset += $else_clause->getWidth();
     $source_ref = shape(
@@ -269,9 +277,8 @@ final class IfStatement
    * PrefixUnaryExpression | QualifiedName | ScopeResolutionExpression |
    * SubscriptExpression | NameToken | VariableExpression
    */
-  <<__Memoize>>
   public function getCondition(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_condition);
+    return TypeAssert\instance_of(IExpression::class, $this->_condition);
   }
 
   /**

--- a/codegen/syntax/InclusionDirective.hack
+++ b/codegen/syntax/InclusionDirective.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<30f840368fc59f57625e41f54d2f7b9f>>
+ * @generated SignedSource<<b27ec9d2cc7b01211fdac942391021ac>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class InclusionDirective extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $expression = Node::fromJSON(
@@ -37,6 +38,7 @@ final class InclusionDirective extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'InclusionExpression',
     );
     $offset += $expression->getWidth();
     $semicolon = Node::fromJSON(
@@ -44,6 +46,7 @@ final class InclusionDirective extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/InclusionExpression.hack
+++ b/codegen/syntax/InclusionExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b5c99ec91efa628b3a7d099f8e0f687c>>
+ * @generated SignedSource<<894e892a4bee6b21934fae278530b638>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -32,6 +32,7 @@ final class InclusionExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $require = Node::fromJSON(
@@ -39,6 +40,7 @@ final class InclusionExpression
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $require->getWidth();
     $filename = Node::fromJSON(
@@ -46,6 +48,7 @@ final class InclusionExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $filename->getWidth();
     $source_ref = shape(
@@ -127,9 +130,8 @@ final class InclusionExpression
    * @return BinaryExpression | LiteralExpression | ParenthesizedExpression |
    * SubscriptExpression | NameToken | VariableExpression
    */
-  <<__Memoize>>
   public function getFilename(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_filename);
+    return TypeAssert\instance_of(IExpression::class, $this->_filename);
   }
 
   /**

--- a/codegen/syntax/InstanceofExpression.hack
+++ b/codegen/syntax/InstanceofExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<195f581cf5be7f250339842127bb6104>>
+ * @generated SignedSource<<ca799afa61c0ae3d9d46ef62dde14cbc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class InstanceofExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_operand = Node::fromJSON(
@@ -42,6 +43,7 @@ final class InstanceofExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $left_operand->getWidth();
     $operator = Node::fromJSON(
@@ -49,6 +51,7 @@ final class InstanceofExpression
       $file,
       $offset,
       $source,
+      'InstanceofToken',
     );
     $offset += $operator->getWidth();
     $right_operand = Node::fromJSON(
@@ -56,6 +59,7 @@ final class InstanceofExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $right_operand->getWidth();
     $source_ref = shape(
@@ -116,9 +120,8 @@ final class InstanceofExpression
    * ParenthesizedExpression | PipeVariableExpression | PrefixUnaryExpression |
    * ScopeResolutionExpression | SubscriptExpression | VariableExpression
    */
-  <<__Memoize>>
   public function getLeftOperand(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_left_operand);
+    return TypeAssert\instance_of(IExpression::class, $this->_left_operand);
   }
 
   /**

--- a/codegen/syntax/IsExpression.hack
+++ b/codegen/syntax/IsExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cac643f49d65e5194508fd5c915abfb5>>
+ * @generated SignedSource<<6a01525df35f18816765a5b9f7a76e2c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class IsExpression extends Node implements ILambdaBody, IExpression {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_operand = Node::fromJSON(
@@ -40,6 +41,7 @@ final class IsExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $left_operand->getWidth();
     $operator = Node::fromJSON(
@@ -47,6 +49,7 @@ final class IsExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'IsToken',
     );
     $offset += $operator->getWidth();
     $right_operand = Node::fromJSON(
@@ -54,6 +57,7 @@ final class IsExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $right_operand->getWidth();
     $source_ref = shape(
@@ -113,9 +117,8 @@ final class IsExpression extends Node implements ILambdaBody, IExpression {
    * ObjectCreationExpression | PipeVariableExpression | PrefixUnaryExpression
    * | VariableExpression
    */
-  <<__Memoize>>
   public function getLeftOperand(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_left_operand);
+    return TypeAssert\instance_of(IExpression::class, $this->_left_operand);
   }
 
   /**

--- a/codegen/syntax/IssetExpression.hack
+++ b/codegen/syntax/IssetExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<020ef5988b345353976529471cfe0f72>>
+ * @generated SignedSource<<d1c8f8f48a1c42bef447f5d060944e80>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class IssetExpression extends Node implements ILambdaBody, IExpression {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class IssetExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'IssetToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -50,6 +52,7 @@ final class IssetExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $argument_list = Node::fromJSON(
@@ -57,6 +60,7 @@ final class IssetExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IExpression>>',
     );
     $offset += $argument_list->getWidth();
     $right_paren = Node::fromJSON(
@@ -64,6 +68,7 @@ final class IssetExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/KeysetIntrinsicExpression.hack
+++ b/codegen/syntax/KeysetIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<aa9cf34d745a6dab394a4c0b13fbc3d3>>
+ * @generated SignedSource<<eba6187998dd2fe0dafd21a75ed316b1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -41,6 +41,7 @@ final class KeysetIntrinsicExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -48,6 +49,7 @@ final class KeysetIntrinsicExpression
       $file,
       $offset,
       $source,
+      'KeysetToken',
     );
     $offset += $keyword->getWidth();
     $explicit_type = Node::fromJSON(
@@ -55,6 +57,7 @@ final class KeysetIntrinsicExpression
       $file,
       $offset,
       $source,
+      'TypeArguments',
     );
     $offset += $explicit_type->getWidth();
     $left_bracket = Node::fromJSON(
@@ -62,6 +65,7 @@ final class KeysetIntrinsicExpression
       $file,
       $offset,
       $source,
+      'LeftBracketToken',
     );
     $offset += $left_bracket->getWidth();
     $members = Node::fromJSON(
@@ -69,6 +73,7 @@ final class KeysetIntrinsicExpression
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IExpression>>',
     );
     $offset += $members->getWidth();
     $right_bracket = Node::fromJSON(
@@ -76,6 +81,7 @@ final class KeysetIntrinsicExpression
       $file,
       $offset,
       $source,
+      'RightBracketToken',
     );
     $offset += $right_bracket->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/KeysetTypeSpecifier.hack
+++ b/codegen/syntax/KeysetTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bda371a84bdb80b65fdd41f0213e70f9>>
+ * @generated SignedSource<<0439b6b67876c3c73acaa140499560a3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -39,6 +39,7 @@ final class KeysetTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -46,6 +47,7 @@ final class KeysetTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'KeysetToken',
     );
     $offset += $keyword->getWidth();
     $left_angle = Node::fromJSON(
@@ -53,6 +55,7 @@ final class KeysetTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'LessThanToken',
     );
     $offset += $left_angle->getWidth();
     $type = Node::fromJSON(
@@ -60,6 +63,7 @@ final class KeysetTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $trailing_comma = Node::fromJSON(
@@ -67,6 +71,7 @@ final class KeysetTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $trailing_comma->getWidth();
     $right_angle = Node::fromJSON(
@@ -74,6 +79,7 @@ final class KeysetTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'GreaterThanToken',
     );
     $offset += $right_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/LambdaExpression.hack
+++ b/codegen/syntax/LambdaExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<19098dbd1b284204aa23b76441d2ad7e>>
+ * @generated SignedSource<<e0d8a2561c170dc146c72b7ccac92676>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -44,6 +44,7 @@ final class LambdaExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute_spec = Node::fromJSON(
@@ -51,6 +52,7 @@ final class LambdaExpression
       $file,
       $offset,
       $source,
+      'AttributeSpecification',
     );
     $offset += $attribute_spec->getWidth();
     $async = Node::fromJSON(
@@ -58,6 +60,7 @@ final class LambdaExpression
       $file,
       $offset,
       $source,
+      'AsyncToken',
     );
     $offset += $async->getWidth();
     $coroutine = Node::fromJSON(
@@ -65,6 +68,7 @@ final class LambdaExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $coroutine->getWidth();
     $signature = Node::fromJSON(
@@ -72,6 +76,7 @@ final class LambdaExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $signature->getWidth();
     $arrow = Node::fromJSON(
@@ -79,6 +84,7 @@ final class LambdaExpression
       $file,
       $offset,
       $source,
+      'EqualEqualGreaterThanToken',
     );
     $offset += $arrow->getWidth();
     $body = Node::fromJSON(
@@ -86,6 +92,7 @@ final class LambdaExpression
       $file,
       $offset,
       $source,
+      'ILambdaBody',
     );
     $offset += $body->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/LambdaSignature.hack
+++ b/codegen/syntax/LambdaSignature.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c87d3103b23b5df837162c8e3696facd>>
+ * @generated SignedSource<<89b79d84e1b45b532d3906ebfdbfb227>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -39,6 +39,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_paren = Node::fromJSON(
@@ -46,6 +47,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $parameters = Node::fromJSON(
@@ -53,6 +55,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IParameter>>',
     );
     $offset += $parameters->getWidth();
     $right_paren = Node::fromJSON(
@@ -60,6 +63,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $colon = Node::fromJSON(
@@ -67,6 +71,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $colon->getWidth();
     $type = Node::fromJSON(
@@ -74,6 +79,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/LetStatement.hack
+++ b/codegen/syntax/LetStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8ca6457ee798b819e34ac74067d9aa4f>>
+ * @generated SignedSource<<6fa80650d0bbdb26b3258510177ffaf2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -42,6 +42,7 @@ final class LetStatement extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -49,6 +50,7 @@ final class LetStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $keyword->getWidth();
     $name = Node::fromJSON(
@@ -56,6 +58,7 @@ final class LetStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $colon = Node::fromJSON(
@@ -63,6 +66,7 @@ final class LetStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $colon->getWidth();
     $type = Node::fromJSON(
@@ -70,6 +74,7 @@ final class LetStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $type->getWidth();
     $initializer = Node::fromJSON(
@@ -77,6 +82,7 @@ final class LetStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $initializer->getWidth();
     $semicolon = Node::fromJSON(
@@ -84,6 +90,7 @@ final class LetStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/LikeTypeSpecifier.hack
+++ b/codegen/syntax/LikeTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6d8faec3ac3febbb3a93dbd1db3c4e51>>
+ * @generated SignedSource<<0d8d6db37d832ce5c35db9b7f65aa977>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class LikeTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $tilde = Node::fromJSON(
@@ -37,6 +38,7 @@ final class LikeTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'TildeToken',
     );
     $offset += $tilde->getWidth();
     $type = Node::fromJSON(
@@ -44,6 +46,7 @@ final class LikeTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ListExpression.hack
+++ b/codegen/syntax/ListExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a91fa65bebaeb5f7f450ac4a7d00bc86>>
+ * @generated SignedSource<<70d6d883ca9ca0229197c4eaee7588b2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class ListExpression extends Node implements ILambdaBody, IExpression {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class ListExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'ListToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -50,6 +52,7 @@ final class ListExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $members = Node::fromJSON(
@@ -57,6 +60,7 @@ final class ListExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<?IExpression>>',
     );
     $offset += $members->getWidth();
     $right_paren = Node::fromJSON(
@@ -64,6 +68,7 @@ final class ListExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/LiteralExpression.hack
+++ b/codegen/syntax/LiteralExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2df3c44b8ff68d475bf99be752c5a56f>>
+ * @generated SignedSource<<871827f8c4883a32ae792ff4ecc7b36f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -27,6 +27,7 @@ final class LiteralExpression extends Node implements ILambdaBody, IExpression {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $expression = Node::fromJSON(
@@ -34,6 +35,7 @@ final class LiteralExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $expression->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/MapArrayTypeSpecifier.hack
+++ b/codegen/syntax/MapArrayTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bff3fb4a0d90970593444cecc98dc7c8>>
+ * @generated SignedSource<<6dd98be1aad2e0e357678f87fe7b601d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -42,6 +42,7 @@ final class MapArrayTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -49,6 +50,7 @@ final class MapArrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ArrayToken',
     );
     $offset += $keyword->getWidth();
     $left_angle = Node::fromJSON(
@@ -56,6 +58,7 @@ final class MapArrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'LessThanToken',
     );
     $offset += $left_angle->getWidth();
     $key = Node::fromJSON(
@@ -63,6 +66,7 @@ final class MapArrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'SimpleTypeSpecifier',
     );
     $offset += $key->getWidth();
     $comma = Node::fromJSON(
@@ -70,6 +74,7 @@ final class MapArrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'CommaToken',
     );
     $offset += $comma->getWidth();
     $value = Node::fromJSON(
@@ -77,6 +82,7 @@ final class MapArrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $value->getWidth();
     $right_angle = Node::fromJSON(
@@ -84,6 +90,7 @@ final class MapArrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'GreaterThanToken',
     );
     $offset += $right_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/MarkupSection.hack
+++ b/codegen/syntax/MarkupSection.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<47ab62e35bdf83d501f03e9b27554a95>>
+ * @generated SignedSource<<c8ff2912c7fcc447392e8a2a13faa2fc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class MarkupSection extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $prefix = Node::fromJSON(
@@ -43,6 +44,7 @@ final class MarkupSection extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $prefix->getWidth();
     $text = Node::fromJSON(
@@ -50,6 +52,7 @@ final class MarkupSection extends Node {
       $file,
       $offset,
       $source,
+      'MarkupToken',
     );
     $offset += $text->getWidth();
     $suffix = Node::fromJSON(
@@ -57,6 +60,7 @@ final class MarkupSection extends Node {
       $file,
       $offset,
       $source,
+      'MarkupSuffix',
     );
     $offset += $suffix->getWidth();
     $expression = Node::fromJSON(
@@ -64,6 +68,7 @@ final class MarkupSection extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $expression->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/MarkupSuffix.hack
+++ b/codegen/syntax/MarkupSuffix.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<57dd68a94c836e06b1542a2fefa896dd>>
+ * @generated SignedSource<<5a09c017d5d8cdbe96d06dbf2b494ad4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class MarkupSuffix extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $less_than_question = Node::fromJSON(
@@ -37,6 +38,7 @@ final class MarkupSuffix extends Node {
       $file,
       $offset,
       $source,
+      'LessThanQuestionToken',
     );
     $offset += $less_than_question->getWidth();
     $name = Node::fromJSON(
@@ -44,6 +46,7 @@ final class MarkupSuffix extends Node {
       $file,
       $offset,
       $source,
+      'NameToken',
     );
     $offset += $name->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/MemberSelectionExpression.hack
+++ b/codegen/syntax/MemberSelectionExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b9cc312d583d8529bd599af7edf73ac2>>
+ * @generated SignedSource<<82e3b281688487f1f2029fc20ccba6ed>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class MemberSelectionExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $object = Node::fromJSON(
@@ -42,6 +43,7 @@ final class MemberSelectionExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $object->getWidth();
     $operator = Node::fromJSON(
@@ -49,6 +51,7 @@ final class MemberSelectionExpression
       $file,
       $offset,
       $source,
+      'MinusGreaterThanToken',
     );
     $offset += $operator->getWidth();
     $name = Node::fromJSON(
@@ -56,6 +59,7 @@ final class MemberSelectionExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $source_ref = shape(
@@ -116,9 +120,8 @@ final class MemberSelectionExpression
    * PipeVariableExpression | SafeMemberSelectionExpression |
    * ScopeResolutionExpression | SubscriptExpression | VariableExpression
    */
-  <<__Memoize>>
   public function getObject(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_object);
+    return TypeAssert\instance_of(IExpression::class, $this->_object);
   }
 
   /**

--- a/codegen/syntax/MethodishDeclaration.hack
+++ b/codegen/syntax/MethodishDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a9388b48f0c75c5094ee204375aa20b2>>
+ * @generated SignedSource<<36373e73e084d7ea5bea56cef214e4ef>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -42,6 +42,7 @@ abstract class MethodishDeclarationGeneratedBase
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute = Node::fromJSON(
@@ -49,6 +50,7 @@ abstract class MethodishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'AttributeSpecification',
     );
     $offset += $attribute->getWidth();
     $function_decl_header = Node::fromJSON(
@@ -56,6 +58,7 @@ abstract class MethodishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'FunctionDeclarationHeader',
     );
     $offset += $function_decl_header->getWidth();
     $function_body = Node::fromJSON(
@@ -63,6 +66,7 @@ abstract class MethodishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'CompoundStatement',
     );
     $offset += $function_body->getWidth();
     $semicolon = Node::fromJSON(
@@ -70,6 +74,7 @@ abstract class MethodishDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/MethodishTraitResolution.hack
+++ b/codegen/syntax/MethodishTraitResolution.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d7119b0af909d245db89424c5315c040>>
+ * @generated SignedSource<<8b731ddef412e725f7f75a4f369afb13>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -41,6 +41,7 @@ final class MethodishTraitResolution
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute = Node::fromJSON(
@@ -48,6 +49,7 @@ final class MethodishTraitResolution
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $attribute->getWidth();
     $function_decl_header = Node::fromJSON(
@@ -55,6 +57,7 @@ final class MethodishTraitResolution
       $file,
       $offset,
       $source,
+      'FunctionDeclarationHeader',
     );
     $offset += $function_decl_header->getWidth();
     $equal = Node::fromJSON(
@@ -62,6 +65,7 @@ final class MethodishTraitResolution
       $file,
       $offset,
       $source,
+      'EqualToken',
     );
     $offset += $equal->getWidth();
     $name = Node::fromJSON(
@@ -69,6 +73,7 @@ final class MethodishTraitResolution
       $file,
       $offset,
       $source,
+      'ScopeResolutionExpression',
     );
     $offset += $name->getWidth();
     $semicolon = Node::fromJSON(
@@ -76,6 +81,7 @@ final class MethodishTraitResolution
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/NamespaceBody.hack
+++ b/codegen/syntax/NamespaceBody.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c34a7f583858332c2129955c781f803c>>
+ * @generated SignedSource<<a04291c78f6bd9f23074270f4e2a2625>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class NamespaceBody extends Node implements INamespaceBody {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_brace = Node::fromJSON(
@@ -40,6 +41,7 @@ final class NamespaceBody extends Node implements INamespaceBody {
       $file,
       $offset,
       $source,
+      'LeftBraceToken',
     );
     $offset += $left_brace->getWidth();
     $declarations = Node::fromJSON(
@@ -47,6 +49,7 @@ final class NamespaceBody extends Node implements INamespaceBody {
       $file,
       $offset,
       $source,
+      'NodeList<Node>',
     );
     $offset += $declarations->getWidth();
     $right_brace = Node::fromJSON(
@@ -54,6 +57,7 @@ final class NamespaceBody extends Node implements INamespaceBody {
       $file,
       $offset,
       $source,
+      'RightBraceToken',
     );
     $offset += $right_brace->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/NamespaceDeclaration.hack
+++ b/codegen/syntax/NamespaceDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<17fb78e0196c0a2afae66e73360c90cc>>
+ * @generated SignedSource<<a2895f18d8e8986de8d08ae76c32ca5c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ abstract class NamespaceDeclarationGeneratedBase extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -40,6 +41,7 @@ abstract class NamespaceDeclarationGeneratedBase extends Node {
       $file,
       $offset,
       $source,
+      'NamespaceToken',
     );
     $offset += $keyword->getWidth();
     $name = Node::fromJSON(
@@ -47,6 +49,7 @@ abstract class NamespaceDeclarationGeneratedBase extends Node {
       $file,
       $offset,
       $source,
+      'INameishNode',
     );
     $offset += $name->getWidth();
     $body = Node::fromJSON(
@@ -54,6 +57,7 @@ abstract class NamespaceDeclarationGeneratedBase extends Node {
       $file,
       $offset,
       $source,
+      'INamespaceBody',
     );
     $offset += $body->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/NamespaceEmptyBody.hack
+++ b/codegen/syntax/NamespaceEmptyBody.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<20fde7b8c3faac85cbb1639a96f513b0>>
+ * @generated SignedSource<<d9419c540e074269ba854c45982ce6fd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -27,6 +27,7 @@ final class NamespaceEmptyBody extends Node implements INamespaceBody {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $semicolon = Node::fromJSON(
@@ -34,6 +35,7 @@ final class NamespaceEmptyBody extends Node implements INamespaceBody {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/NamespaceGroupUseDeclaration.hack
+++ b/codegen/syntax/NamespaceGroupUseDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<95b5820b8150b15d8b91b2ba16d9f3e1>>
+ * @generated SignedSource<<188844105e5ec996df6b03e1dbe14943>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -47,6 +47,7 @@ final class NamespaceGroupUseDeclaration
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -54,6 +55,7 @@ final class NamespaceGroupUseDeclaration
       $file,
       $offset,
       $source,
+      'UseToken',
     );
     $offset += $keyword->getWidth();
     $kind = Node::fromJSON(
@@ -61,6 +63,7 @@ final class NamespaceGroupUseDeclaration
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $kind->getWidth();
     $prefix = Node::fromJSON(
@@ -68,6 +71,7 @@ final class NamespaceGroupUseDeclaration
       $file,
       $offset,
       $source,
+      'QualifiedName',
     );
     $offset += $prefix->getWidth();
     $left_brace = Node::fromJSON(
@@ -75,6 +79,7 @@ final class NamespaceGroupUseDeclaration
       $file,
       $offset,
       $source,
+      'LeftBraceToken',
     );
     $offset += $left_brace->getWidth();
     $clauses = Node::fromJSON(
@@ -82,6 +87,7 @@ final class NamespaceGroupUseDeclaration
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<NamespaceUseClause>>',
     );
     $offset += $clauses->getWidth();
     $right_brace = Node::fromJSON(
@@ -89,6 +95,7 @@ final class NamespaceGroupUseDeclaration
       $file,
       $offset,
       $source,
+      'RightBraceToken',
     );
     $offset += $right_brace->getWidth();
     $semicolon = Node::fromJSON(
@@ -96,6 +103,7 @@ final class NamespaceGroupUseDeclaration
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/NamespaceUseClause.hack
+++ b/codegen/syntax/NamespaceUseClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<976c9e9047bea667bcfda25ef00d9d9d>>
+ * @generated SignedSource<<c4b899c30af1d90134c547de3c7dbf19>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class NamespaceUseClause extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $clause_kind = Node::fromJSON(
@@ -43,6 +44,7 @@ final class NamespaceUseClause extends Node {
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $clause_kind->getWidth();
     $name = Node::fromJSON(
@@ -50,6 +52,7 @@ final class NamespaceUseClause extends Node {
       $file,
       $offset,
       $source,
+      'INameishNode',
     );
     $offset += $name->getWidth();
     $as = Node::fromJSON(
@@ -57,6 +60,7 @@ final class NamespaceUseClause extends Node {
       $file,
       $offset,
       $source,
+      'AsToken',
     );
     $offset += $as->getWidth();
     $alias = Node::fromJSON(
@@ -64,6 +68,7 @@ final class NamespaceUseClause extends Node {
       $file,
       $offset,
       $source,
+      'NameToken',
     );
     $offset += $alias->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/NamespaceUseDeclaration.hack
+++ b/codegen/syntax/NamespaceUseDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<88410c279e201735d7746b39b21d1ec4>>
+ * @generated SignedSource<<60b8d171a9a015620885587259b1bf97>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -38,6 +38,7 @@ final class NamespaceUseDeclaration
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -45,6 +46,7 @@ final class NamespaceUseDeclaration
       $file,
       $offset,
       $source,
+      'UseToken',
     );
     $offset += $keyword->getWidth();
     $kind = Node::fromJSON(
@@ -52,6 +54,7 @@ final class NamespaceUseDeclaration
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $kind->getWidth();
     $clauses = Node::fromJSON(
@@ -59,6 +62,7 @@ final class NamespaceUseDeclaration
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<NamespaceUseClause>>',
     );
     $offset += $clauses->getWidth();
     $semicolon = Node::fromJSON(
@@ -66,6 +70,7 @@ final class NamespaceUseDeclaration
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/NullableAsExpression.hack
+++ b/codegen/syntax/NullableAsExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f54af527bb07dadcac5e42fb191e5a6b>>
+ * @generated SignedSource<<8c616416416e6bb192d62846be701e87>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class NullableAsExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_operand = Node::fromJSON(
@@ -42,6 +43,7 @@ final class NullableAsExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $left_operand->getWidth();
     $operator = Node::fromJSON(
@@ -49,6 +51,7 @@ final class NullableAsExpression
       $file,
       $offset,
       $source,
+      'QuestionAsToken',
     );
     $offset += $operator->getWidth();
     $right_operand = Node::fromJSON(
@@ -56,6 +59,7 @@ final class NullableAsExpression
       $file,
       $offset,
       $source,
+      'SimpleTypeSpecifier',
     );
     $offset += $right_operand->getWidth();
     $source_ref = shape(
@@ -113,9 +117,8 @@ final class NullableAsExpression
   /**
    * @return FunctionCallExpression | VariableExpression
    */
-  <<__Memoize>>
   public function getLeftOperand(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_left_operand);
+    return TypeAssert\instance_of(IExpression::class, $this->_left_operand);
   }
 
   /**

--- a/codegen/syntax/NullableTypeSpecifier.hack
+++ b/codegen/syntax/NullableTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<630457e709bd8e27cd75fec4b2105e81>>
+ * @generated SignedSource<<a8a52e1f40ce6a8d28a65992f79a0127>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class NullableTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $question = Node::fromJSON(
@@ -37,6 +38,7 @@ final class NullableTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'QuestionToken',
     );
     $offset += $question->getWidth();
     $type = Node::fromJSON(
@@ -44,6 +46,7 @@ final class NullableTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ObjectCreationExpression.hack
+++ b/codegen/syntax/ObjectCreationExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<368a2014ec663c4bbf081ffdbd67b986>>
+ * @generated SignedSource<<243837dea5303bb8a6d73a7c9a92670b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -32,6 +32,7 @@ final class ObjectCreationExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $new_keyword = Node::fromJSON(
@@ -39,6 +40,7 @@ final class ObjectCreationExpression
       $file,
       $offset,
       $source,
+      'NewToken',
     );
     $offset += $new_keyword->getWidth();
     $object = Node::fromJSON(
@@ -46,6 +48,7 @@ final class ObjectCreationExpression
       $file,
       $offset,
       $source,
+      'ConstructorCall',
     );
     $offset += $object->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ParameterDeclaration.hack
+++ b/codegen/syntax/ParameterDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d03393f6c1ac7d4d77bfd51bf4a15502>>
+ * @generated SignedSource<<c4801c2d0713b191d5768dfd5ee1fcbe>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -44,6 +44,7 @@ abstract class ParameterDeclarationGeneratedBase
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute = Node::fromJSON(
@@ -51,6 +52,7 @@ abstract class ParameterDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'AttributeSpecification',
     );
     $offset += $attribute->getWidth();
     $visibility = Node::fromJSON(
@@ -58,6 +60,7 @@ abstract class ParameterDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $visibility->getWidth();
     $call_convention = Node::fromJSON(
@@ -65,6 +68,7 @@ abstract class ParameterDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'InoutToken',
     );
     $offset += $call_convention->getWidth();
     $type = Node::fromJSON(
@@ -72,6 +76,7 @@ abstract class ParameterDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $name = Node::fromJSON(
@@ -79,6 +84,7 @@ abstract class ParameterDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $name->getWidth();
     $default_value = Node::fromJSON(
@@ -86,6 +92,7 @@ abstract class ParameterDeclarationGeneratedBase
       $file,
       $offset,
       $source,
+      'SimpleInitializer',
     );
     $offset += $default_value->getWidth();
     $source_ref = shape(
@@ -343,9 +350,8 @@ abstract class ParameterDeclarationGeneratedBase
   /**
    * @return DecoratedExpression | VariableToken
    */
-  <<__Memoize>>
   public function getName(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_name);
+    return TypeAssert\instance_of(IExpression::class, $this->_name);
   }
 
   /**

--- a/codegen/syntax/ParenthesizedExpression.hack
+++ b/codegen/syntax/ParenthesizedExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0f2ecf6b6033245f50757112f91da14b>>
+ * @generated SignedSource<<da3b641d34a5b5a4c796df37f71ac4dc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class ParenthesizedExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_paren = Node::fromJSON(
@@ -42,6 +43,7 @@ final class ParenthesizedExpression
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $expression = Node::fromJSON(
@@ -49,6 +51,7 @@ final class ParenthesizedExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $expression->getWidth();
     $right_paren = Node::fromJSON(
@@ -56,6 +59,7 @@ final class ParenthesizedExpression
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(
@@ -150,9 +154,8 @@ final class ParenthesizedExpression
    * NameToken | VariableExpression | VectorIntrinsicExpression | XHPExpression
    * | YieldExpression
    */
-  <<__Memoize>>
   public function getExpression(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_expression);
+    return TypeAssert\instance_of(IExpression::class, $this->_expression);
   }
 
   /**

--- a/codegen/syntax/Php7AnonymousFunction.hack
+++ b/codegen/syntax/Php7AnonymousFunction.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bcfad2a054ef1b938391f8cf3dcb8cac>>
+ * @generated SignedSource<<5d6303a0c8b5dc27043e2c970b9e00c9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -62,6 +62,7 @@ final class Php7AnonymousFunction
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute_spec = Node::fromJSON(
@@ -69,6 +70,7 @@ final class Php7AnonymousFunction
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $attribute_spec->getWidth();
     $static_keyword = Node::fromJSON(
@@ -76,6 +78,7 @@ final class Php7AnonymousFunction
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $static_keyword->getWidth();
     $async_keyword = Node::fromJSON(
@@ -83,6 +86,7 @@ final class Php7AnonymousFunction
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $async_keyword->getWidth();
     $coroutine_keyword = Node::fromJSON(
@@ -90,6 +94,7 @@ final class Php7AnonymousFunction
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $coroutine_keyword->getWidth();
     $function_keyword = Node::fromJSON(
@@ -97,6 +102,7 @@ final class Php7AnonymousFunction
       $file,
       $offset,
       $source,
+      'FunctionToken',
     );
     $offset += $function_keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -104,6 +110,7 @@ final class Php7AnonymousFunction
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $parameters = Node::fromJSON(
@@ -111,6 +118,7 @@ final class Php7AnonymousFunction
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $parameters->getWidth();
     $right_paren = Node::fromJSON(
@@ -118,6 +126,7 @@ final class Php7AnonymousFunction
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $use = Node::fromJSON(
@@ -125,6 +134,7 @@ final class Php7AnonymousFunction
       $file,
       $offset,
       $source,
+      'AnonymousFunctionUseClause',
     );
     $offset += $use->getWidth();
     $colon = Node::fromJSON(
@@ -132,6 +142,7 @@ final class Php7AnonymousFunction
       $file,
       $offset,
       $source,
+      'ColonToken',
     );
     $offset += $colon->getWidth();
     $type = Node::fromJSON(
@@ -139,6 +150,7 @@ final class Php7AnonymousFunction
       $file,
       $offset,
       $source,
+      'SimpleTypeSpecifier',
     );
     $offset += $type->getWidth();
     $body = Node::fromJSON(
@@ -146,6 +158,7 @@ final class Php7AnonymousFunction
       $file,
       $offset,
       $source,
+      'CompoundStatement',
     );
     $offset += $body->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/PipeVariableExpression.hack
+++ b/codegen/syntax/PipeVariableExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d955ebaa8c2857668e8de4860c77d9e4>>
+ * @generated SignedSource<<324fa33a6188ae7ec41a535e2fcc0047>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -29,6 +29,7 @@ final class PipeVariableExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $expression = Node::fromJSON(
@@ -36,6 +37,7 @@ final class PipeVariableExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $expression->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/PocketAtomExpression.hack
+++ b/codegen/syntax/PocketAtomExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c666615d5bc9e947e9a19635c870b22a>>
+ * @generated SignedSource<<80b3a228a22e337ec78b2c78a5274793>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -32,6 +32,7 @@ final class PocketAtomExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $glyph = Node::fromJSON(
@@ -39,6 +40,7 @@ final class PocketAtomExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $glyph->getWidth();
     $expression = Node::fromJSON(
@@ -46,6 +48,7 @@ final class PocketAtomExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $expression->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/PocketAtomMappingDeclaration.hack
+++ b/codegen/syntax/PocketAtomMappingDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ffb36636fff0f95acb5405aa0705004b>>
+ * @generated SignedSource<<7714f704bf3a975a5ad0f3c5e200425f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -42,6 +42,7 @@ final class PocketAtomMappingDeclaration extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $glyph = Node::fromJSON(
@@ -49,6 +50,7 @@ final class PocketAtomMappingDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $glyph->getWidth();
     $name = Node::fromJSON(
@@ -56,6 +58,7 @@ final class PocketAtomMappingDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $left_paren = Node::fromJSON(
@@ -63,6 +66,7 @@ final class PocketAtomMappingDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $left_paren->getWidth();
     $mappings = Node::fromJSON(
@@ -70,6 +74,7 @@ final class PocketAtomMappingDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $mappings->getWidth();
     $right_paren = Node::fromJSON(
@@ -77,6 +82,7 @@ final class PocketAtomMappingDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $right_paren->getWidth();
     $semicolon = Node::fromJSON(
@@ -84,6 +90,7 @@ final class PocketAtomMappingDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/PocketEnumDeclaration.hack
+++ b/codegen/syntax/PocketEnumDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7a63eaff4c9984bca047a26a75e905b2>>
+ * @generated SignedSource<<3a36a0b8386545b648851d69b3701ce9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -42,6 +42,7 @@ final class PocketEnumDeclaration extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $modifiers = Node::fromJSON(
@@ -49,6 +50,7 @@ final class PocketEnumDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $modifiers->getWidth();
     $enum = Node::fromJSON(
@@ -56,6 +58,7 @@ final class PocketEnumDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $enum->getWidth();
     $name = Node::fromJSON(
@@ -63,6 +66,7 @@ final class PocketEnumDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $left_brace = Node::fromJSON(
@@ -70,6 +74,7 @@ final class PocketEnumDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $left_brace->getWidth();
     $fields = Node::fromJSON(
@@ -77,6 +82,7 @@ final class PocketEnumDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $fields->getWidth();
     $right_brace = Node::fromJSON(
@@ -84,6 +90,7 @@ final class PocketEnumDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $right_brace->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/PocketFieldTypeDeclaration.hack
+++ b/codegen/syntax/PocketFieldTypeDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7953219e47fe3e21cc25a854af99fa6a>>
+ * @generated SignedSource<<4f47413b43df71c99e4cf249acb92cbe>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class PocketFieldTypeDeclaration extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $case = Node::fromJSON(
@@ -43,6 +44,7 @@ final class PocketFieldTypeDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $case->getWidth();
     $type = Node::fromJSON(
@@ -50,6 +52,7 @@ final class PocketFieldTypeDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $type->getWidth();
     $name = Node::fromJSON(
@@ -57,6 +60,7 @@ final class PocketFieldTypeDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $semicolon = Node::fromJSON(
@@ -64,6 +68,7 @@ final class PocketFieldTypeDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/PocketFieldTypeExprDeclaration.hack
+++ b/codegen/syntax/PocketFieldTypeExprDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<eceaf3139c119727d25646ec154517c1>>
+ * @generated SignedSource<<2bbb9da2420e8f5136e4e256203bb60b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class PocketFieldTypeExprDeclaration extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $case = Node::fromJSON(
@@ -43,6 +44,7 @@ final class PocketFieldTypeExprDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $case->getWidth();
     $type = Node::fromJSON(
@@ -50,6 +52,7 @@ final class PocketFieldTypeExprDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $type->getWidth();
     $name = Node::fromJSON(
@@ -57,6 +60,7 @@ final class PocketFieldTypeExprDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $semicolon = Node::fromJSON(
@@ -64,6 +68,7 @@ final class PocketFieldTypeExprDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/PocketIdentifierExpression.hack
+++ b/codegen/syntax/PocketIdentifierExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c47bd741df21d54ea017ba9d9d7842e7>>
+ * @generated SignedSource<<78723bfec8a76d76953b335a1575cae8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -41,6 +41,7 @@ final class PocketIdentifierExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $qualifier = Node::fromJSON(
@@ -48,6 +49,7 @@ final class PocketIdentifierExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $qualifier->getWidth();
     $pu_operator = Node::fromJSON(
@@ -55,6 +57,7 @@ final class PocketIdentifierExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $pu_operator->getWidth();
     $field = Node::fromJSON(
@@ -62,6 +65,7 @@ final class PocketIdentifierExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $field->getWidth();
     $operator = Node::fromJSON(
@@ -69,6 +73,7 @@ final class PocketIdentifierExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $operator->getWidth();
     $name = Node::fromJSON(
@@ -76,6 +81,7 @@ final class PocketIdentifierExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/PocketMappingIdDeclaration.hack
+++ b/codegen/syntax/PocketMappingIdDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b2d7ca5535ee15bc00087c870847570d>>
+ * @generated SignedSource<<de30988b67e3efe63baed23dde08b16b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class PocketMappingIdDeclaration extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $name = Node::fromJSON(
@@ -37,6 +38,7 @@ final class PocketMappingIdDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $initializer = Node::fromJSON(
@@ -44,6 +46,7 @@ final class PocketMappingIdDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $initializer->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/PocketMappingTypeDeclaration.hack
+++ b/codegen/syntax/PocketMappingTypeDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<650e45924bd4b6bb6c7b67d572eefe32>>
+ * @generated SignedSource<<429117f8a19d90254238ad76e82c0919>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class PocketMappingTypeDeclaration extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class PocketMappingTypeDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $keyword->getWidth();
     $name = Node::fromJSON(
@@ -50,6 +52,7 @@ final class PocketMappingTypeDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $equal = Node::fromJSON(
@@ -57,6 +60,7 @@ final class PocketMappingTypeDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $equal->getWidth();
     $type = Node::fromJSON(
@@ -64,6 +68,7 @@ final class PocketMappingTypeDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $type->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/PostfixUnaryExpression.hack
+++ b/codegen/syntax/PostfixUnaryExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<457b099fcd9365daaad94cb88172851f>>
+ * @generated SignedSource<<24867f5ac723493c49195d0a69d32905>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -32,6 +32,7 @@ final class PostfixUnaryExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $operand = Node::fromJSON(
@@ -39,6 +40,7 @@ final class PostfixUnaryExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $operand->getWidth();
     $operator = Node::fromJSON(
@@ -46,6 +48,7 @@ final class PostfixUnaryExpression
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $operator->getWidth();
     $source_ref = shape(
@@ -98,9 +101,8 @@ final class PostfixUnaryExpression
    * @return MemberSelectionExpression | ScopeResolutionExpression |
    * SubscriptExpression | VariableExpression
    */
-  <<__Memoize>>
   public function getOperand(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_operand);
+    return TypeAssert\instance_of(IExpression::class, $this->_operand);
   }
 
   /**

--- a/codegen/syntax/PrefixUnaryExpression.hack
+++ b/codegen/syntax/PrefixUnaryExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bf32fa55a39bdf54d44400868c05bb10>>
+ * @generated SignedSource<<b050fa9e3ce7e698005085d001c7eceb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -32,6 +32,7 @@ final class PrefixUnaryExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $operator = Node::fromJSON(
@@ -39,6 +40,7 @@ final class PrefixUnaryExpression
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $operator->getWidth();
     $operand = Node::fromJSON(
@@ -46,6 +48,7 @@ final class PrefixUnaryExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $operand->getWidth();
     $source_ref = shape(
@@ -138,9 +141,8 @@ final class PrefixUnaryExpression
    * QualifiedName | ScopeResolutionExpression | SubscriptExpression |
    * NameToken | VariableExpression
    */
-  <<__Memoize>>
   public function getOperand(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_operand);
+    return TypeAssert\instance_of(IExpression::class, $this->_operand);
   }
 
   /**

--- a/codegen/syntax/PrefixedStringExpression.hack
+++ b/codegen/syntax/PrefixedStringExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fd4ecc33ecf20ef60b492ef946e66d9e>>
+ * @generated SignedSource<<100b4900ef6544058cba789dfaa9fc95>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -32,6 +32,7 @@ final class PrefixedStringExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $name = Node::fromJSON(
@@ -39,6 +40,7 @@ final class PrefixedStringExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $str = Node::fromJSON(
@@ -46,6 +48,7 @@ final class PrefixedStringExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $str->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/PropertyDeclaration.hack
+++ b/codegen/syntax/PropertyDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<243eac4f15c984749462307510c4a560>>
+ * @generated SignedSource<<95a488a5048a21e14632e000603b10bb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -41,6 +41,7 @@ final class PropertyDeclaration
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute_spec = Node::fromJSON(
@@ -48,6 +49,7 @@ final class PropertyDeclaration
       $file,
       $offset,
       $source,
+      'AttributeSpecification',
     );
     $offset += $attribute_spec->getWidth();
     $modifiers = Node::fromJSON(
@@ -55,6 +57,7 @@ final class PropertyDeclaration
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $modifiers->getWidth();
     $type = Node::fromJSON(
@@ -62,6 +65,7 @@ final class PropertyDeclaration
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $declarators = Node::fromJSON(
@@ -69,6 +73,7 @@ final class PropertyDeclaration
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<PropertyDeclarator>>',
     );
     $offset += $declarators->getWidth();
     $semicolon = Node::fromJSON(
@@ -76,6 +81,7 @@ final class PropertyDeclaration
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/PropertyDeclarator.hack
+++ b/codegen/syntax/PropertyDeclarator.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c61eddfb25d0eb0ab6b73c52b2c930ca>>
+ * @generated SignedSource<<a29b8db49672bff51776daf8a9be065b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class PropertyDeclarator extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $name = Node::fromJSON(
@@ -37,6 +38,7 @@ final class PropertyDeclarator extends Node {
       $file,
       $offset,
       $source,
+      'VariableToken',
     );
     $offset += $name->getWidth();
     $initializer = Node::fromJSON(
@@ -44,6 +46,7 @@ final class PropertyDeclarator extends Node {
       $file,
       $offset,
       $source,
+      'SimpleInitializer',
     );
     $offset += $initializer->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/QualifiedName.hack
+++ b/codegen/syntax/QualifiedName.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7c14907c38daf863c293ca7729c2e0fb>>
+ * @generated SignedSource<<73645230ec3e051a6a8724c4d58710b3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -27,6 +27,7 @@ final class QualifiedName extends Node implements INameishNode {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $parts = Node::fromJSON(
@@ -34,6 +35,7 @@ final class QualifiedName extends Node implements INameishNode {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<?NameToken>>',
     );
     $offset += $parts->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/RecordCreationExpression.hack
+++ b/codegen/syntax/RecordCreationExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9726e1e8a517718b58cd49adbe29301d>>
+ * @generated SignedSource<<eee693aec36182bf3ee2d151db7f56fd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -38,6 +38,7 @@ final class RecordCreationExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $type = Node::fromJSON(
@@ -45,6 +46,7 @@ final class RecordCreationExpression
       $file,
       $offset,
       $source,
+      'NameToken',
     );
     $offset += $type->getWidth();
     $left_bracket = Node::fromJSON(
@@ -52,6 +54,7 @@ final class RecordCreationExpression
       $file,
       $offset,
       $source,
+      'LeftBracketToken',
     );
     $offset += $left_bracket->getWidth();
     $members = Node::fromJSON(
@@ -59,6 +62,7 @@ final class RecordCreationExpression
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ElementInitializer>>',
     );
     $offset += $members->getWidth();
     $right_bracket = Node::fromJSON(
@@ -66,6 +70,7 @@ final class RecordCreationExpression
       $file,
       $offset,
       $source,
+      'RightBracketToken',
     );
     $offset += $right_bracket->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/RecordDeclaration.hack
+++ b/codegen/syntax/RecordDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5bc645da1c817c2aee0310249abf8c6e>>
+ * @generated SignedSource<<1d1090749d73abe156e1ceaae85fe614>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -42,6 +42,7 @@ final class RecordDeclaration extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute_spec = Node::fromJSON(
@@ -49,6 +50,7 @@ final class RecordDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $attribute_spec->getWidth();
     $keyword = Node::fromJSON(
@@ -56,6 +58,7 @@ final class RecordDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $keyword->getWidth();
     $name = Node::fromJSON(
@@ -63,6 +66,7 @@ final class RecordDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $left_brace = Node::fromJSON(
@@ -70,6 +74,7 @@ final class RecordDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $left_brace->getWidth();
     $fields = Node::fromJSON(
@@ -77,6 +82,7 @@ final class RecordDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $fields->getWidth();
     $right_brace = Node::fromJSON(
@@ -84,6 +90,7 @@ final class RecordDeclaration extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $right_brace->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/RecordField.hack
+++ b/codegen/syntax/RecordField.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ebb3f1220724cab5fd268dbd930c5012>>
+ * @generated SignedSource<<f0801335fb93e1d1ddbea52d97b9afbd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -39,6 +39,7 @@ final class RecordField extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $name = Node::fromJSON(
@@ -46,6 +47,7 @@ final class RecordField extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $colon = Node::fromJSON(
@@ -53,6 +55,7 @@ final class RecordField extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $colon->getWidth();
     $type = Node::fromJSON(
@@ -60,6 +63,7 @@ final class RecordField extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $type->getWidth();
     $init = Node::fromJSON(
@@ -67,6 +71,7 @@ final class RecordField extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $init->getWidth();
     $comma = Node::fromJSON(
@@ -74,6 +79,7 @@ final class RecordField extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $comma->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ReifiedTypeArgument.hack
+++ b/codegen/syntax/ReifiedTypeArgument.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9d037bec2fb23a34155b942781023081>>
+ * @generated SignedSource<<b14c86167e72fdea068cf1201ce39af6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class ReifiedTypeArgument extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $reified = Node::fromJSON(
@@ -37,6 +38,7 @@ final class ReifiedTypeArgument extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $reified->getWidth();
     $type = Node::fromJSON(
@@ -44,6 +46,7 @@ final class ReifiedTypeArgument extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $type->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/RequireClause.hack
+++ b/codegen/syntax/RequireClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<97f5ac934d64067749256e4508a115e8>>
+ * @generated SignedSource<<5490f3e831a50a4240c3a3c9e2e31218>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class RequireClause extends Node implements IClassBodyDeclaration {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class RequireClause extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'RequireToken',
     );
     $offset += $keyword->getWidth();
     $kind = Node::fromJSON(
@@ -50,6 +52,7 @@ final class RequireClause extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $kind->getWidth();
     $name = Node::fromJSON(
@@ -57,6 +60,7 @@ final class RequireClause extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'ISimpleCreationSpecifier',
     );
     $offset += $name->getWidth();
     $semicolon = Node::fromJSON(
@@ -64,6 +68,7 @@ final class RequireClause extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ReturnStatement.hack
+++ b/codegen/syntax/ReturnStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a81d7ce2d67cdd241890b69dea50bc02>>
+ * @generated SignedSource<<9a5dee24e4e48095ee1d26dee024df22>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class ReturnStatement extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -40,6 +41,7 @@ final class ReturnStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'ReturnToken',
     );
     $offset += $keyword->getWidth();
     $expression = Node::fromJSON(
@@ -47,6 +49,7 @@ final class ReturnStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $expression->getWidth();
     $semicolon = Node::fromJSON(
@@ -54,6 +57,7 @@ final class ReturnStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(
@@ -152,12 +156,11 @@ final class ReturnStatement extends Node implements IStatement {
    * VariableExpression | VarrayIntrinsicExpression | VectorIntrinsicExpression
    * | XHPExpression | YieldFromExpression
    */
-  <<__Memoize>>
   public function getExpression(): ?IExpression {
     if ($this->_expression->isMissing()) {
       return null;
     }
-    return __Private\Wrap\wrap_IExpression($this->_expression);
+    return TypeAssert\instance_of(IExpression::class, $this->_expression);
   }
 
   /**

--- a/codegen/syntax/SafeMemberSelectionExpression.hack
+++ b/codegen/syntax/SafeMemberSelectionExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e12108a5ed6d9cc671448d6f719fbcb2>>
+ * @generated SignedSource<<122a060f4edf767b566cd42378fd29fb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class SafeMemberSelectionExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $object = Node::fromJSON(
@@ -42,6 +43,7 @@ final class SafeMemberSelectionExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $object->getWidth();
     $operator = Node::fromJSON(
@@ -49,6 +51,7 @@ final class SafeMemberSelectionExpression
       $file,
       $offset,
       $source,
+      'QuestionMinusGreaterThanToken',
     );
     $offset += $operator->getWidth();
     $name = Node::fromJSON(
@@ -56,6 +59,7 @@ final class SafeMemberSelectionExpression
       $file,
       $offset,
       $source,
+      'NameToken',
     );
     $offset += $name->getWidth();
     $source_ref = shape(
@@ -115,9 +119,8 @@ final class SafeMemberSelectionExpression
    * SafeMemberSelectionExpression | ScopeResolutionExpression |
    * VariableExpression
    */
-  <<__Memoize>>
   public function getObject(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_object);
+    return TypeAssert\instance_of(IExpression::class, $this->_object);
   }
 
   /**

--- a/codegen/syntax/ScopeResolutionExpression.hack
+++ b/codegen/syntax/ScopeResolutionExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4f2631604a9eab70d251d0d461961d25>>
+ * @generated SignedSource<<5d6c7266183e68fd9b98502dd92a17a2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class ScopeResolutionExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $qualifier = Node::fromJSON(
@@ -42,6 +43,7 @@ final class ScopeResolutionExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $qualifier->getWidth();
     $operator = Node::fromJSON(
@@ -49,6 +51,7 @@ final class ScopeResolutionExpression
       $file,
       $offset,
       $source,
+      'ColonColonToken',
     );
     $offset += $operator->getWidth();
     $name = Node::fromJSON(
@@ -56,6 +59,7 @@ final class ScopeResolutionExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $name->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/Script.hack
+++ b/codegen/syntax/Script.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<91bc9351db081e6e635dcbd37d89efc0>>
+ * @generated SignedSource<<eb74024e09973bf5bec4a2be7b4ec251>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -27,6 +27,7 @@ abstract class ScriptGeneratedBase extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $declarations = Node::fromJSON(
@@ -34,6 +35,7 @@ abstract class ScriptGeneratedBase extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<Node>',
     );
     $offset += $declarations->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ShapeExpression.hack
+++ b/codegen/syntax/ShapeExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<19a1beac96305cdd7a262e3947d4c6e2>>
+ * @generated SignedSource<<adc24154db926c69086fa452a5ebc67b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class ShapeExpression extends Node implements ILambdaBody, IExpression {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class ShapeExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'ShapeToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -50,6 +52,7 @@ final class ShapeExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $fields = Node::fromJSON(
@@ -57,6 +60,7 @@ final class ShapeExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<FieldInitializer>>',
     );
     $offset += $fields->getWidth();
     $right_paren = Node::fromJSON(
@@ -64,6 +68,7 @@ final class ShapeExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/ShapeTypeSpecifier.hack
+++ b/codegen/syntax/ShapeTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a195c58fdee48d5e441e57878baa4006>>
+ * @generated SignedSource<<23f17706853ed278eccda99d0cb8a24c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -39,6 +39,7 @@ final class ShapeTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -46,6 +47,7 @@ final class ShapeTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ShapeToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -53,6 +55,7 @@ final class ShapeTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $fields = Node::fromJSON(
@@ -60,6 +63,7 @@ final class ShapeTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<FieldSpecifier>>',
     );
     $offset += $fields->getWidth();
     $ellipsis = Node::fromJSON(
@@ -67,6 +71,7 @@ final class ShapeTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'DotDotDotToken',
     );
     $offset += $ellipsis->getWidth();
     $right_paren = Node::fromJSON(
@@ -74,6 +79,7 @@ final class ShapeTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/SimpleInitializer.hack
+++ b/codegen/syntax/SimpleInitializer.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4ccf49eb9f9d317d2385939821cd9df1>>
+ * @generated SignedSource<<af535f7d5805667245cd7bc78756a97a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class SimpleInitializer extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $equal = Node::fromJSON(
@@ -37,6 +38,7 @@ final class SimpleInitializer extends Node {
       $file,
       $offset,
       $source,
+      'EqualToken',
     );
     $offset += $equal->getWidth();
     $value = Node::fromJSON(
@@ -44,6 +46,7 @@ final class SimpleInitializer extends Node {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $value->getWidth();
     $source_ref = shape(
@@ -131,9 +134,8 @@ final class SimpleInitializer extends Node {
    * TupleExpression | VarrayIntrinsicExpression | VectorIntrinsicExpression |
    * XHPExpression
    */
-  <<__Memoize>>
   public function getValue(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_value);
+    return TypeAssert\instance_of(IExpression::class, $this->_value);
   }
 
   /**

--- a/codegen/syntax/SimpleTypeSpecifier.hack
+++ b/codegen/syntax/SimpleTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d438f27c27140f2a9255f225f0c2480c>>
+ * @generated SignedSource<<fb137ec6490dc64b204f9e84aac2778d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -29,6 +29,7 @@ final class SimpleTypeSpecifier
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $specifier = Node::fromJSON(
@@ -36,6 +37,7 @@ final class SimpleTypeSpecifier
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $specifier->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/SoftTypeSpecifier.hack
+++ b/codegen/syntax/SoftTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<64ebe128bacee7ae450827f8b821c877>>
+ * @generated SignedSource<<224a16da114f87a6cdeeee7fce81aca4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class SoftTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $at = Node::fromJSON(
@@ -37,6 +38,7 @@ final class SoftTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'AtToken',
     );
     $offset += $at->getWidth();
     $type = Node::fromJSON(
@@ -44,6 +46,7 @@ final class SoftTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/SubscriptExpression.hack
+++ b/codegen/syntax/SubscriptExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6d4907a742d3c4ae240b3ece98d3f7b3>>
+ * @generated SignedSource<<27b6f6e8a0ed2917436f75c29b6b60db>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -38,6 +38,7 @@ final class SubscriptExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $receiver = Node::fromJSON(
@@ -45,6 +46,7 @@ final class SubscriptExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $receiver->getWidth();
     $left_bracket = Node::fromJSON(
@@ -52,6 +54,7 @@ final class SubscriptExpression
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $left_bracket->getWidth();
     $index = Node::fromJSON(
@@ -59,6 +62,7 @@ final class SubscriptExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $index->getWidth();
     $right_bracket = Node::fromJSON(
@@ -66,6 +70,7 @@ final class SubscriptExpression
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $right_bracket->getWidth();
     $source_ref = shape(
@@ -141,9 +146,8 @@ final class SubscriptExpression
    * ScopeResolutionExpression | SubscriptExpression | NameToken |
    * VariableExpression
    */
-  <<__Memoize>>
   public function getReceiver(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_receiver);
+    return TypeAssert\instance_of(IExpression::class, $this->_receiver);
   }
 
   /**
@@ -219,12 +223,11 @@ final class SubscriptExpression
    * ScopeResolutionExpression | SubscriptExpression | NameToken |
    * VariableExpression
    */
-  <<__Memoize>>
   public function getIndex(): ?IExpression {
     if ($this->_index->isMissing()) {
       return null;
     }
-    return __Private\Wrap\wrap_IExpression($this->_index);
+    return TypeAssert\instance_of(IExpression::class, $this->_index);
   }
 
   /**

--- a/codegen/syntax/SwitchFallthrough.hack
+++ b/codegen/syntax/SwitchFallthrough.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<50ed2393fb424aca88b542d79ef9b2aa>>
+ * @generated SignedSource<<4d94aaef9e51fe5bb3c311534a2251a4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class SwitchFallthrough extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -37,6 +38,7 @@ final class SwitchFallthrough extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $keyword->getWidth();
     $semicolon = Node::fromJSON(
@@ -44,6 +46,7 @@ final class SwitchFallthrough extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/SwitchSection.hack
+++ b/codegen/syntax/SwitchSection.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9c01d700da9f1cc3d7c57d691abc7502>>
+ * @generated SignedSource<<6acdfecd5ca5cbc1b73973ff210ae23c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class SwitchSection extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $labels = Node::fromJSON(
@@ -40,6 +41,7 @@ final class SwitchSection extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<ISwitchLabel>',
     );
     $offset += $labels->getWidth();
     $statements = Node::fromJSON(
@@ -47,6 +49,7 @@ final class SwitchSection extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<IStatement>',
     );
     $offset += $statements->getWidth();
     $fallthrough = Node::fromJSON(
@@ -54,6 +57,7 @@ final class SwitchSection extends Node {
       $file,
       $offset,
       $source,
+      'SwitchFallthrough',
     );
     $offset += $fallthrough->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/SwitchStatement.hack
+++ b/codegen/syntax/SwitchStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<da6cb5e89e01b119d9ecade176c5bf73>>
+ * @generated SignedSource<<2d38758f23f7a5e4efc909101cffaa6f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -47,6 +47,7 @@ final class SwitchStatement
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -54,6 +55,7 @@ final class SwitchStatement
       $file,
       $offset,
       $source,
+      'SwitchToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -61,6 +63,7 @@ final class SwitchStatement
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $expression = Node::fromJSON(
@@ -68,6 +71,7 @@ final class SwitchStatement
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $expression->getWidth();
     $right_paren = Node::fromJSON(
@@ -75,6 +79,7 @@ final class SwitchStatement
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $left_brace = Node::fromJSON(
@@ -82,6 +87,7 @@ final class SwitchStatement
       $file,
       $offset,
       $source,
+      'LeftBraceToken',
     );
     $offset += $left_brace->getWidth();
     $sections = Node::fromJSON(
@@ -89,6 +95,7 @@ final class SwitchStatement
       $file,
       $offset,
       $source,
+      'NodeList<SwitchSection>',
     );
     $offset += $sections->getWidth();
     $right_brace = Node::fromJSON(
@@ -96,6 +103,7 @@ final class SwitchStatement
       $file,
       $offset,
       $source,
+      'RightBraceToken',
     );
     $offset += $right_brace->getWidth();
     $source_ref = shape(
@@ -266,9 +274,8 @@ final class SwitchStatement
    * MemberSelectionExpression | ObjectCreationExpression |
    * ScopeResolutionExpression | SubscriptExpression | VariableExpression
    */
-  <<__Memoize>>
   public function getExpression(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_expression);
+    return TypeAssert\instance_of(IExpression::class, $this->_expression);
   }
 
   /**

--- a/codegen/syntax/ThrowStatement.hack
+++ b/codegen/syntax/ThrowStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9ca534ded10669cd29f38303cafb0f35>>
+ * @generated SignedSource<<e5c51db1f1e08116da9528c4c65a2092>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class ThrowStatement extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -40,6 +41,7 @@ final class ThrowStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'ThrowToken',
     );
     $offset += $keyword->getWidth();
     $expression = Node::fromJSON(
@@ -47,6 +49,7 @@ final class ThrowStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $expression->getWidth();
     $semicolon = Node::fromJSON(
@@ -54,6 +57,7 @@ final class ThrowStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(
@@ -142,9 +146,8 @@ final class ThrowStatement extends Node implements IStatement {
    * MemberSelectionExpression | ObjectCreationExpression |
    * ParenthesizedExpression | VariableExpression
    */
-  <<__Memoize>>
   public function getExpression(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_expression);
+    return TypeAssert\instance_of(IExpression::class, $this->_expression);
   }
 
   /**

--- a/codegen/syntax/TraitUse.hack
+++ b/codegen/syntax/TraitUse.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5efda498e8c3773f9d83597c704be650>>
+ * @generated SignedSource<<a9c3c3fdb0a2bbbcb2067c1c72a9ed22>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class TraitUse extends Node implements IClassBodyDeclaration {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -40,6 +41,7 @@ final class TraitUse extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'UseToken',
     );
     $offset += $keyword->getWidth();
     $names = Node::fromJSON(
@@ -47,6 +49,7 @@ final class TraitUse extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ISimpleCreationSpecifier>>',
     );
     $offset += $names->getWidth();
     $semicolon = Node::fromJSON(
@@ -54,6 +57,7 @@ final class TraitUse extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/TraitUseAliasItem.hack
+++ b/codegen/syntax/TraitUseAliasItem.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9ffa2f50febea8a6803a6fe310f16eec>>
+ * @generated SignedSource<<8ccc2bbf27ab8128da10c60a25368a92>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class TraitUseAliasItem extends Node implements ITraitUseItem {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $aliasing_name = Node::fromJSON(
@@ -43,6 +44,7 @@ final class TraitUseAliasItem extends Node implements ITraitUseItem {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $aliasing_name->getWidth();
     $keyword = Node::fromJSON(
@@ -50,6 +52,7 @@ final class TraitUseAliasItem extends Node implements ITraitUseItem {
       $file,
       $offset,
       $source,
+      'AsToken',
     );
     $offset += $keyword->getWidth();
     $modifiers = Node::fromJSON(
@@ -57,6 +60,7 @@ final class TraitUseAliasItem extends Node implements ITraitUseItem {
       $file,
       $offset,
       $source,
+      'NodeList<Token>',
     );
     $offset += $modifiers->getWidth();
     $aliased_name = Node::fromJSON(
@@ -64,6 +68,7 @@ final class TraitUseAliasItem extends Node implements ITraitUseItem {
       $file,
       $offset,
       $source,
+      'SimpleTypeSpecifier',
     );
     $offset += $aliased_name->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/TraitUseConflictResolution.hack
+++ b/codegen/syntax/TraitUseConflictResolution.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9d2ebf81ea78cfd40618da9c5532d88e>>
+ * @generated SignedSource<<76e8f763ffd916444f65f08a47ed3c27>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -41,6 +41,7 @@ final class TraitUseConflictResolution
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -48,6 +49,7 @@ final class TraitUseConflictResolution
       $file,
       $offset,
       $source,
+      'UseToken',
     );
     $offset += $keyword->getWidth();
     $names = Node::fromJSON(
@@ -55,6 +57,7 @@ final class TraitUseConflictResolution
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<SimpleTypeSpecifier>>',
     );
     $offset += $names->getWidth();
     $left_brace = Node::fromJSON(
@@ -62,6 +65,7 @@ final class TraitUseConflictResolution
       $file,
       $offset,
       $source,
+      'LeftBraceToken',
     );
     $offset += $left_brace->getWidth();
     $clauses = Node::fromJSON(
@@ -69,6 +73,7 @@ final class TraitUseConflictResolution
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ITraitUseItem>>',
     );
     $offset += $clauses->getWidth();
     $right_brace = Node::fromJSON(
@@ -76,6 +81,7 @@ final class TraitUseConflictResolution
       $file,
       $offset,
       $source,
+      'RightBraceToken',
     );
     $offset += $right_brace->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/TraitUsePrecedenceItem.hack
+++ b/codegen/syntax/TraitUsePrecedenceItem.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a94d686782758f5d62a7cf79b6bcccd9>>
+ * @generated SignedSource<<7ca837e1ed44ccbf4b46f0af0948b092>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class TraitUsePrecedenceItem extends Node implements ITraitUseItem {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $name = Node::fromJSON(
@@ -40,6 +41,7 @@ final class TraitUsePrecedenceItem extends Node implements ITraitUseItem {
       $file,
       $offset,
       $source,
+      'ScopeResolutionExpression',
     );
     $offset += $name->getWidth();
     $keyword = Node::fromJSON(
@@ -47,6 +49,7 @@ final class TraitUsePrecedenceItem extends Node implements ITraitUseItem {
       $file,
       $offset,
       $source,
+      'InsteadofToken',
     );
     $offset += $keyword->getWidth();
     $removed_names = Node::fromJSON(
@@ -54,6 +57,7 @@ final class TraitUsePrecedenceItem extends Node implements ITraitUseItem {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<SimpleTypeSpecifier>>',
     );
     $offset += $removed_names->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/TryStatement.hack
+++ b/codegen/syntax/TryStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<55b080d7b80c341a59ec6858e0143ff9>>
+ * @generated SignedSource<<a8535c01af2708d1dec6a6d0b966d5aa>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class TryStatement extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class TryStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'TryToken',
     );
     $offset += $keyword->getWidth();
     $compound_statement = Node::fromJSON(
@@ -50,6 +52,7 @@ final class TryStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'CompoundStatement',
     );
     $offset += $compound_statement->getWidth();
     $catch_clauses = Node::fromJSON(
@@ -57,6 +60,7 @@ final class TryStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'NodeList<CatchClause>',
     );
     $offset += $catch_clauses->getWidth();
     $finally_clause = Node::fromJSON(
@@ -64,6 +68,7 @@ final class TryStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'FinallyClause',
     );
     $offset += $finally_clause->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/TupleExpression.hack
+++ b/codegen/syntax/TupleExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f1e490e84791d0f638963584ab260494>>
+ * @generated SignedSource<<acc13291f813556c918422cde5c678ef>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class TupleExpression extends Node implements ILambdaBody, IExpression {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class TupleExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'TupleToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -50,6 +52,7 @@ final class TupleExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $items = Node::fromJSON(
@@ -57,6 +60,7 @@ final class TupleExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IExpression>>',
     );
     $offset += $items->getWidth();
     $right_paren = Node::fromJSON(
@@ -64,6 +68,7 @@ final class TupleExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/TupleTypeExplicitSpecifier.hack
+++ b/codegen/syntax/TupleTypeExplicitSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e9a1d9707746cbc658cfde7bdfa8902f>>
+ * @generated SignedSource<<d02cf2a7a85adea874116d4578466556>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class TupleTypeExplicitSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class TupleTypeExplicitSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $keyword->getWidth();
     $left_angle = Node::fromJSON(
@@ -50,6 +52,7 @@ final class TupleTypeExplicitSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $left_angle->getWidth();
     $types = Node::fromJSON(
@@ -57,6 +60,7 @@ final class TupleTypeExplicitSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $types->getWidth();
     $right_angle = Node::fromJSON(
@@ -64,6 +68,7 @@ final class TupleTypeExplicitSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $right_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/TupleTypeSpecifier.hack
+++ b/codegen/syntax/TupleTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e9abeb6a827c24dc26cb5004cfa78f29>>
+ * @generated SignedSource<<f16dc34bbc573c99c9e08772d2eef242>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class TupleTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_paren = Node::fromJSON(
@@ -40,6 +41,7 @@ final class TupleTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $types = Node::fromJSON(
@@ -47,6 +49,7 @@ final class TupleTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ITypeSpecifier>>',
     );
     $offset += $types->getWidth();
     $right_paren = Node::fromJSON(
@@ -54,6 +57,7 @@ final class TupleTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/TypeArguments.hack
+++ b/codegen/syntax/TypeArguments.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<dfb6e2201b0c8a36673767a7fcff0ac2>>
+ * @generated SignedSource<<6afb3f7b3497231cd3fd6c2f48ffd221>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class TypeArguments extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_angle = Node::fromJSON(
@@ -40,6 +41,7 @@ final class TypeArguments extends Node {
       $file,
       $offset,
       $source,
+      'LessThanToken',
     );
     $offset += $left_angle->getWidth();
     $types = Node::fromJSON(
@@ -47,6 +49,7 @@ final class TypeArguments extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<ITypeSpecifier>>',
     );
     $offset += $types->getWidth();
     $right_angle = Node::fromJSON(
@@ -54,6 +57,7 @@ final class TypeArguments extends Node {
       $file,
       $offset,
       $source,
+      'GreaterThanToken',
     );
     $offset += $right_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/TypeConstDeclaration.hack
+++ b/codegen/syntax/TypeConstDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ff7d098b1dccd5cc175870bcf0cd8897>>
+ * @generated SignedSource<<7e335736f1c1ecfa419be821f29f8b22>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -54,6 +54,7 @@ final class TypeConstDeclaration extends Node implements IClassBodyDeclaration {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute_spec = Node::fromJSON(
@@ -61,6 +62,7 @@ final class TypeConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $attribute_spec->getWidth();
     $abstract = Node::fromJSON(
@@ -68,6 +70,7 @@ final class TypeConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'AbstractToken',
     );
     $offset += $abstract->getWidth();
     $keyword = Node::fromJSON(
@@ -75,6 +78,7 @@ final class TypeConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'ConstToken',
     );
     $offset += $keyword->getWidth();
     $type_keyword = Node::fromJSON(
@@ -82,6 +86,7 @@ final class TypeConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'TypeToken',
     );
     $offset += $type_keyword->getWidth();
     $name = Node::fromJSON(
@@ -89,6 +94,7 @@ final class TypeConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'NameToken',
     );
     $offset += $name->getWidth();
     $type_parameters = Node::fromJSON(
@@ -96,6 +102,7 @@ final class TypeConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $type_parameters->getWidth();
     $type_constraint = Node::fromJSON(
@@ -103,6 +110,7 @@ final class TypeConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'TypeConstraint',
     );
     $offset += $type_constraint->getWidth();
     $equal = Node::fromJSON(
@@ -110,6 +118,7 @@ final class TypeConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'EqualToken',
     );
     $offset += $equal->getWidth();
     $type_specifier = Node::fromJSON(
@@ -117,6 +126,7 @@ final class TypeConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type_specifier->getWidth();
     $semicolon = Node::fromJSON(
@@ -124,6 +134,7 @@ final class TypeConstDeclaration extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/TypeConstant.hack
+++ b/codegen/syntax/TypeConstant.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<270e4ea2d779be04781f01e6caae33bf>>
+ * @generated SignedSource<<630f1fb8b66a4814196ac1680341a031>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class TypeConstant extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_type = Node::fromJSON(
@@ -40,6 +41,7 @@ final class TypeConstant extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $left_type->getWidth();
     $separator = Node::fromJSON(
@@ -47,6 +49,7 @@ final class TypeConstant extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ColonColonToken',
     );
     $offset += $separator->getWidth();
     $right_type = Node::fromJSON(
@@ -54,6 +57,7 @@ final class TypeConstant extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'NameToken',
     );
     $offset += $right_type->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/TypeConstraint.hack
+++ b/codegen/syntax/TypeConstraint.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<470d3a8cbcb3f319844e1eb6a93819b1>>
+ * @generated SignedSource<<fc308f69cbd373c0b51ee21bfd22cc33>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class TypeConstraint extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -37,6 +38,7 @@ final class TypeConstraint extends Node {
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $keyword->getWidth();
     $type = Node::fromJSON(
@@ -44,6 +46,7 @@ final class TypeConstraint extends Node {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/TypeParameter.hack
+++ b/codegen/syntax/TypeParameter.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e38163cf72c09d2ed37a7477bf266ccd>>
+ * @generated SignedSource<<3b875b23fe5f344bf7509028b6a17e52>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -39,6 +39,7 @@ final class TypeParameter extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $attribute_spec = Node::fromJSON(
@@ -46,6 +47,7 @@ final class TypeParameter extends Node {
       $file,
       $offset,
       $source,
+      'AttributeSpecification',
     );
     $offset += $attribute_spec->getWidth();
     $reified = Node::fromJSON(
@@ -53,6 +55,7 @@ final class TypeParameter extends Node {
       $file,
       $offset,
       $source,
+      'ReifyToken',
     );
     $offset += $reified->getWidth();
     $variance = Node::fromJSON(
@@ -60,6 +63,7 @@ final class TypeParameter extends Node {
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $variance->getWidth();
     $name = Node::fromJSON(
@@ -67,6 +71,7 @@ final class TypeParameter extends Node {
       $file,
       $offset,
       $source,
+      'NameToken',
     );
     $offset += $name->getWidth();
     $constraints = Node::fromJSON(
@@ -74,6 +79,7 @@ final class TypeParameter extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<TypeConstraint>',
     );
     $offset += $constraints->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/TypeParameters.hack
+++ b/codegen/syntax/TypeParameters.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bd3e271b25feed4e3ae6ddc11ac7e382>>
+ * @generated SignedSource<<a885138941c9c6543a70328f104bf6ec>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class TypeParameters extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_angle = Node::fromJSON(
@@ -40,6 +41,7 @@ final class TypeParameters extends Node {
       $file,
       $offset,
       $source,
+      'LessThanToken',
     );
     $offset += $left_angle->getWidth();
     $parameters = Node::fromJSON(
@@ -47,6 +49,7 @@ final class TypeParameters extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<TypeParameter>>',
     );
     $offset += $parameters->getWidth();
     $right_angle = Node::fromJSON(
@@ -54,6 +57,7 @@ final class TypeParameters extends Node {
       $file,
       $offset,
       $source,
+      'GreaterThanToken',
     );
     $offset += $right_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/UnsetStatement.hack
+++ b/codegen/syntax/UnsetStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d2e8c448c3a042e43f04d00a6a237ce8>>
+ * @generated SignedSource<<56f725c5b34e86bcbac6bcef3f6ee3ab>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -39,6 +39,7 @@ final class UnsetStatement extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -46,6 +47,7 @@ final class UnsetStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'UnsetToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -53,6 +55,7 @@ final class UnsetStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $variables = Node::fromJSON(
@@ -60,6 +63,7 @@ final class UnsetStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IExpression>>',
     );
     $offset += $variables->getWidth();
     $right_paren = Node::fromJSON(
@@ -67,6 +71,7 @@ final class UnsetStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $semicolon = Node::fromJSON(
@@ -74,6 +79,7 @@ final class UnsetStatement extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/UsingStatementBlockScoped.hack
+++ b/codegen/syntax/UsingStatementBlockScoped.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e053f0e7be3619714cfdecbc6275f9f0>>
+ * @generated SignedSource<<68aa3bd7c3b4fe6cb3808d493b8f333e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -42,6 +42,7 @@ final class UsingStatementBlockScoped extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $await_keyword = Node::fromJSON(
@@ -49,6 +50,7 @@ final class UsingStatementBlockScoped extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'AwaitToken',
     );
     $offset += $await_keyword->getWidth();
     $using_keyword = Node::fromJSON(
@@ -56,6 +58,7 @@ final class UsingStatementBlockScoped extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'UsingToken',
     );
     $offset += $using_keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -63,6 +66,7 @@ final class UsingStatementBlockScoped extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $expressions = Node::fromJSON(
@@ -70,6 +74,7 @@ final class UsingStatementBlockScoped extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IExpression>>',
     );
     $offset += $expressions->getWidth();
     $right_paren = Node::fromJSON(
@@ -77,6 +82,7 @@ final class UsingStatementBlockScoped extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $body = Node::fromJSON(
@@ -84,6 +90,7 @@ final class UsingStatementBlockScoped extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'CompoundStatement',
     );
     $offset += $body->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/UsingStatementFunctionScoped.hack
+++ b/codegen/syntax/UsingStatementFunctionScoped.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6be609978c4644de520955a43f28f6f9>>
+ * @generated SignedSource<<cb5c0e337224d9c6934fd46600d9ed35>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class UsingStatementFunctionScoped extends Node implements IStatement {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $await_keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class UsingStatementFunctionScoped extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'AwaitToken',
     );
     $offset += $await_keyword->getWidth();
     $using_keyword = Node::fromJSON(
@@ -50,6 +52,7 @@ final class UsingStatementFunctionScoped extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'UsingToken',
     );
     $offset += $using_keyword->getWidth();
     $expression = Node::fromJSON(
@@ -57,6 +60,7 @@ final class UsingStatementFunctionScoped extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $expression->getWidth();
     $semicolon = Node::fromJSON(
@@ -64,6 +68,7 @@ final class UsingStatementFunctionScoped extends Node implements IStatement {
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(
@@ -207,9 +212,8 @@ final class UsingStatementFunctionScoped extends Node implements IStatement {
    * @return BinaryExpression | LambdaExpression | ObjectCreationExpression |
    * ParenthesizedExpression | PrefixUnaryExpression
    */
-  <<__Memoize>>
   public function getExpression(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_expression);
+    return TypeAssert\instance_of(IExpression::class, $this->_expression);
   }
 
   /**

--- a/codegen/syntax/VariableExpression.hack
+++ b/codegen/syntax/VariableExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<09342a64c505b4a221298faefa599747>>
+ * @generated SignedSource<<d86f00cbc281a39ffe24b47fef09281f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -29,6 +29,7 @@ final class VariableExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $expression = Node::fromJSON(
@@ -36,6 +37,7 @@ final class VariableExpression
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $expression->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/VariadicParameter.hack
+++ b/codegen/syntax/VariadicParameter.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6f32bcb2949930514292a9d5d32e547f>>
+ * @generated SignedSource<<dfb3960edcbfb6912f6dfe769d471359>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class VariadicParameter
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $call_convention = Node::fromJSON(
@@ -42,6 +43,7 @@ final class VariadicParameter
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $call_convention->getWidth();
     $type = Node::fromJSON(
@@ -49,6 +51,7 @@ final class VariadicParameter
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $ellipsis = Node::fromJSON(
@@ -56,6 +59,7 @@ final class VariadicParameter
       $file,
       $offset,
       $source,
+      'DotDotDotToken',
     );
     $offset += $ellipsis->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/VarrayIntrinsicExpression.hack
+++ b/codegen/syntax/VarrayIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d1debfb76515cd9b1f26a3e84ac8b925>>
+ * @generated SignedSource<<297d859cad7a2810cec92ec8756c7ca3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -41,6 +41,7 @@ final class VarrayIntrinsicExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -48,6 +49,7 @@ final class VarrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'VarrayToken',
     );
     $offset += $keyword->getWidth();
     $explicit_type = Node::fromJSON(
@@ -55,6 +57,7 @@ final class VarrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'TypeArguments',
     );
     $offset += $explicit_type->getWidth();
     $left_bracket = Node::fromJSON(
@@ -62,6 +65,7 @@ final class VarrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'LeftBracketToken',
     );
     $offset += $left_bracket->getWidth();
     $members = Node::fromJSON(
@@ -69,6 +73,7 @@ final class VarrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IExpression>>',
     );
     $offset += $members->getWidth();
     $right_bracket = Node::fromJSON(
@@ -76,6 +81,7 @@ final class VarrayIntrinsicExpression
       $file,
       $offset,
       $source,
+      'RightBracketToken',
     );
     $offset += $right_bracket->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/VarrayTypeSpecifier.hack
+++ b/codegen/syntax/VarrayTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<58b21db1c8c73b36986fa90ea78b13d6>>
+ * @generated SignedSource<<5fb69d9276adbbecd6d5d8227d57594e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -39,6 +39,7 @@ final class VarrayTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -46,6 +47,7 @@ final class VarrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'VarrayToken',
     );
     $offset += $keyword->getWidth();
     $left_angle = Node::fromJSON(
@@ -53,6 +55,7 @@ final class VarrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'LessThanToken',
     );
     $offset += $left_angle->getWidth();
     $type = Node::fromJSON(
@@ -60,6 +63,7 @@ final class VarrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $trailing_comma = Node::fromJSON(
@@ -67,6 +71,7 @@ final class VarrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $trailing_comma->getWidth();
     $right_angle = Node::fromJSON(
@@ -74,6 +79,7 @@ final class VarrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'GreaterThanToken',
     );
     $offset += $right_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/VectorArrayTypeSpecifier.hack
+++ b/codegen/syntax/VectorArrayTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d7193af323e485e0f288199b5c68fb5c>>
+ * @generated SignedSource<<a18fb72fb338896327612c8b89e4de2c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class VectorArrayTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -43,6 +44,7 @@ final class VectorArrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ArrayToken',
     );
     $offset += $keyword->getWidth();
     $left_angle = Node::fromJSON(
@@ -50,6 +52,7 @@ final class VectorArrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'LessThanToken',
     );
     $offset += $left_angle->getWidth();
     $type = Node::fromJSON(
@@ -57,6 +60,7 @@ final class VectorArrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $right_angle = Node::fromJSON(
@@ -64,6 +68,7 @@ final class VectorArrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'GreaterThanToken',
     );
     $offset += $right_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/VectorIntrinsicExpression.hack
+++ b/codegen/syntax/VectorIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<05313c6d21da51ef093d0b67dd02e8d8>>
+ * @generated SignedSource<<dceeb47af83a8691fb726d370e0c253b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -41,6 +41,7 @@ final class VectorIntrinsicExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -48,6 +49,7 @@ final class VectorIntrinsicExpression
       $file,
       $offset,
       $source,
+      'VecToken',
     );
     $offset += $keyword->getWidth();
     $explicit_type = Node::fromJSON(
@@ -55,6 +57,7 @@ final class VectorIntrinsicExpression
       $file,
       $offset,
       $source,
+      'TypeArguments',
     );
     $offset += $explicit_type->getWidth();
     $left_bracket = Node::fromJSON(
@@ -62,6 +65,7 @@ final class VectorIntrinsicExpression
       $file,
       $offset,
       $source,
+      'LeftBracketToken',
     );
     $offset += $left_bracket->getWidth();
     $members = Node::fromJSON(
@@ -69,6 +73,7 @@ final class VectorIntrinsicExpression
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<IExpression>>',
     );
     $offset += $members->getWidth();
     $right_bracket = Node::fromJSON(
@@ -76,6 +81,7 @@ final class VectorIntrinsicExpression
       $file,
       $offset,
       $source,
+      'RightBracketToken',
     );
     $offset += $right_bracket->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/VectorTypeSpecifier.hack
+++ b/codegen/syntax/VectorTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f7117159e009714865383502c138ae9b>>
+ * @generated SignedSource<<96c0168179aeef6f8bc1935b323a8868>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -39,6 +39,7 @@ final class VectorTypeSpecifier extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -46,6 +47,7 @@ final class VectorTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'VecToken',
     );
     $offset += $keyword->getWidth();
     $left_angle = Node::fromJSON(
@@ -53,6 +55,7 @@ final class VectorTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'LessThanToken',
     );
     $offset += $left_angle->getWidth();
     $type = Node::fromJSON(
@@ -60,6 +63,7 @@ final class VectorTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $trailing_comma = Node::fromJSON(
@@ -67,6 +71,7 @@ final class VectorTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $trailing_comma->getWidth();
     $right_angle = Node::fromJSON(
@@ -74,6 +79,7 @@ final class VectorTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'GreaterThanToken',
     );
     $offset += $right_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/WhereClause.hack
+++ b/codegen/syntax/WhereClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<25dce71f555b2388d692c926ee6224a4>>
+ * @generated SignedSource<<de073e8834f1d6854e7fe13128304578>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class WhereClause extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -37,6 +38,7 @@ final class WhereClause extends Node {
       $file,
       $offset,
       $source,
+      'WhereToken',
     );
     $offset += $keyword->getWidth();
     $constraints = Node::fromJSON(
@@ -44,6 +46,7 @@ final class WhereClause extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<WhereConstraint>>',
     );
     $offset += $constraints->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/WhereConstraint.hack
+++ b/codegen/syntax/WhereConstraint.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<99def36e8ae63ccf064801fa238d317a>>
+ * @generated SignedSource<<d91942428b0eb9e2d8fd3e9351f87164>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class WhereConstraint extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_type = Node::fromJSON(
@@ -40,6 +41,7 @@ final class WhereConstraint extends Node {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $left_type->getWidth();
     $operator = Node::fromJSON(
@@ -47,6 +49,7 @@ final class WhereConstraint extends Node {
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $operator->getWidth();
     $right_type = Node::fromJSON(
@@ -54,6 +57,7 @@ final class WhereConstraint extends Node {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $right_type->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/WhileStatement.hack
+++ b/codegen/syntax/WhileStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<212e4fa0838767969db6f4987b322862>>
+ * @generated SignedSource<<e394c99b6ceed117b732688a7b81728f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -41,6 +41,7 @@ final class WhileStatement
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -48,6 +49,7 @@ final class WhileStatement
       $file,
       $offset,
       $source,
+      'WhileToken',
     );
     $offset += $keyword->getWidth();
     $left_paren = Node::fromJSON(
@@ -55,6 +57,7 @@ final class WhileStatement
       $file,
       $offset,
       $source,
+      'LeftParenToken',
     );
     $offset += $left_paren->getWidth();
     $condition = Node::fromJSON(
@@ -62,6 +65,7 @@ final class WhileStatement
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $condition->getWidth();
     $right_paren = Node::fromJSON(
@@ -69,6 +73,7 @@ final class WhileStatement
       $file,
       $offset,
       $source,
+      'RightParenToken',
     );
     $offset += $right_paren->getWidth();
     $body = Node::fromJSON(
@@ -76,6 +81,7 @@ final class WhileStatement
       $file,
       $offset,
       $source,
+      'IStatement',
     );
     $offset += $body->getWidth();
     $source_ref = shape(
@@ -225,9 +231,8 @@ final class WhileStatement
    * MemberSelectionExpression | ParenthesizedExpression |
    * PostfixUnaryExpression | PrefixUnaryExpression | VariableExpression
    */
-  <<__Memoize>>
   public function getCondition(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_condition);
+    return TypeAssert\instance_of(IExpression::class, $this->_condition);
   }
 
   /**

--- a/codegen/syntax/XHPCategoryDeclaration.hack
+++ b/codegen/syntax/XHPCategoryDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d077fdbe437db53542e98b80d7a9311e>>
+ * @generated SignedSource<<13ad778082e980379254334629223844>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class XHPCategoryDeclaration
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -42,6 +43,7 @@ final class XHPCategoryDeclaration
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $keyword->getWidth();
     $categories = Node::fromJSON(
@@ -49,6 +51,7 @@ final class XHPCategoryDeclaration
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $categories->getWidth();
     $semicolon = Node::fromJSON(
@@ -56,6 +59,7 @@ final class XHPCategoryDeclaration
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/XHPChildrenDeclaration.hack
+++ b/codegen/syntax/XHPChildrenDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f5957466510697f11c146460dfb087b7>>
+ * @generated SignedSource<<2b30c798b5cf378a6998341fcd736a9c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class XHPChildrenDeclaration
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -42,6 +43,7 @@ final class XHPChildrenDeclaration
       $file,
       $offset,
       $source,
+      'ChildrenToken',
     );
     $offset += $keyword->getWidth();
     $expression = Node::fromJSON(
@@ -49,6 +51,7 @@ final class XHPChildrenDeclaration
       $file,
       $offset,
       $source,
+      'EmptyToken',
     );
     $offset += $expression->getWidth();
     $semicolon = Node::fromJSON(
@@ -56,6 +59,7 @@ final class XHPChildrenDeclaration
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/XHPChildrenParenthesizedList.hack
+++ b/codegen/syntax/XHPChildrenParenthesizedList.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e7637b4f24f415d37378d14a980d11d5>>
+ * @generated SignedSource<<097d322067c73882ebd5b3a79f5192e5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class XHPChildrenParenthesizedList extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_paren = Node::fromJSON(
@@ -40,6 +41,7 @@ final class XHPChildrenParenthesizedList extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $left_paren->getWidth();
     $xhp_children = Node::fromJSON(
@@ -47,6 +49,7 @@ final class XHPChildrenParenthesizedList extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $xhp_children->getWidth();
     $right_paren = Node::fromJSON(
@@ -54,6 +57,7 @@ final class XHPChildrenParenthesizedList extends Node {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $right_paren->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/XHPClassAttribute.hack
+++ b/codegen/syntax/XHPClassAttribute.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0ba0d8b862bda999ba2ef50b4f448296>>
+ * @generated SignedSource<<2fbf0a18545ede026eb61b5e7ac631fc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class XHPClassAttribute extends Node implements IXHPAttribute {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $type = Node::fromJSON(
@@ -43,6 +44,7 @@ final class XHPClassAttribute extends Node implements IXHPAttribute {
       $file,
       $offset,
       $source,
+      'ITypeSpecifier',
     );
     $offset += $type->getWidth();
     $name = Node::fromJSON(
@@ -50,6 +52,7 @@ final class XHPClassAttribute extends Node implements IXHPAttribute {
       $file,
       $offset,
       $source,
+      'XHPElementNameToken',
     );
     $offset += $name->getWidth();
     $initializer = Node::fromJSON(
@@ -57,6 +60,7 @@ final class XHPClassAttribute extends Node implements IXHPAttribute {
       $file,
       $offset,
       $source,
+      'SimpleInitializer',
     );
     $offset += $initializer->getWidth();
     $required = Node::fromJSON(
@@ -64,6 +68,7 @@ final class XHPClassAttribute extends Node implements IXHPAttribute {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $required->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/XHPClassAttributeDeclaration.hack
+++ b/codegen/syntax/XHPClassAttributeDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<576cfd514a289f2fd1f32bbb14cdb097>>
+ * @generated SignedSource<<fb05156869770b52ca64f0280c3b18ae>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class XHPClassAttributeDeclaration
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -42,6 +43,7 @@ final class XHPClassAttributeDeclaration
       $file,
       $offset,
       $source,
+      'AttributeToken',
     );
     $offset += $keyword->getWidth();
     $attributes = Node::fromJSON(
@@ -49,6 +51,7 @@ final class XHPClassAttributeDeclaration
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<Node>>',
     );
     $offset += $attributes->getWidth();
     $semicolon = Node::fromJSON(
@@ -56,6 +59,7 @@ final class XHPClassAttributeDeclaration
       $file,
       $offset,
       $source,
+      'SemicolonToken',
     );
     $offset += $semicolon->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/XHPClose.hack
+++ b/codegen/syntax/XHPClose.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fa244a4ffcc255dfbd87fa3715eb9b6f>>
+ * @generated SignedSource<<1068fa863827684a09f356e8449640ae>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class XHPClose extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_angle = Node::fromJSON(
@@ -40,6 +41,7 @@ final class XHPClose extends Node {
       $file,
       $offset,
       $source,
+      'LessThanSlashToken',
     );
     $offset += $left_angle->getWidth();
     $name = Node::fromJSON(
@@ -47,6 +49,7 @@ final class XHPClose extends Node {
       $file,
       $offset,
       $source,
+      'XHPElementNameToken',
     );
     $offset += $name->getWidth();
     $right_angle = Node::fromJSON(
@@ -54,6 +57,7 @@ final class XHPClose extends Node {
       $file,
       $offset,
       $source,
+      'GreaterThanToken',
     );
     $offset += $right_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/XHPEnumType.hack
+++ b/codegen/syntax/XHPEnumType.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<92d947291afda1e0dca7fad20a566a41>>
+ * @generated SignedSource<<7e88b4bb12b8b17eee9c1b97854bf529>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -39,6 +39,7 @@ final class XHPEnumType extends Node implements ITypeSpecifier {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $optional = Node::fromJSON(
@@ -46,6 +47,7 @@ final class XHPEnumType extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $optional->getWidth();
     $keyword = Node::fromJSON(
@@ -53,6 +55,7 @@ final class XHPEnumType extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'EnumToken',
     );
     $offset += $keyword->getWidth();
     $left_brace = Node::fromJSON(
@@ -60,6 +63,7 @@ final class XHPEnumType extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'LeftBraceToken',
     );
     $offset += $left_brace->getWidth();
     $values = Node::fromJSON(
@@ -67,6 +71,7 @@ final class XHPEnumType extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'NodeList<ListItem<LiteralExpression>>',
     );
     $offset += $values->getWidth();
     $right_brace = Node::fromJSON(
@@ -74,6 +79,7 @@ final class XHPEnumType extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
+      'RightBraceToken',
     );
     $offset += $right_brace->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/XHPExpression.hack
+++ b/codegen/syntax/XHPExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4c19dec084a54ea49c29d50fd5bc4211>>
+ * @generated SignedSource<<39eca4cc53038cda07c1c744d9d1175f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class XHPExpression extends Node implements ILambdaBody, IExpression {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $open = Node::fromJSON(
@@ -40,6 +41,7 @@ final class XHPExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'XHPOpen',
     );
     $offset += $open->getWidth();
     $body = Node::fromJSON(
@@ -47,6 +49,7 @@ final class XHPExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'NodeList<Node>',
     );
     $offset += $body->getWidth();
     $close = Node::fromJSON(
@@ -54,6 +57,7 @@ final class XHPExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'XHPClose',
     );
     $offset += $close->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/XHPLateinit.hack
+++ b/codegen/syntax/XHPLateinit.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e2c9812f0de9270274c2f98c692e0628>>
+ * @generated SignedSource<<7b89df0f29ce016d50a3495055475d7b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class XHPLateinit extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $at = Node::fromJSON(
@@ -37,6 +38,7 @@ final class XHPLateinit extends Node {
       $file,
       $offset,
       $source,
+      'AtToken',
     );
     $offset += $at->getWidth();
     $keyword = Node::fromJSON(
@@ -44,6 +46,7 @@ final class XHPLateinit extends Node {
       $file,
       $offset,
       $source,
+      'LateinitToken',
     );
     $offset += $keyword->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/XHPOpen.hack
+++ b/codegen/syntax/XHPOpen.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bd1407b81f17608fccc7e1421b0a60f3>>
+ * @generated SignedSource<<a89dd50ac7f3d502f0c104cf3cfc4776>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class XHPOpen extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_angle = Node::fromJSON(
@@ -43,6 +44,7 @@ final class XHPOpen extends Node {
       $file,
       $offset,
       $source,
+      'LessThanToken',
     );
     $offset += $left_angle->getWidth();
     $name = Node::fromJSON(
@@ -50,6 +52,7 @@ final class XHPOpen extends Node {
       $file,
       $offset,
       $source,
+      'XHPElementNameToken',
     );
     $offset += $name->getWidth();
     $attributes = Node::fromJSON(
@@ -57,6 +60,7 @@ final class XHPOpen extends Node {
       $file,
       $offset,
       $source,
+      'NodeList<Node>',
     );
     $offset += $attributes->getWidth();
     $right_angle = Node::fromJSON(
@@ -64,6 +68,7 @@ final class XHPOpen extends Node {
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $right_angle->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/XHPRequired.hack
+++ b/codegen/syntax/XHPRequired.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b444c63f01bf01c5e43c37fff9e05351>>
+ * @generated SignedSource<<f27a8ab02c0b8ac59b421d27c4ceef00>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class XHPRequired extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $at = Node::fromJSON(
@@ -37,6 +38,7 @@ final class XHPRequired extends Node {
       $file,
       $offset,
       $source,
+      'AtToken',
     );
     $offset += $at->getWidth();
     $keyword = Node::fromJSON(
@@ -44,6 +46,7 @@ final class XHPRequired extends Node {
       $file,
       $offset,
       $source,
+      'RequiredToken',
     );
     $offset += $keyword->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/XHPSimpleAttribute.hack
+++ b/codegen/syntax/XHPSimpleAttribute.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<41032267411fff6d7f18218c464c6b33>>
+ * @generated SignedSource<<28a918a6293eaaac7ffc3ec88cab2931>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -33,6 +33,7 @@ final class XHPSimpleAttribute extends Node implements IXHPAttribute {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $name = Node::fromJSON(
@@ -40,6 +41,7 @@ final class XHPSimpleAttribute extends Node implements IXHPAttribute {
       $file,
       $offset,
       $source,
+      'XHPElementNameToken',
     );
     $offset += $name->getWidth();
     $equal = Node::fromJSON(
@@ -47,6 +49,7 @@ final class XHPSimpleAttribute extends Node implements IXHPAttribute {
       $file,
       $offset,
       $source,
+      'EqualToken',
     );
     $offset += $equal->getWidth();
     $expression = Node::fromJSON(
@@ -54,6 +57,7 @@ final class XHPSimpleAttribute extends Node implements IXHPAttribute {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $expression->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/XHPSimpleClassAttribute.hack
+++ b/codegen/syntax/XHPSimpleClassAttribute.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9433b556c5a7e59f65c9b08120347cdb>>
+ * @generated SignedSource<<35a3971af13e582fc54b1f20b6e5fb6e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -27,6 +27,7 @@ final class XHPSimpleClassAttribute extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $type = Node::fromJSON(
@@ -34,6 +35,7 @@ final class XHPSimpleClassAttribute extends Node {
       $file,
       $offset,
       $source,
+      'SimpleTypeSpecifier',
     );
     $offset += $type->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/XHPSpreadAttribute.hack
+++ b/codegen/syntax/XHPSpreadAttribute.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d486bb738f00e9584b314a0d499d15b0>>
+ * @generated SignedSource<<564edf970d3e104255ef7ef04574b896>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -36,6 +36,7 @@ final class XHPSpreadAttribute extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $left_brace = Node::fromJSON(
@@ -43,6 +44,7 @@ final class XHPSpreadAttribute extends Node {
       $file,
       $offset,
       $source,
+      'LeftBraceToken',
     );
     $offset += $left_brace->getWidth();
     $spread_operator = Node::fromJSON(
@@ -50,6 +52,7 @@ final class XHPSpreadAttribute extends Node {
       $file,
       $offset,
       $source,
+      'DotDotDotToken',
     );
     $offset += $spread_operator->getWidth();
     $expression = Node::fromJSON(
@@ -57,6 +60,7 @@ final class XHPSpreadAttribute extends Node {
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $expression->getWidth();
     $right_brace = Node::fromJSON(
@@ -64,6 +68,7 @@ final class XHPSpreadAttribute extends Node {
       $file,
       $offset,
       $source,
+      'RightBraceToken',
     );
     $offset += $right_brace->getWidth();
     $source_ref = shape(
@@ -206,9 +211,8 @@ final class XHPSpreadAttribute extends Node {
   /**
    * @return VariableExpression | XHPExpression
    */
-  <<__Memoize>>
   public function getExpression(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_expression);
+    return TypeAssert\instance_of(IExpression::class, $this->_expression);
   }
 
   /**

--- a/codegen/syntax/YieldExpression.hack
+++ b/codegen/syntax/YieldExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ede251cea165871dd27ccf1b3fe97538>>
+ * @generated SignedSource<<852380d4a7f3541f7583b4b0496cad0c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -30,6 +30,7 @@ final class YieldExpression extends Node implements ILambdaBody, IExpression {
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
@@ -37,6 +38,7 @@ final class YieldExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'YieldToken',
     );
     $offset += $keyword->getWidth();
     $operand = Node::fromJSON(
@@ -44,6 +46,7 @@ final class YieldExpression extends Node implements ILambdaBody, IExpression {
       $file,
       $offset,
       $source,
+      'Node',
     );
     $offset += $operand->getWidth();
     $source_ref = shape(

--- a/codegen/syntax/YieldFromExpression.hack
+++ b/codegen/syntax/YieldFromExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ff65601fe17edc0fa3b1d6c449efdad3>>
+ * @generated SignedSource<<022e4a110ba843ebbed26887258bf858>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -35,6 +35,7 @@ final class YieldFromExpression
     string $file,
     int $initial_offset,
     string $source,
+    string $_type_hint,
   ): this {
     $offset = $initial_offset;
     $yield_keyword = Node::fromJSON(
@@ -42,6 +43,7 @@ final class YieldFromExpression
       $file,
       $offset,
       $source,
+      'YieldToken',
     );
     $offset += $yield_keyword->getWidth();
     $from_keyword = Node::fromJSON(
@@ -49,6 +51,7 @@ final class YieldFromExpression
       $file,
       $offset,
       $source,
+      'FromToken',
     );
     $offset += $from_keyword->getWidth();
     $operand = Node::fromJSON(
@@ -56,6 +59,7 @@ final class YieldFromExpression
       $file,
       $offset,
       $source,
+      'IExpression',
     );
     $offset += $operand->getWidth();
     $source_ref = shape(
@@ -172,9 +176,8 @@ final class YieldFromExpression
    * @return ArrayCreationExpression | FunctionCallExpression |
    * LiteralExpression | ParenthesizedExpression | VariableExpression
    */
-  <<__Memoize>>
   public function getOperand(): IExpression {
-    return __Private\Wrap\wrap_IExpression($this->_operand);
+    return TypeAssert\instance_of(IExpression::class, $this->_operand);
   }
 
   /**

--- a/src/__Private/codegen/CodegenNodeFromJSON.hack
+++ b/src/__Private/codegen/CodegenNodeFromJSON.hack
@@ -53,12 +53,13 @@ final class CodegenNodeFromJSON extends CodegenBase {
       ->useNamespace('Facebook\\HHAST')
       ->addFunction(
         $cg
-          ->codegenFunction('node_from_json')
+          ->codegenFunction('node_from_json_unwrapped')
           ->setReturnType('HHAST\\Node')
           ->addParameter('dict<string, mixed> $json')
           ->addParameter('string $file')
           ->addParameter('int $offset')
           ->addParameter('string $source')
+          ->addParameter('string $type_hint')
           ->setBody(
             $cg
               ->codegenHackBuilder()
@@ -72,10 +73,11 @@ final class CodegenNodeFromJSON extends CodegenBase {
               ->addMultilineCall(
                 'HHAST\\Token::fromJSON',
                 vec[
-                  '$json[\'token\'] as dict<_, _>',
+                  '/* HH_FIXME[4110] */ $json[\'token\']',
                   '$file',
                   '$offset',
                   '$source',
+                  '$type_hint',
                 ],
               )
               ->endIfBlock()
@@ -98,7 +100,7 @@ final class CodegenNodeFromJSON extends CodegenBase {
               ->add('return ')
               ->addMultilineCall(
                 '$class::fromJSON',
-                vec['$json', '$file', '$offset', '$source'],
+                vec['$json', '$file', '$offset', '$source', '$type_hint'],
               )
               ->endIfBlock()
               ->addMultilineCall(

--- a/src/__Private/from_decoded_json.hack
+++ b/src/__Private/from_decoded_json.hack
@@ -9,7 +9,7 @@
 
 namespace Facebook\HHAST\__Private;
 
-use type Facebook\HHAST\{Node, SchemaVersionError, Script};
+use type Facebook\HHAST\{SchemaVersionError, Script};
 use const Facebook\HHAST\SCHEMA_VERSION;
 
 function from_decoded_json(
@@ -20,10 +20,11 @@ function from_decoded_json(
   if ($version is string && $version !== SCHEMA_VERSION) {
     throw new SchemaVersionError($file ?? '! no file !', $version);
   }
-  return Node::fromJSON(
+  return Script::fromJSON(
     /* HH_IGNORE_ERROR[4110] */ $json['parse_tree'],
     $file ?? '! no file !',
     0,
     /* HH_IGNORE_ERROR[4110] */ $json['program_text'],
-  ) as Script;
+    'Script',
+  );
 }

--- a/src/__Private/node_from_json.hack
+++ b/src/__Private/node_from_json.hack
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private;
+
+use type Facebook\HHAST\Node;
+
+function node_from_json(
+  dict<string, mixed> $json,
+  string $file,
+  int $offset,
+  string $source,
+  string $type_hint,
+): Node {
+  $node = node_from_json_unwrapped($json, $file, $offset, $source, $type_hint);
+  if ($type_hint === 'IExpression') {
+    return Wrap\wrap_IExpression($node);
+  }
+  return $node;
+}

--- a/src/__Private/node_from_json.hack
+++ b/src/__Private/node_from_json.hack
@@ -19,6 +19,9 @@ function node_from_json(
   string $type_hint,
 ): Node {
   $node = node_from_json_unwrapped($json, $file, $offset, $source, $type_hint);
+  if ($node->isMissing()) {
+    return $node;
+  }
   if ($type_hint === 'IExpression') {
     return Wrap\wrap_IExpression($node);
   }

--- a/src/nodes/ListItem.hack
+++ b/src/nodes/ListItem.hack
@@ -10,6 +10,7 @@
 namespace Facebook\HHAST;
 
 use namespace Facebook\TypeAssert;
+use namespace HH\Lib\Str;
 
 final class ListItem<+T as ?Node> extends Node {
 
@@ -34,13 +35,22 @@ final class ListItem<+T as ?Node> extends Node {
     string $file,
     int $initial_offset,
     string $source,
+    string $type_hint,
   ): this {
+    if (Str\starts_with($type_hint, 'ListItem<')) {
+      $type_hint = $type_hint
+        |> Str\strip_prefix($$, 'ListItem<')
+        |> Str\strip_suffix($$, '>');
+    } else {
+      $type_hint = 'Node';
+    }
     $offset = $initial_offset;
     $item = Node::fromJSON(
       /* HH_FIXME[4110] */ $json['list_item'],
       $file,
       $offset,
       $source,
+      $type_hint,
     );
     $offset += $item->getWidth();
     $separator = Node::fromJSON(
@@ -48,6 +58,7 @@ final class ListItem<+T as ?Node> extends Node {
       $file,
       $offset,
       $source,
+      'Token',
     );
     $offset += $separator->getWidth();
     $source_ref = shape(

--- a/src/nodes/Missing.hack
+++ b/src/nodes/Missing.hack
@@ -37,6 +37,7 @@ final class Missing extends Node {
     string $_file,
     int $_position,
     string $_source,
+    string $_type_hint,
   ): this {
     return self::getInstance();
   }

--- a/src/nodes/Node.hack
+++ b/src/nodes/Node.hack
@@ -132,8 +132,9 @@ abstract class Node {
     string $file,
     int $offset,
     string $source,
+    string $type_hint,
   ): Node {
-    return __Private\node_from_json($json, $file, $offset, $source);
+    return __Private\node_from_json($json, $file, $offset, $source, $type_hint);
   }
 
   public function toVec(): vec<Node> {

--- a/src/nodes/NodeList.hack
+++ b/src/nodes/NodeList.hack
@@ -9,7 +9,7 @@
 
 namespace Facebook\HHAST;
 
-use namespace HH\Lib\{C, Vec};
+use namespace HH\Lib\{C, Str, Vec};
 
 final class NodeList<+Titem as Node> extends Node {
   const string SYNTAX_KIND = 'list';
@@ -90,11 +90,25 @@ final class NodeList<+Titem as Node> extends Node {
     string $file,
     int $offset,
     string $source,
+    string $type_hint,
   ): this {
+    if (Str\starts_with($type_hint, 'NodeList<')) {
+      $type_hint = $type_hint
+        |> Str\strip_prefix($$, 'NodeList<')
+        |> Str\strip_suffix($$, '>');
+    } else {
+      $type_hint = 'Node';
+    }
     $children = vec[];
     $current_position = $offset;
     foreach (/* HH_FIXME[4110] */ $json['elements'] as $element) {
-      $child = Node::fromJSON($element, $file, $current_position, $source);
+      $child = Node::fromJSON(
+        $element,
+        $file,
+        $current_position,
+        $source,
+        $type_hint,
+      );
       $children[] = $child;
       $current_position += $child->getWidth();
     }

--- a/src/nodes/Token.hack
+++ b/src/nodes/Token.hack
@@ -126,10 +126,11 @@ abstract class Token extends Node {
     string $file,
     int $offset,
     string $source,
+    string $_type_hint,
   ): Token {
     $leading_list = __Private\fold_map(
       /* HH_FIXME[4110] use like-types when available*/ $json['leading'],
-      ($j, $p) ==> Node::fromJSON($j, $file, $p, $source),
+      ($j, $p) ==> Node::fromJSON($j, $file, $p, $source, 'Node'),
       ($j, $p) ==> $j['width'] + $p,
       $offset,
     );
@@ -151,7 +152,7 @@ abstract class Token extends Node {
     $trailing_position = $token_position + $token_width;
     $trailing_list = __Private\fold_map(
       /* HH_IGNORE_ERROR[4110] */ $json['trailing'],
-      ($j, $p) ==> Node::fromJSON($j, $file, $p, $source),
+      ($j, $p) ==> Node::fromJSON($j, $file, $p, $source, 'Node'),
       ($j, $p) ==> $j['width'] + $p,
       $trailing_position,
     );
@@ -169,6 +170,7 @@ abstract class Token extends Node {
     $width = $json['leading_width'] as int +
       $json['width'] as int +
       $json['trailing_width'] as int;
+
     return __Private\token_from_data(
       shape(
         'file' => $file,

--- a/src/nodes/Trivia.hack
+++ b/src/nodes/Trivia.hack
@@ -49,6 +49,7 @@ abstract class Trivia extends Node {
     string $file,
     int $offset,
     string $source,
+    string $_type_hint,
   ): Trivia {
     return __Private\trivia_from_json($json, shape(
       'file' => $file,

--- a/tests/NodeTypesTest.hack
+++ b/tests/NodeTypesTest.hack
@@ -7,20 +7,22 @@
  *
  */
 
-
 namespace Facebook\HHAST;
+
+use function Facebook\FBExpect\expect;
+use namespace HH\Lib\{Str, Vec};
 
 final class NodeTypesTest extends TestCase {
   public function testListVariance(): void {
-    $_typecheck = ((?NodeList<ListItem<IParameter>> $_) ==> null)(
-      (null ?as FunctionDeclarationHeader)?->getParameterListx(),
-    );
-    $_typecheck = ((?NodeList<ListItem<Node>> $_) ==> null)(
-      (null ?as FunctionDeclarationHeader)?->getParameterListx(),
-    );
-    $_typecheck = ((?NodeList<Node> $_) ==> null)(
-      (null ?as FunctionDeclarationHeader)?->getParameterListx(),
-    );
+    $_typecheck = (
+      (?NodeList<ListItem<IParameter>> $_) ==> null
+    )((null ?as FunctionDeclarationHeader)?->getParameterListx());
+    $_typecheck = (
+      (?NodeList<ListItem<Node>> $_) ==> null
+    )((null ?as FunctionDeclarationHeader)?->getParameterListx());
+    $_typecheck = (
+      (?NodeList<Node> $_) ==> null
+    )((null ?as FunctionDeclarationHeader)?->getParameterListx());
   }
 
   public function testBinaryExpressionOperandsAreExpressions(): void {
@@ -28,5 +30,64 @@ final class NodeTypesTest extends TestCase {
     $be = null ?as BinaryExpression;
     $typecheck($be?->getLeftOperand());
     $typecheck($be?->getRightOperand());
+  }
+
+  public async function testNameTokenWrappedAsExpression(): Awaitable<void> {
+    $code = "<?hh \$x = SOME_CONST; \$y = SOME\\NAMESPACED\\CONST;";
+    $ast = await from_file_async(File::fromPathAndContents('/dev/null', $code));
+    list($_markup, $x, $y) = $ast->getDeclarations()->getChildren();
+
+    $x = expect($x)->toBeInstanceOf(ExpressionStatement::class);
+    $x_expr = $x->getExpressionx() as BinaryExpression;
+    $some_const = expect($x_expr->getRightOperand())->toBeInstanceOf(
+      NameExpression::class,
+    );
+    $name_token = expect($some_const->getWrappedNode())->toBeInstanceOf(
+      NameToken::class,
+    );
+    expect($name_token->getText())->toBeSame('SOME_CONST');
+
+    $y = expect($y)->toBeInstanceOf(ExpressionStatement::class);
+    $y_expr = $y->getExpressionx() as BinaryExpression;
+    $some_namespaced_const = expect($y_expr->getRightOperand())->toBeInstanceOf(
+      NameExpression::class,
+    );
+    $qualified_name = expect($some_namespaced_const->getWrappedNode())
+      ->toBeInstanceOf(QualifiedName::class);
+    expect(
+      $qualified_name->getDescendantsOfType(Token::class)
+        |> Vec\map($$, $t ==> $t->getText())
+        |> Str\join($$, ''),
+    )->toBeSame("SOME\\NAMESPACED\\CONST");
+  }
+
+  public async function testNameTokenWrappedInListOfItemsOfExpressions(
+  ): Awaitable<void> {
+    // Make sure that tokens in List<ListItem<IExpression>> get wrapped
+    $code = "<?hh \$x = tuple(SOME_CONST, SOME\\NAMESPACED\\CONST);";
+    $ast = await from_file_async(File::fromPathAndContents('/dev/null', $code));
+    list($_markup, $x) = $ast->getDeclarations()->getChildren();
+    $x = expect($x)->toBeInstanceOf(ExpressionStatement::class);
+    $x_expr = $x->getExpressionx() as BinaryExpression;
+    $rhs = expect($x_expr->getRightOperand())->toBeInstanceOf(
+      TupleExpression::class,
+    );
+    list($c1, $c2) = $rhs->getItemsx()->getChildrenOfItems();
+    $c1 = expect($c1)->toBeInstanceOf(
+      NameExpression::class,
+      'constant in tuple is not wrapped',
+    );
+    $c2 = expect($c2)->toBeInstanceOf(
+      NameExpression::class,
+      'namespaced constant in tuple is not wrapped',
+    );
+    $c1 = expect($c1->getWrappedNode())->toBeInstanceOf(NameToken::class);
+    expect($c1->getText())->toBeSame('SOME_CONST');
+    $c2 = expect($c2->getWrappedNode())->toBeInstanceOf(QualifiedName::class);
+    expect(
+      $c2->getDescendantsOfType(Token::class)
+        |> Vec\map($$, $t ==> $t->getText())
+        |> Str\join($$, ''),
+    )->toBeSame("SOME\\NAMESPACED\\CONST");
   }
 }

--- a/tests/RewriteBehaviorTest.hack
+++ b/tests/RewriteBehaviorTest.hack
@@ -146,7 +146,7 @@ final class RewriteBehaviorTest extends TestCase {
 
   public async function testRewritePreservesCaseOfFixedTextTokens(
   ): Awaitable<void> {
-    $code = "<?hh NuLl; aRrAy; aNd; oR; cAsE";
+    $code = "<?hh \$x = NuLl;";
     $ast = await HHAST\from_file_async(
       HHAST\File::fromPathAndContents('/dev/null', $code),
     );

--- a/tests/examples/migrations/assert_to_expect.php.expect
+++ b/tests/examples/migrations/assert_to_expect.php.expect
@@ -5,7 +5,7 @@ use function hello;
 use function Facebook\FBExpect\expect;
 use type that;
 
-public class Test {
+class Test {
 
   public function testMethod(): void {
     expect($a)->toBeSame($a);

--- a/tests/examples/migrations/assert_to_expect.php.in
+++ b/tests/examples/migrations/assert_to_expect.php.in
@@ -4,7 +4,7 @@ use namespace hi;
 use function hello;
 use type that;
 
-public class Test {
+class Test {
 
   public function testMethod(): void {
     self::assertSame($a, $a);


### PR DESCRIPTION
fixes #180

Previously would wrap in accessors; instead wrap when converting the
JSON to objects, passing through type information.

- fixed several unit test that were checking invalid Hack code, as this
moves "expected expression" errors to an earlier phase
- added runtime tests for `IExpression` and `List<ListItem<IExpression>>`
- while I was there, removed `as dict<_, _>` given poor
non-repo-auth-mode performance