### PR TITLE
Add linter to detect unused variables

### DIFF
--- a/src/Linters/FinalOrAbstractClassLinter.hack
+++ b/src/Linters/FinalOrAbstractClassLinter.hack
@@ -29,7 +29,6 @@ final class FinalOrAbstractClassLinter extends ASTLinter {
 
     // check if the ClassishDeclaration has modifiers
     $modifiers = $node->getModifiers();
-    $found = false;
     if ($modifiers !== null) {
       foreach ($modifiers->traverse() as $mod) {
         if ($mod is FinalToken || $mod is AbstractToken) {

--- a/src/Linters/NoEmptyStatementsLinter.hack
+++ b/src/Linters/NoEmptyStatementsLinter.hack
@@ -57,8 +57,6 @@ final class NoEmptyStatementsLinter extends AutoFixingASTLinter {
     }
 
     $semicolon = $stmt->getSemicolonx();
-    $leading = $semicolon->getLeading();
-    $trailing = $semicolon->getTrailing();
 
     return NodeList::concat(
       $semicolon->getLeading(),

--- a/src/Linters/NoStringInterpolationLinter.hack
+++ b/src/Linters/NoStringInterpolationLinter.hack
@@ -43,8 +43,6 @@ final class NoStringInterpolationLinter extends AutoFixingASTLinter {
     $expr = $root_expr->getExpression();
     invariant($expr is NodeList<_>, "Expected list, got %s", \get_class($expr));
 
-    $leading = null;
-    $trailing = null;
     $children = vec($expr->getChildren());
     $child_count = C\count($children);
     $new_children = vec[];
@@ -56,7 +54,6 @@ final class NoStringInterpolationLinter extends AutoFixingASTLinter {
       }
       if ($child is DoubleQuotedStringLiteralHeadToken) {
         if ($child->getText() === '"') {
-          $leading = $child->getLeading();
           continue;
         }
         $new_children[] = new DoubleQuotedStringLiteralToken(
@@ -69,7 +66,6 @@ final class NoStringInterpolationLinter extends AutoFixingASTLinter {
 
       if ($child is DoubleQuotedStringLiteralTailToken) {
         if ($child->getText() === '"') {
-          $trailing = $child->getTrailing();
           break;
         }
         $new_children[] = new DoubleQuotedStringLiteralToken(

--- a/src/Linters/UnusedVariableLinter.hack
+++ b/src/Linters/UnusedVariableLinter.hack
@@ -187,9 +187,6 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
     VariableExpression $var,
     vec<Node> $parents,
   ): bool {
-    // Whether we have encountered a $parent SubscriptExpression where SubscriptExpression::getReceiver === $var
-    $is_subscript_receiver = null;
-
     foreach (Vec\reverse($parents) as $parent) {
       if ($parent === $var) {
         continue;
@@ -212,11 +209,11 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
       // $a[$b] = '123'; // assignment of $a, use of $b
       // f($a[$b]);      // use of $a
       if ($parent is HHAST\SubscriptExpression) {
-        $is_subscript_receiver ??= $parent->getReceiver() === $var;
-        if ($is_subscript_receiver) {
-          continue;
-        } else {
+        $index = $parent->getIndex();
+        if ($index !== null && $index->isAncestorOf($var)) {
           return false;
+        } else {
+          continue;
         }
       }
 

--- a/src/Linters/UnusedVariableLinter.hack
+++ b/src/Linters/UnusedVariableLinter.hack
@@ -22,7 +22,7 @@ use type Facebook\HHAST\{
 };
 
 use namespace Facebook\HHAST;
-use namespace HH\Lib\{C, Str, Vec};
+use namespace HH\Lib\{C, Keyset, Str, Vec};
 
 final class UnusedVariableLinter extends AutoFixingASTLinter {
   const type TNode = VariableExpression;
@@ -73,14 +73,14 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
    */
   private function getAlwaysUsedVariables(
     HHAST\FunctionDeclarationHeader $header,
-  ): vec<string> {
+  ): keyset<string> {
     $params = $header->getDescendantsOfType(ParameterDeclaration::class);
 
     return Vec\filter(
       $params,
       $p ==> self::isByRefParam($p) || self::isInoutParam($p),
     )
-      |> Vec\map($$, $p ==> self::getParamName($p));
+      |> Keyset\map($$, $p ==> self::getParamName($p));
   }
 
   private static function isInoutParam(ParameterDeclaration $param): bool {
@@ -154,7 +154,7 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
   <<__Memoize>>
   private function classifyVariables(
     MemoizableNode<CompoundStatement> $node,
-  ): shape('assigned' => vec<string>, 'used' => vec<string>) {
+  ): shape('assigned' => keyset<string>, 'used' => keyset<string>) {
     $body = $node->getNode();
 
     $ret = shape('assigned' => vec[], 'used' => vec[]);
@@ -168,11 +168,11 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
       }
     }
 
-    $ret['assigned'] = Vec\map(
+    $ret['assigned'] = Keyset\map(
       $ret['assigned'],
       $v ==> ($v->getExpression() as VariableToken)->getText(),
     );
-    $ret['used'] = Vec\map(
+    $ret['used'] = Keyset\map(
       $ret['used'],
       $v ==> ($v->getExpression() as VariableToken)->getText(),
     );

--- a/src/Linters/UnusedVariableLinter.hack
+++ b/src/Linters/UnusedVariableLinter.hack
@@ -33,7 +33,6 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
       return null;
     }
 
-
     list($header, $body) = $this->getFunctionishParts($functionish);
     if (C\contains($this->getAlwaysUsedVariables($header), $name)) {
       return null;

--- a/src/Linters/UnusedVariableLinter.hack
+++ b/src/Linters/UnusedVariableLinter.hack
@@ -7,21 +7,8 @@
  *
  */
 
-namespace Facebook\HHAST\Linters;
+namespace Facebook\HHAST;
 
-use type Facebook\HHAST\{
-  CompoundStatement,
-  FunctionDeclaration,
-  FunctionDeclarationHeader,
-  IFunctionishDeclaration,
-  MethodishDeclaration,
-  Node,
-  ParameterDeclaration,
-  VariableExpression,
-  VariableToken,
-};
-
-use namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Keyset, Str, Vec};
 
 final class UnusedVariableLinter extends AutoFixingASTLinter {
@@ -72,7 +59,7 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
    * considered "used"
    */
   private function getAlwaysUsedVariables(
-    HHAST\FunctionDeclarationHeader $header,
+    FunctionDeclarationHeader $header,
   ): keyset<string> {
     $params = $header->getDescendantsOfType(ParameterDeclaration::class);
 
@@ -84,13 +71,13 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
   }
 
   private static function isInoutParam(ParameterDeclaration $param): bool {
-    return $param->getCallConvention() is HHAST\InoutToken;
+    return $param->getCallConvention() is InoutToken;
   }
 
   private static function isByRefParam(ParameterDeclaration $param): bool {
     $name = $param->getName();
-    return $name is HHAST\DecoratedExpression &&
-      $name->getDecorator() is HHAST\AmpersandToken;
+    return $name is DecoratedExpression &&
+      $name->getDecorator() is AmpersandToken;
   }
 
   private static function getParamName(ParameterDeclaration $param): string {
@@ -98,7 +85,7 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
     return $name is VariableToken
       ? $name->getText()
       : (
-          ($name as HHAST\DecoratedExpression)->getExpression() as VariableToken
+          ($name as DecoratedExpression)->getExpression() as VariableToken
         )->getText();
   }
 
@@ -193,7 +180,7 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
       }
 
       // Too early to tell
-      if ($parent is HHAST\ListItem<_> || $parent is HHAST\NodeList<_>) {
+      if ($parent is ListItem<_> || $parent is NodeList<_>) {
         continue;
       }
 
@@ -208,7 +195,7 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
       //
       // $a[$b] = '123'; // assignment of $a, use of $b
       // f($a[$b]);      // use of $a
-      if ($parent is HHAST\SubscriptExpression) {
+      if ($parent is SubscriptExpression) {
         $index = $parent->getIndex();
         if ($index !== null && $index->isAncestorOf($var)) {
           return false;
@@ -218,7 +205,7 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
       }
 
       if (
-        $parent is HHAST\BinaryExpression &&
+        $parent is BinaryExpression &&
         $this->isAssignmentExpression($parent) &&
         $parent->getLeftOperand()->isAncestorOf($var)
       ) {
@@ -226,14 +213,14 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
       }
 
       if (
-        $parent is HHAST\ForeachStatement &&
+        $parent is ForeachStatement &&
         (($parent->getValue() === $var) || ($parent->getKey() === $var))
       ) {
         return true;
       }
 
       if (
-        $parent is HHAST\ListExpression &&
+        $parent is ListExpression &&
         (bool)$parent->getMembers()?->isAncestorOf($var)
       ) {
         return true;
@@ -249,23 +236,23 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
    * These are all the return types of BinaryExpression::getOperator
    * that contain "Equal" and are not comparison operators.
    */
-  private function isAssignmentExpression(HHAST\BinaryExpression $expr): bool {
+  private function isAssignmentExpression(BinaryExpression $expr): bool {
     $op = $expr->getOperator();
     return (
-      $op is HHAST\AmpersandEqualToken ||
-      $op is HHAST\BarEqualToken ||
-      $op is HHAST\CaratEqualToken ||
-      $op is HHAST\DotEqualToken ||
-      $op is HHAST\EqualToken ||
-      $op is HHAST\GreaterThanGreaterThanEqualToken ||
-      $op is HHAST\LessThanLessThanEqualToken ||
-      $op is HHAST\MinusEqualToken ||
-      $op is HHAST\PercentEqualToken ||
-      $op is HHAST\PlusEqualToken ||
-      $op is HHAST\QuestionQuestionEqualToken ||
-      $op is HHAST\SlashEqualToken ||
-      $op is HHAST\StarEqualToken ||
-      $op is HHAST\StarStarEqualToken
+      $op is AmpersandEqualToken ||
+      $op is BarEqualToken ||
+      $op is CaratEqualToken ||
+      $op is DotEqualToken ||
+      $op is EqualToken ||
+      $op is GreaterThanGreaterThanEqualToken ||
+      $op is LessThanLessThanEqualToken ||
+      $op is MinusEqualToken ||
+      $op is PercentEqualToken ||
+      $op is PlusEqualToken ||
+      $op is QuestionQuestionEqualToken ||
+      $op is SlashEqualToken ||
+      $op is StarEqualToken ||
+      $op is StarStarEqualToken
     );
   }
 

--- a/src/Linters/UnusedVariableLinter.hack
+++ b/src/Linters/UnusedVariableLinter.hack
@@ -1,0 +1,253 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\Linters;
+
+use type Facebook\HHAST\{
+  CompoundStatement,
+  FunctionDeclaration,
+  ParameterDeclaration,
+  VariableToken,
+  VariableExpression,
+  Node,
+};
+
+use namespace Facebook\HHAST;
+use namespace HH\Lib\{C, Str, Vec};
+
+final class UnusedVariableLinter extends AutoFixingASTLinter {
+  const type TNode = VariableExpression;
+  const type TContext = FunctionDeclaration;
+
+  <<__Override>>
+  public function getLintErrorForNode(
+    FunctionDeclaration $functionish,
+    VariableExpression $node,
+  ): ?ASTLintError {
+
+    $var = $node->getExpression();
+    if (!$var is VariableToken) {
+      return null;
+    }
+    $name = $var->getText();
+
+    // $_ is the convention for marking a variable unused
+    // Use of $GLOBALS by definition may happen outside the scope of $functionish
+    if (Str\starts_with($name, '$_') || $name === '$GLOBALS') {
+      return null;
+    }
+
+    // TODO: Support methods
+    $body = $functionish->getBody() as CompoundStatement;
+    $header = $functionish->getDeclarationHeader();
+
+    if (C\contains($this->getAlwaysUsedVariables($header), $name)) {
+      return null;
+    }
+
+    $vars = $this->classifyVariables($body);
+    if (C\contains($vars['used'], $name)) {
+      return null;
+    }
+
+    // If a variable is not classified as used then we are currently
+    // evaluating an assignment
+    return new ASTLintError(
+      $this,
+      "Variable is unused",
+      $node,
+      () ==> $this->getFixedNode($node),
+    );
+  }
+
+  /**
+   * Get parameters that are passed by reference or marked inout which are always
+   * considered "used"
+   */
+  private function getAlwaysUsedVariables(
+    HHAST\FunctionDeclarationHeader $header,
+  ): vec<string> {
+    $params = $header->getDescendantsOfType(ParameterDeclaration::class);
+
+    return Vec\filter(
+      $params,
+      $p ==> self::isByRefParam($p) || self::isInoutParam($p),
+    )
+      |> Vec\map($$, $p ==> self::getParamName($p));
+  }
+
+  private static function isInoutParam(ParameterDeclaration $param): bool {
+    return $param->getCallConvention() is HHAST\InoutToken;
+  }
+
+  private static function isByRefParam(ParameterDeclaration $param): bool {
+    $name = $param->getName();
+    return $name is HHAST\DecoratedExpression &&
+      $name->getDecorator() is HHAST\AmpersandToken;
+  }
+
+  private static function getParamName(ParameterDeclaration $param): string {
+    $name = $param->getName();
+    return $name is VariableToken
+      ? $name->getText()
+      : (
+          ($name as HHAST\DecoratedExpression)->getExpression() as VariableToken
+        )->getText();
+  }
+
+  /**
+   * Classify every variable expression in `$body` as an assignment or a use.
+   *
+   * An assignment is a variable expression that is one of the following:
+   *
+   * 1a. The left-hand side of a binary expression with an assignment operator
+   *   that is not part of the index of a subscript expression.
+   * 2. The key or value of a foreach clause
+   * 3. The members of a list expression
+   *
+   * Any non-assignment of a variable is considered to be a use. This means that
+   * bugs or oversights in this method will cause false negatives.
+   *
+   * Examples of assignment:
+   * ```
+   * // 1.
+   * $a = 1;
+   * $b .= 'foo';
+   * $by_id[2] = 'baz';
+   *
+   * // 2.
+   * foreach ($items as $k => $v) {}
+   *
+   * // 3.
+   * list($a, $b) = $parts;
+   * ```
+   */
+  private function classifyVariables(
+    CompoundStatement $body,
+  ): shape('assigned' => vec<string>, 'used' => vec<string>) {
+    $ret = shape('assigned' => vec[], 'used' => vec[]);
+    foreach ($body->getDescendantsOfType(VariableExpression::class) as $var) {
+      if (
+        $this->isVariableAssignment($var, $body->getAncestorsOfDescendant($var))
+      ) {
+        $ret['assigned'][] = $var;
+      } else {
+        $ret['used'][] = $var;
+      }
+    }
+
+    $ret['assigned'] = Vec\map(
+      $ret['assigned'],
+      $v ==> ($v->getExpression() as VariableToken)->getText(),
+    );
+    $ret['used'] = Vec\map(
+      $ret['used'],
+      $v ==> ($v->getExpression() as VariableToken)->getText(),
+    );
+
+    return $ret;
+  }
+
+  /**
+   * Return whether `$var` is being assigned in the scope of `$parents`.
+   */
+  private function isVariableAssignment(
+    VariableExpression $var,
+    vec<Node> $parents,
+  ): bool {
+    foreach (Vec\reverse($parents) as $parent) {
+      if ($parent === $var) {
+        continue;
+      }
+
+      // Too early to tell
+      if ($parent is HHAST\ListItem<_> || $parent is HHAST\NodeList<_>) {
+        continue;
+      }
+
+      // $a[$b]
+      // ^^ ^^
+      // |  +-- index
+      // +-- receiver
+      if ($parent is HHAST\SubscriptExpression) {
+        return $parent->getReceiver() === $var;
+      }
+
+      if (
+        $parent is HHAST\BinaryExpression &&
+        $this->isAssignmentExpression($parent) &&
+        $parent->getLeftOperand() === $var
+      ) {
+        return true;
+      }
+
+      if (
+        $parent is HHAST\ForeachStatement &&
+        (($parent->getValue() === $var) || ($parent->getKey() === $var))
+      ) {
+        return true;
+      }
+
+      if (
+        $parent is HHAST\ListExpression &&
+        (bool)$parent->getMembers()?->isAncestorOf($var)
+      ) {
+        return true;
+      }
+
+      break;
+    }
+
+    return false;
+  }
+
+  /**
+   * These are all the return types of BinaryExpression::getOperator
+   * that contain "Equal" and are not comparison operators.
+   */
+  private function isAssignmentExpression(HHAST\BinaryExpression $expr): bool {
+    $op = $expr->getOperator();
+    return (
+      $op is HHAST\AmpersandEqualToken ||
+      $op is HHAST\BarEqualToken ||
+      $op is HHAST\CaratEqualToken ||
+      $op is HHAST\DotEqualToken ||
+      $op is HHAST\EqualToken ||
+      $op is HHAST\GreaterThanGreaterThanEqualToken ||
+      $op is HHAST\LessThanLessThanEqualToken ||
+      $op is HHAST\MinusEqualToken ||
+      $op is HHAST\PercentEqualToken ||
+      $op is HHAST\PlusEqualToken ||
+      $op is HHAST\QuestionQuestionEqualToken ||
+      $op is HHAST\SlashEqualToken ||
+      $op is HHAST\StarEqualToken ||
+      $op is HHAST\StarStarEqualToken
+    );
+  }
+
+  public function getFixedNode(VariableExpression $node): VariableExpression {
+    $expr = $node->getExpression();
+    if (!$expr is VariableToken) {
+      return $node;
+    }
+    return $node->withExpression(
+      $expr->withText('$_'.Str\strip_prefix($expr->getText(), '$')),
+    );
+  }
+
+  <<__Override>>
+  public function getTitleForFix(ASTLintError $err): string {
+    $expr = ($err->getBlameNode() as this::TNode);
+    $token = $expr->getExpression();
+    invariant($token is VariableToken, 'unhandled type');
+
+    $new_name = '$_'.Str\strip_prefix($token->getText(), '$');
+    return Str\format('Rename to `%s`', $new_name);
+  }
+}

--- a/src/Migrations/AddFixmesMigration.hack
+++ b/src/Migrations/AddFixmesMigration.hack
@@ -48,7 +48,7 @@ final class AddFixmesMigration extends BaseMigration {
         $column += $column_offset;
       } else {
         $previous_error_line = $line;
-        $column_offest = 0;
+        $column_offset = 0;
       }
       $node = find_node_at_position($root, $line, $column)->getFirstTokenx();
       $leading = $node->getLeading();

--- a/src/Migrations/HSLMigration.hack
+++ b/src/Migrations/HSLMigration.hack
@@ -401,9 +401,6 @@ final class HSLMigration extends BaseMigration {
         // we can compute the correct length as abs(offset) + length and rewrite teh node
         if ($offset < 0) {
           $rewrite_length_value = Math\abs($offset) + $length;
-          $unary = C\onlyx(
-            $items[2]->getDescendantsOfType(PrefixUnaryExpression::class),
-          );
           $new_length = new ListItem(
             new LiteralExpression(new DecimalLiteralToken(
               null,
@@ -478,8 +475,6 @@ final class HSLMigration extends BaseMigration {
     Script $root,
     FunctionCallExpression $node,
   ): Script {
-    $parents = null;
-    $found = false;
     $stack = $root->getAncestorsOfDescendant($node);
     invariant(!C\is_empty($stack), 'did not find node in root');
     invariant(C\lastx($stack) === $node, 'expected node at top of stack');

--- a/src/__Private/LSPLib/Server.hack
+++ b/src/__Private/LSPLib/Server.hack
@@ -157,7 +157,6 @@ abstract class Server<TState as ServerState> {
       return;
     }
 
-    $error = $result->getError();
     await $this->client
       ->sendResponseMessageAsync(shape(
         'jsonrpc' => '2.0',

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -71,6 +71,7 @@ final class LintRunConfig {
     HHAST\NoElseifLinter::class,
     HHAST\NoPHPEqualityLinter::class,
     HHAST\UnusedParameterLinter::class,
+    HHAST\UnusedVariableLinter::class,
     HHAST\UnusedUseClauseLinter::class,
     HHAST\UseStatementWithLeadingBackslashLinter::class,
     HHAST\UseStatementWithoutKindLinter::class,

--- a/src/__Private/LinterCLI.hack
+++ b/src/__Private/LinterCLI.hack
@@ -160,7 +160,6 @@ final class LinterCLI extends CLIWithArguments {
       ));
       if ($pos !== null && \is_readable($e->getFileBeingLinted())) {
         list($line, $column) = $pos;
-        $content = \file_get_contents($e->getFileBeingLinted());
         await (
           \file_get_contents($e->getFileBeingLinted())
           |> Str\split($$, "\n")

--- a/src/__Private/codegen/CodegenSyntax.hack
+++ b/src/__Private/codegen/CodegenSyntax.hack
@@ -440,7 +440,6 @@ final class CodegenSyntax extends CodegenBase {
             Vec\map(
               $fields,
               $field ==> {
-                $spec = $this->getTypeSpecForField($syntax, $field);
                 return Str\format(
                   '$%s = $this->_%s->rewrite($rewriter, $parents);',
                   $field,

--- a/src/nodes/Node.hack
+++ b/src/nodes/Node.hack
@@ -116,7 +116,7 @@ abstract class Node {
   protected function getCodeUncached(): string {
     /* TODO: Make an accumulation sequence operator */
     $s = '';
-    foreach ($this->getChildren() as $key => $node) {
+    foreach ($this->getChildren() as $node) {
       $s .= $node->getCode();
     }
     return $s;
@@ -151,7 +151,6 @@ abstract class Node {
   final public function getFirstDescendantOfType<T as Node>(
     classname<T> $what,
   ): ?T {
-    $out = vec[];
     foreach ($this->_descendants as $node) {
       if (\is_a($node, $what)) {
         return /* HH_FIXME[4110] need reified generics */ $node;
@@ -241,7 +240,6 @@ abstract class Node {
     }
 
     invariant($this->isAncestorOf($node), "Node is not a descendant");
-    $stack = vec[$this];
     foreach ($this->getChildren() as $child) {
       if ($child === $node) {
         return vec[$this, $node];

--- a/src/nodes/TokenWithFixedText.hack
+++ b/src/nodes/TokenWithFixedText.hack
@@ -32,7 +32,6 @@ abstract class TokenWithFixedText extends Token {
     $parents[] = $this;
     $leading = $rewriter($this->getLeading(), $parents);
     $trailing = $rewriter($this->getTrailing(), $parents);
-    $text = $this->getText();
     if (
       $leading === $this->getLeading() && $trailing === $this->getTrailing()
     ) {

--- a/tests/LSPServerTest.hack
+++ b/tests/LSPServerTest.hack
@@ -23,7 +23,7 @@ final class LSPServerTest extends TestCase {
   use LinterCLITestTrait;
 
   public function testImmediateExit(): void {
-    list($cli, $in, $out, $err) = $this->getCLI('--mode', 'lsp');
+    list($cli, $in, $_out, $err) = $this->getCLI('--mode', 'lsp');
 
     shape(
       'jsonrpc' => '2.0',
@@ -39,7 +39,7 @@ final class LSPServerTest extends TestCase {
   }
 
   public function testExitAfterShutdown(): void {
-    list($cli, $in, $out, $err) = $this->getCLI('--mode', 'lsp');
+    list($cli, $in, $_out, $err) = $this->getCLI('--mode', 'lsp');
 
     shape(
       'jsonrpc' => '2.0',
@@ -118,7 +118,7 @@ final class LSPServerTest extends TestCase {
 
     $debug = (bool)\getenv('HHAST_LSP_DEBUG') ?? false;
 
-    list($code, $_) = await Tuple\from_async(
+    list($_code, $_) = await Tuple\from_async(
       $cli->mainAsync(),
       async {
         foreach ($messages as $message) {

--- a/tests/RewriteBehaviorTest.hack
+++ b/tests/RewriteBehaviorTest.hack
@@ -162,9 +162,6 @@ final class RewriteBehaviorTest extends TestCase {
           return $shape;
         }
 
-        $fields = $shape->getFieldsx()
-          ->getDescendantsOfType(HHAST\FieldSpecifier::class);
-
         return $shape->withFields(
           new HHAST\NodeList(
             Vec\map(

--- a/tests/TestLib/ExpectObj.hack
+++ b/tests/TestLib/ExpectObj.hack
@@ -74,7 +74,6 @@ final class ExpectObj<T> extends \Facebook\FBExpect\ExpectObj<T> {
       \fwrite(\STDERR, "----- END -----\n");
       \stream_set_blocking(\STDERR, false);
 
-      $recorded = false;
       if (\posix_isatty(\STDIN) && \posix_isatty(\STDERR)) {
         \fprintf(\STDERR, "Would you like to save this output? [y/N] ");
         \stream_set_blocking(\STDIN, true);
@@ -82,7 +81,6 @@ final class ExpectObj<T> extends \Facebook\FBExpect\ExpectObj<T> {
         \stream_set_blocking(\STDIN, false);
         if ($response === 'y') {
           \file_put_contents($expect_file, $code);
-          $recorded = true;
         }
       } else {
         throw new \Exception($expect_file.' does not exist');

--- a/tests/UnusedVariableLinterTest.hack
+++ b/tests/UnusedVariableLinterTest.hack
@@ -10,46 +10,46 @@
 namespace Facebook\HHAST;
 
 final class UnusedVariableLinterTest extends TestCase {
-  use AutoFixingLinterTestTrait<Linters\ASTLintError>;
+  use AutoFixingLinterTestTrait<ASTLintError>;
 
-  protected function getLinter(string $file): Linters\UnusedVariableLinter {
-    return Linters\UnusedVariableLinter::fromPath($file);
+  protected function getLinter(string $file): UnusedVariableLinter {
+    return UnusedVariableLinter::fromPath($file);
   }
 
-  public function getCleanExamples(): array<array<string>> {
-    return [
-      ['<?hh function foo() { $bar = 1; return $bar; }'],
-      ['<?hh function foo() { $_bar = 1; return 2; }'],
-      ['<?hh function foo() { $GLOBALS["foo"] = "bar"; }'],
-      ['<?hh function foo($xs) { foreach($xs as $x) { echo $x; } }'],
-      ['<?hh function foo($xs) { foreach($xs as $i => $x) { echo $i; echo $x; } }'],
-      ['<?hh function foo() { $k = 1; return dict[1 => 2][$k]; }'],
-      ['<?hh function foo($d) { $k = 1; $d[$k] = 5; return $d; }'],
-      ['<?hh function foo() { $d = []; return $d[1]; }'],
-      ['<?hh function foo() { $d = []; $d["a"] = "b"; f($d["a"]); }'],
-      ['<?hh function foo(&$d) { $d = 5; }'],
-      ['<?hh function foo(inout $d) { $d = 5; }'],
-      ['<?hh function foo() { $users = []; $u = ["id" => 15]; $users[$u["id"]] = 5; return $users; }'],
-      ['<?hh function foo() { $s = "a"; echo "{$s}"; }'],
+  public function getCleanExamples(): vec<(string)> {
+    return vec[
+      tuple('<?hh function foo() { $bar = 1; return $bar; }'),
+      tuple('<?hh function foo() { $_bar = 1; return 2; }'),
+      tuple('<?hh function foo() { $GLOBALS["foo"] = "bar"; }'),
+      tuple('<?hh function foo($xs) { foreach($xs as $x) { echo $x; } }'),
+      tuple('<?hh function foo($xs) { foreach($xs as $i => $x) { echo $i; echo $x; } }'),
+      tuple('<?hh function foo() { $k = 1; return dict[1 => 2][$k]; }'),
+      tuple('<?hh function foo($d) { $k = 1; $d[$k] = 5; return $d; }'),
+      tuple('<?hh function foo() { $d = []; return $d[1]; }'),
+      tuple('<?hh function foo() { $d = []; $d["a"] = "b"; f($d["a"]); }'),
+      tuple('<?hh function foo(&$d) { $d = 5; }'),
+      tuple('<?hh function foo(inout $d) { $d = 5; }'),
+      tuple('<?hh function foo() { $users = []; $u = ["id" => 15]; $users[$u["id"]] = 5; return $users; }'),
+      tuple('<?hh function foo() { $s = "a"; echo "{$s}"; }'),
       // TODO: Decide whether to support "${}" style string interpolation
-      // ['<?hh function foo() { $s = "a"; echo "${s}"; }'],
-      // ['<?hh function foo() { $d = dict["a" => "b"]; echo "${d[\'a\']}"; }'],
-      ['<?hh class C { public function foo() { $bar = 1; return $bar; } }'],
-      ['<?hh class C { public function foo() { $_bar = 1; return 2; } }'],
-      ['<?hh class C { public function foo() { $GLOBALS["foo"] = "bar"; } }'],
-      ['<?hh class C { public function foo($xs) { foreach($xs as $x) { echo $x; } } }'],
-      ['<?hh class C { public function foo($xs) { foreach($xs as $i => $x) { echo $i; echo $x; } } }'],
-      ['<?hh class C { public function foo() { $k = 1; return dict[1 => 2][$k]; } }'],
-      ['<?hh class C { public function foo($d) { $k = 1; $d[$k] = 5; return $d; } }'],
-      ['<?hh class C { public function foo() { $d = []; return $d[1]; } }'],
-      ['<?hh class C { public function foo() { $d = []; $d["a"] = "b"; f($d["a"]); } }'],
-      ['<?hh class C { public function foo(&$d) { $d = 5; } }'],
-      ['<?hh class C { public function foo(inout $d) { $d = 5; } }'],
-      ['<?hh class C { public function foo() { $users = []; $u = ["id" => 15]; $users[$u["id"]] = 5; return $users; } }'],
-      ['<?hh class C { public function foo() { $s = "a"; echo "{$s}"; } }'],
+      // tuple('<?hh function foo() { $s = "a"; echo "${s}"; }'),
+      // tuple('<?hh function foo() { $d = dict["a" => "b"]; echo "${d[\'a\']}"; }'),
+      tuple('<?hh class C { public function foo() { $bar = 1; return $bar; } }'),
+      tuple('<?hh class C { public function foo() { $_bar = 1; return 2; } }'),
+      tuple('<?hh class C { public function foo() { $GLOBALS["foo"] = "bar"; } }'),
+      tuple('<?hh class C { public function foo($xs) { foreach($xs as $x) { echo $x; } } }'),
+      tuple('<?hh class C { public function foo($xs) { foreach($xs as $i => $x) { echo $i; echo $x; } } }'),
+      tuple('<?hh class C { public function foo() { $k = 1; return dict[1 => 2][$k]; } }'),
+      tuple('<?hh class C { public function foo($d) { $k = 1; $d[$k] = 5; return $d; } }'),
+      tuple('<?hh class C { public function foo() { $d = []; return $d[1]; } }'),
+      tuple('<?hh class C { public function foo() { $d = []; $d["a"] = "b"; f($d["a"]); } }'),
+      tuple('<?hh class C { public function foo(&$d) { $d = 5; } }'),
+      tuple('<?hh class C { public function foo(inout $d) { $d = 5; } }'),
+      tuple('<?hh class C { public function foo() { $users = []; $u = ["id" => 15]; $users[$u["id"]] = 5; return $users; } }'),
+      tuple('<?hh class C { public function foo() { $s = "a"; echo "{$s}"; } }'),
       // TODO: Decide whether to support "${}" style string interpolation
-      // ['<?hh class C { public function foo() { $s = "a"; echo "${s}"; } }'],
-      // ['<?hh class C { public function foo() { $d = dict["a" => "b"]; echo "${d[\'a\']}"; } }'],
+      // tuple('<?hh class C { public function foo() { $s = "a"; echo "${s}"; } }'),
+      // tuple('<?hh class C { public function foo() { $d = dict["a" => "b"]; echo "${d[\'a\']}"; } }'),
     ];
   }
 }

--- a/tests/UnusedVariableLinterTest.hack
+++ b/tests/UnusedVariableLinterTest.hack
@@ -29,6 +29,7 @@ final class UnusedVariableLinterTest extends TestCase {
       ['<?hh function foo() { $d = []; $d["a"] = "b"; f($d["a"]); }'],
       ['<?hh function foo(&$d) { $d = 5; }'],
       ['<?hh function foo(inout $d) { $d = 5; }'],
+      ['<?hh function foo() { $users = []; $u = ["id" => 15]; $users[$u["id"]] = 5; return $users; }'],
       ['<?hh class C { public function foo() { $bar = 1; return $bar; } }'],
       ['<?hh class C { public function foo() { $_bar = 1; return 2; } }'],
       ['<?hh class C { public function foo() { $GLOBALS["foo"] = "bar"; } }'],
@@ -38,6 +39,7 @@ final class UnusedVariableLinterTest extends TestCase {
       ['<?hh class C { public function foo($d) { $k = 1; $d[$k] = 5; return $d; } }'],
       ['<?hh class C { public function foo(&$d) { $d = 5; } }'],
       ['<?hh class C { public function foo(inout $d) { $d = 5; } }'],
+      ['<?hh class C { public function foo() { $users = []; $u = ["id" => 15]; $users[$u["id"]] = 5; return $users; } }'],
     ];
   }
 }

--- a/tests/UnusedVariableLinterTest.hack
+++ b/tests/UnusedVariableLinterTest.hack
@@ -31,9 +31,6 @@ final class UnusedVariableLinterTest extends TestCase {
       tuple('<?hh function foo(inout $d) { $d = 5; }'),
       tuple('<?hh function foo() { $users = []; $u = ["id" => 15]; $users[$u["id"]] = 5; return $users; }'),
       tuple('<?hh function foo() { $s = "a"; echo "{$s}"; }'),
-      // TODO: Decide whether to support "${}" style string interpolation
-      // tuple('<?hh function foo() { $s = "a"; echo "${s}"; }'),
-      // tuple('<?hh function foo() { $d = dict["a" => "b"]; echo "${d[\'a\']}"; }'),
       tuple('<?hh class C { public function foo() { $bar = 1; return $bar; } }'),
       tuple('<?hh class C { public function foo() { $_bar = 1; return 2; } }'),
       tuple('<?hh class C { public function foo() { $GLOBALS["foo"] = "bar"; } }'),
@@ -47,9 +44,6 @@ final class UnusedVariableLinterTest extends TestCase {
       tuple('<?hh class C { public function foo(inout $d) { $d = 5; } }'),
       tuple('<?hh class C { public function foo() { $users = []; $u = ["id" => 15]; $users[$u["id"]] = 5; return $users; } }'),
       tuple('<?hh class C { public function foo() { $s = "a"; echo "{$s}"; } }'),
-      // TODO: Decide whether to support "${}" style string interpolation
-      // tuple('<?hh class C { public function foo() { $s = "a"; echo "${s}"; } }'),
-      // tuple('<?hh class C { public function foo() { $d = dict["a" => "b"]; echo "${d[\'a\']}"; } }'),
     ];
   }
 }

--- a/tests/UnusedVariableLinterTest.hack
+++ b/tests/UnusedVariableLinterTest.hack
@@ -30,6 +30,10 @@ final class UnusedVariableLinterTest extends TestCase {
       ['<?hh function foo(&$d) { $d = 5; }'],
       ['<?hh function foo(inout $d) { $d = 5; }'],
       ['<?hh function foo() { $users = []; $u = ["id" => 15]; $users[$u["id"]] = 5; return $users; }'],
+      ['<?hh function foo() { $s = "a"; echo "{$s}"; }'],
+      // TODO: Decide whether to support "${}" style string interpolation
+      // ['<?hh function foo() { $s = "a"; echo "${s}"; }'],
+      // ['<?hh function foo() { $d = dict["a" => "b"]; echo "${d[\'a\']}"; }'],
       ['<?hh class C { public function foo() { $bar = 1; return $bar; } }'],
       ['<?hh class C { public function foo() { $_bar = 1; return 2; } }'],
       ['<?hh class C { public function foo() { $GLOBALS["foo"] = "bar"; } }'],
@@ -37,9 +41,15 @@ final class UnusedVariableLinterTest extends TestCase {
       ['<?hh class C { public function foo($xs) { foreach($xs as $i => $x) { echo $i; echo $x; } } }'],
       ['<?hh class C { public function foo() { $k = 1; return dict[1 => 2][$k]; } }'],
       ['<?hh class C { public function foo($d) { $k = 1; $d[$k] = 5; return $d; } }'],
+      ['<?hh class C { public function foo() { $d = []; return $d[1]; } }'],
+      ['<?hh class C { public function foo() { $d = []; $d["a"] = "b"; f($d["a"]); } }'],
       ['<?hh class C { public function foo(&$d) { $d = 5; } }'],
       ['<?hh class C { public function foo(inout $d) { $d = 5; } }'],
       ['<?hh class C { public function foo() { $users = []; $u = ["id" => 15]; $users[$u["id"]] = 5; return $users; } }'],
+      ['<?hh class C { public function foo() { $s = "a"; echo "{$s}"; } }'],
+      // TODO: Decide whether to support "${}" style string interpolation
+      // ['<?hh class C { public function foo() { $s = "a"; echo "${s}"; } }'],
+      // ['<?hh class C { public function foo() { $d = dict["a" => "b"]; echo "${d[\'a\']}"; } }'],
     ];
   }
 }

--- a/tests/UnusedVariableLinterTest.hack
+++ b/tests/UnusedVariableLinterTest.hack
@@ -27,6 +27,15 @@ final class UnusedVariableLinterTest extends TestCase {
       ['<?hh function foo($d) { $k = 1; $d[$k] = 5; return $d; }'],
       ['<?hh function foo(&$d) { $d = 5; }'],
       ['<?hh function foo(inout $d) { $d = 5; }'],
+      ['<?hh class C { public function foo() { $bar = 1; return $bar; } }'],
+      ['<?hh class C { public function foo() { $_bar = 1; return 2; } }'],
+      ['<?hh class C { public function foo() { $GLOBALS["foo"] = "bar"; } }'],
+      ['<?hh class C { public function foo($xs) { foreach($xs as $x) { echo $x; } } }'],
+      ['<?hh class C { public function foo($xs) { foreach($xs as $i => $x) { echo $i; echo $x; } } }'],
+      ['<?hh class C { public function foo() { $k = 1; return dict[1 => 2][$k]; } }'],
+      ['<?hh class C { public function foo($d) { $k = 1; $d[$k] = 5; return $d; } }'],
+      ['<?hh class C { public function foo(&$d) { $d = 5; } }'],
+      ['<?hh class C { public function foo(inout $d) { $d = 5; } }'],
     ];
   }
 }

--- a/tests/UnusedVariableLinterTest.hack
+++ b/tests/UnusedVariableLinterTest.hack
@@ -25,6 +25,8 @@ final class UnusedVariableLinterTest extends TestCase {
       ['<?hh function foo($xs) { foreach($xs as $i => $x) { echo $i; echo $x; } }'],
       ['<?hh function foo() { $k = 1; return dict[1 => 2][$k]; }'],
       ['<?hh function foo($d) { $k = 1; $d[$k] = 5; return $d; }'],
+      ['<?hh function foo() { $d = []; return $d[1]; }'],
+      ['<?hh function foo() { $d = []; $d["a"] = "b"; f($d["a"]); }'],
       ['<?hh function foo(&$d) { $d = 5; }'],
       ['<?hh function foo(inout $d) { $d = 5; }'],
       ['<?hh class C { public function foo() { $bar = 1; return $bar; } }'],

--- a/tests/UnusedVariableLinterTest.hack
+++ b/tests/UnusedVariableLinterTest.hack
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class UnusedVariableLinterTest extends TestCase {
+  use AutoFixingLinterTestTrait<Linters\ASTLintError>;
+
+  protected function getLinter(string $file): Linters\UnusedVariableLinter {
+    return Linters\UnusedVariableLinter::fromPath($file);
+  }
+
+  public function getCleanExamples(): array<array<string>> {
+    return [
+      ['<?hh function foo() { $bar = 1; return $bar; }'],
+      ['<?hh function foo() { $_bar = 1; return 2; }'],
+      ['<?hh function foo() { $GLOBALS["foo"] = "bar"; }'],
+      ['<?hh function foo($xs) { foreach($xs as $x) { echo $x; } }'],
+      ['<?hh function foo($xs) { foreach($xs as $i => $x) { echo $i; echo $x; } }'],
+      ['<?hh function foo() { $k = 1; return dict[1 => 2][$k]; }'],
+      ['<?hh function foo($d) { $k = 1; $d[$k] = 5; return $d; }'],
+      ['<?hh function foo(&$d) { $d = 5; }'],
+      ['<?hh function foo(inout $d) { $d = 5; }'],
+    ];
+  }
+}

--- a/tests/examples/UnusedVariableLinter/unused_foreach.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_foreach.php.autofix.expect
@@ -16,3 +16,22 @@ function foreach_shadow($items) {
   foreach ($items as $_i => $_item) {
   }
 }
+
+class C {
+  public function foreach_value($items) {
+    foreach ($items as $_item) {
+    }
+  }
+
+  public function foreach_key_value($items) {
+    foreach ($items as $_i => $_item) {
+    }
+  }
+
+  public function foreach_shadow($items) {
+    $_i = 0;
+    $_item = 'a';
+    foreach ($items as $_i => $_item) {
+    }
+  }
+}

--- a/tests/examples/UnusedVariableLinter/unused_foreach.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_foreach.php.autofix.expect
@@ -1,0 +1,18 @@
+<?hh
+
+function foreach_value($items) {
+  foreach ($items as $_item) {
+  }
+}
+
+function foreach_key_value($items) {
+  foreach ($items as $_i => $_item) {
+  }
+}
+
+function foreach_shadow($items) {
+  $_i = 0;
+  $_item = 'a';
+  foreach ($items as $_i => $_item) {
+  }
+}

--- a/tests/examples/UnusedVariableLinter/unused_foreach.php.expect
+++ b/tests/examples/UnusedVariableLinter/unused_foreach.php.expect
@@ -1,0 +1,37 @@
+[
+    {
+        "blame": "$item",
+        "blame_pretty": "$item",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "$i ",
+        "blame_pretty": "$i ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "$item",
+        "blame_pretty": "$item",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "  $i ",
+        "blame_pretty": "  $i ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "  $item ",
+        "blame_pretty": "  $item ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "$i ",
+        "blame_pretty": "$i ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "$item",
+        "blame_pretty": "$item",
+        "description": "Variable is unused"
+    }
+]

--- a/tests/examples/UnusedVariableLinter/unused_foreach.php.expect
+++ b/tests/examples/UnusedVariableLinter/unused_foreach.php.expect
@@ -33,5 +33,40 @@
         "blame": "$item",
         "blame_pretty": "$item",
         "description": "Variable is unused"
+    },
+    {
+        "blame": "$item",
+        "blame_pretty": "$item",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "$i ",
+        "blame_pretty": "$i ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "$item",
+        "blame_pretty": "$item",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "    $i ",
+        "blame_pretty": "    $i ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "    $item ",
+        "blame_pretty": "    $item ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "$i ",
+        "blame_pretty": "$i ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "$item",
+        "blame_pretty": "$item",
+        "description": "Variable is unused"
     }
 ]

--- a/tests/examples/UnusedVariableLinter/unused_foreach.php.in
+++ b/tests/examples/UnusedVariableLinter/unused_foreach.php.in
@@ -1,0 +1,18 @@
+<?hh
+
+function foreach_value($items) {
+  foreach ($items as $item) {
+  }
+}
+
+function foreach_key_value($items) {
+  foreach ($items as $i => $item) {
+  }
+}
+
+function foreach_shadow($items) {
+  $i = 0;
+  $item = 'a';
+  foreach ($items as $i => $item) {
+  }
+}

--- a/tests/examples/UnusedVariableLinter/unused_foreach.php.in
+++ b/tests/examples/UnusedVariableLinter/unused_foreach.php.in
@@ -16,3 +16,22 @@ function foreach_shadow($items) {
   foreach ($items as $i => $item) {
   }
 }
+
+class C {
+  public function foreach_value($items) {
+    foreach ($items as $item) {
+    }
+  }
+
+  public function foreach_key_value($items) {
+    foreach ($items as $i => $item) {
+    }
+  }
+
+  public function foreach_shadow($items) {
+    $i = 0;
+    $item = 'a';
+    foreach ($items as $i => $item) {
+    }
+  }
+}

--- a/tests/examples/UnusedVariableLinter/unused_list.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_list.php.autofix.expect
@@ -3,3 +3,9 @@
 function list_expression(): void {
   list($_L1, $_L2) = vec[1, 2];
 }
+
+class C {
+  public function list_expression(): void {
+    list($_L1, $_L2) = vec[1, 2];
+  }
+}

--- a/tests/examples/UnusedVariableLinter/unused_list.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_list.php.autofix.expect
@@ -1,0 +1,5 @@
+<?hh
+
+function list_expression(): void {
+  list($_L1, $_L2) = vec[1, 2];
+}

--- a/tests/examples/UnusedVariableLinter/unused_list.php.expect
+++ b/tests/examples/UnusedVariableLinter/unused_list.php.expect
@@ -8,5 +8,15 @@
         "blame": "$L2",
         "blame_pretty": "$L2",
         "description": "Variable is unused"
+    },
+    {
+        "blame": "$L1",
+        "blame_pretty": "$L1",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "$L2",
+        "blame_pretty": "$L2",
+        "description": "Variable is unused"
     }
 ]

--- a/tests/examples/UnusedVariableLinter/unused_list.php.expect
+++ b/tests/examples/UnusedVariableLinter/unused_list.php.expect
@@ -1,0 +1,12 @@
+[
+    {
+        "blame": "$L1",
+        "blame_pretty": "$L1",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "$L2",
+        "blame_pretty": "$L2",
+        "description": "Variable is unused"
+    }
+]

--- a/tests/examples/UnusedVariableLinter/unused_list.php.in
+++ b/tests/examples/UnusedVariableLinter/unused_list.php.in
@@ -1,0 +1,5 @@
+<?hh
+
+function list_expression(): void {
+  list($L1, $L2) = vec[1, 2];
+}

--- a/tests/examples/UnusedVariableLinter/unused_list.php.in
+++ b/tests/examples/UnusedVariableLinter/unused_list.php.in
@@ -3,3 +3,9 @@
 function list_expression(): void {
   list($L1, $L2) = vec[1, 2];
 }
+
+class C {
+  public function list_expression(): void {
+    list($L1, $L2) = vec[1, 2];
+  }
+}

--- a/tests/examples/UnusedVariableLinter/unused_subscript.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_subscript.php.autofix.expect
@@ -1,0 +1,13 @@
+<?hh
+
+function subscript_expressions(): void {
+  $_a = dict[];
+  $b = 'b';
+  $c = 'c';
+  $d = 'd';
+  $_a['a'] = 1;
+  $_a[$b] = 5;
+  $_a[$c.$d] = 10;
+
+  return;
+}

--- a/tests/examples/UnusedVariableLinter/unused_subscript.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_subscript.php.autofix.expect
@@ -11,3 +11,17 @@ function subscript_expressions(): void {
 
   return;
 }
+
+class C {
+  public function subscript_expressions(): void {
+    $_a = dict[];
+    $b = 'b';
+    $c = 'c';
+    $d = 'd';
+    $_a['a'] = 1;
+    $_a[$b] = 5;
+    $_a[$c.$d] = 10;
+
+    return;
+  }
+}

--- a/tests/examples/UnusedVariableLinter/unused_subscript.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_subscript.php.autofix.expect
@@ -8,6 +8,8 @@ function subscript_expressions(): void {
   $_a['a'] = 1;
   $_a[$b] = 5;
   $_a[$c.$d] = 10;
+  $_a[1]['a']['b'] = 10;
+  $_a[1]['c'][] = 10;
 
   return;
 }
@@ -21,6 +23,8 @@ class C {
     $_a['a'] = 1;
     $_a[$b] = 5;
     $_a[$c.$d] = 10;
+    $_a[1]['a']['b'] = 10;
+    $_a[1]['c'][] = 10;
 
     return;
   }

--- a/tests/examples/UnusedVariableLinter/unused_subscript.php.expect
+++ b/tests/examples/UnusedVariableLinter/unused_subscript.php.expect
@@ -1,0 +1,22 @@
+[
+    {
+        "blame": "  $a ",
+        "blame_pretty": "  $a ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "  $a",
+        "blame_pretty": "  $a",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "  $a",
+        "blame_pretty": "  $a",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "  $a",
+        "blame_pretty": "  $a",
+        "description": "Variable is unused"
+    }
+]

--- a/tests/examples/UnusedVariableLinter/unused_subscript.php.expect
+++ b/tests/examples/UnusedVariableLinter/unused_subscript.php.expect
@@ -20,8 +20,28 @@
         "description": "Variable is unused"
     },
     {
+        "blame": "  $a",
+        "blame_pretty": "  $a",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "  $a",
+        "blame_pretty": "  $a",
+        "description": "Variable is unused"
+    },
+    {
         "blame": "    $a ",
         "blame_pretty": "    $a ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "    $a",
+        "blame_pretty": "    $a",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "    $a",
+        "blame_pretty": "    $a",
         "description": "Variable is unused"
     },
     {

--- a/tests/examples/UnusedVariableLinter/unused_subscript.php.expect
+++ b/tests/examples/UnusedVariableLinter/unused_subscript.php.expect
@@ -18,5 +18,25 @@
         "blame": "  $a",
         "blame_pretty": "  $a",
         "description": "Variable is unused"
+    },
+    {
+        "blame": "    $a ",
+        "blame_pretty": "    $a ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "    $a",
+        "blame_pretty": "    $a",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "    $a",
+        "blame_pretty": "    $a",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "    $a",
+        "blame_pretty": "    $a",
+        "description": "Variable is unused"
     }
 ]

--- a/tests/examples/UnusedVariableLinter/unused_subscript.php.in
+++ b/tests/examples/UnusedVariableLinter/unused_subscript.php.in
@@ -1,0 +1,13 @@
+<?hh
+
+function subscript_expressions(): void {
+  $a = dict[];
+  $b = 'b';
+  $c = 'c';
+  $d = 'd';
+  $a['a'] = 1;
+  $a[$b] = 5;
+  $a[$c.$d] = 10;
+
+  return;
+}

--- a/tests/examples/UnusedVariableLinter/unused_subscript.php.in
+++ b/tests/examples/UnusedVariableLinter/unused_subscript.php.in
@@ -8,6 +8,8 @@ function subscript_expressions(): void {
   $a['a'] = 1;
   $a[$b] = 5;
   $a[$c.$d] = 10;
+  $a[1]['a']['b'] = 10;
+  $a[1]['c'][] = 10;
 
   return;
 }
@@ -21,6 +23,8 @@ class C {
     $a['a'] = 1;
     $a[$b] = 5;
     $a[$c.$d] = 10;
+    $a[1]['a']['b'] = 10;
+    $a[1]['c'][] = 10;
 
     return;
   }

--- a/tests/examples/UnusedVariableLinter/unused_subscript.php.in
+++ b/tests/examples/UnusedVariableLinter/unused_subscript.php.in
@@ -11,3 +11,17 @@ function subscript_expressions(): void {
 
   return;
 }
+
+class C {
+  public function subscript_expressions(): void {
+    $a = dict[];
+    $b = 'b';
+    $c = 'c';
+    $d = 'd';
+    $a['a'] = 1;
+    $a[$b] = 5;
+    $a[$c.$d] = 10;
+
+    return;
+  }
+}

--- a/tests/examples/UnusedVariableLinter/unused_variable.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_variable.php.autofix.expect
@@ -14,3 +14,20 @@ function with_mutation(): void {
 
   return;
 }
+
+class C {
+  public function simple(int $bar): int {
+    $_baz = $bar;
+    return $bar;
+  }
+
+  public function with_mutation(): void {
+    $_b = 0;
+    $_b += 1;
+
+    $_c = 'hello';
+    $_c .= ' world';
+
+    return;
+  }
+}

--- a/tests/examples/UnusedVariableLinter/unused_variable.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_variable.php.autofix.expect
@@ -1,0 +1,16 @@
+<?hh
+
+function simple(int $bar): int {
+  $_baz = $bar;
+  return $bar;
+}
+
+function with_mutation(): void {
+  $_b = 0;
+  $_b += 1;
+
+  $_c = 'hello';
+  $_c .= ' world';
+
+  return;
+}

--- a/tests/examples/UnusedVariableLinter/unused_variable.php.expect
+++ b/tests/examples/UnusedVariableLinter/unused_variable.php.expect
@@ -23,5 +23,30 @@
         "blame": "  $c ",
         "blame_pretty": "  $c ",
         "description": "Variable is unused"
+    },
+    {
+        "blame": "    $baz ",
+        "blame_pretty": "    $baz ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "    $b ",
+        "blame_pretty": "    $b ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "    $b ",
+        "blame_pretty": "    $b ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "\n    $c ",
+        "blame_pretty": "\n    $c ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "    $c ",
+        "blame_pretty": "    $c ",
+        "description": "Variable is unused"
     }
 ]

--- a/tests/examples/UnusedVariableLinter/unused_variable.php.expect
+++ b/tests/examples/UnusedVariableLinter/unused_variable.php.expect
@@ -1,0 +1,27 @@
+[
+    {
+        "blame": "  $baz ",
+        "blame_pretty": "  $baz ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "  $b ",
+        "blame_pretty": "  $b ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "  $b ",
+        "blame_pretty": "  $b ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "\n  $c ",
+        "blame_pretty": "\n  $c ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "  $c ",
+        "blame_pretty": "  $c ",
+        "description": "Variable is unused"
+    }
+]

--- a/tests/examples/UnusedVariableLinter/unused_variable.php.in
+++ b/tests/examples/UnusedVariableLinter/unused_variable.php.in
@@ -14,3 +14,20 @@ function with_mutation(): void {
 
   return;
 }
+
+class C {
+  public function simple(int $bar): int {
+    $baz = $bar;
+    return $bar;
+  }
+
+  public function with_mutation(): void {
+    $b = 0;
+    $b += 1;
+
+    $c = 'hello';
+    $c .= ' world';
+
+    return;
+  }
+}

--- a/tests/examples/UnusedVariableLinter/unused_variable.php.in
+++ b/tests/examples/UnusedVariableLinter/unused_variable.php.in
@@ -1,0 +1,16 @@
+<?hh
+
+function simple(int $bar): int {
+  $baz = $bar;
+  return $bar;
+}
+
+function with_mutation(): void {
+  $b = 0;
+  $b += 1;
+
+  $c = 'hello';
+  $c .= ' world';
+
+  return;
+}


### PR DESCRIPTION
This change adds the `UnusedVariableLinter` which detects unused variables in a function or method body. It is based on `UnusedParameterLinter` and has the same error message and autofix suggestion.

**Approach**
The strategy used here is to classify every variable expression in a function/method body as an assignment or a use. If the variable expression being considered does not appear in the list of uses, it's an error. The details of classification are documented at `UnusedVariableLinter::classifyVariables`:

```
   * An assignment is a variable expression that is one of the following:
   *
   * 1a. The left-hand side of a binary expression with an assignment operator
   *   that is not part of the index of a subscript expression.
   * 2. The key or value of a foreach clause
   * 3. The members of a list expression
```

**Caveats**
This linter assumed that no variables are used before they are assigned, which should be enforced separately by the typechecker. It may have false negatives (variables that are unused but not detected as such) either because of bugs or unreachable uses (e.g. `$a = 1; return 5; return $a;`).

**Performance**
`UnusedVariableLinter::classifyVariables` is probably slow because it needs the parents for the variable expression node. For small functions this won't matter much; for large functions I made some performance improvements in separate commits:
1. Use `MemoizableNode` to classify variables once per function/methods
2. Switch vecs to keysets

If these changes make sense, `MemoizableNode` probably belongs somewhere else.