### PR TITLE
Add migration for top-level requires

### DIFF
--- a/bin/hhast-inspect
+++ b/bin/hhast-inspect
@@ -10,11 +10,13 @@
 
 namespace Facebook\HHAST\__Private;
 
-require_once(__DIR__.'/hhast-inspect.hack');
-
 // As this file does not have an extension, it is not typechecked. Delegate
 // to the typechecked one.
 <<__EntryPoint>>
 async function hhast_inspect_main_async_UNSAFE(): Awaitable<noreturn> {
+  (() ==> {
+    // HHAST-generated to avoid pseudomain local leaks
+    require_once(__DIR__.'/hhast-inspect.hack');
+  })();
   await hhast_inspect_main_async();
 }

--- a/bin/hhast-lint
+++ b/bin/hhast-lint
@@ -10,11 +10,13 @@
 
 namespace Facebook\HHAST\__Private;
 
-require_once(__DIR__.'/hhast-lint.hack');
-
 // As this file does not have an extension, it is not typechecked. Delegate
 // to the typechecked one.
 <<__EntryPoint>>
 async function hhast_lint_main_async_UNSAFE(): Awaitable<noreturn> {
+  (() ==> {
+    // HHAST-generated to avoid pseudomain local leaks
+    require_once(__DIR__.'/hhast-lint.hack');
+  })();
   await hhast_lint_main_async();
 }

--- a/bin/hhast-migrate
+++ b/bin/hhast-migrate
@@ -10,11 +10,13 @@
 
 namespace Facebook\HHAST\__Private;
 
-require_once(__DIR__.'/hhast-migrate.hack');
-
 // As this file does not have an extension, it is not typechecked. Delegate
 // to the typechecked one.
 <<__EntryPoint>>
 async function hhast_migrate_main_async_UNSAFE(): Awaitable<noreturn> {
+  (() ==> {
+    // HHAST-generated to avoid pseudomain local leaks
+    require_once(__DIR__.'/hhast-migrate.hack');
+  })();
   await hhast_migrate_main_async();
 }

--- a/bin/update-codegen
+++ b/bin/update-codegen
@@ -10,11 +10,13 @@
 
 namespace Facebook\HHAST\__Private;
 
-require_once(__DIR__.'/update-codegen.hack');
-
 // As this file does not have an extension, it is not typechecked. Delegate
 // to the typechecked one.
 <<__EntryPoint>>
 async function update_codegen_async_UNSAFE(): Awaitable<noreturn> {
+  (() ==> {
+    // HHAST-generated to avoid pseudomain local leaks
+    require_once(__DIR__.'/update-codegen.hack');
+  })();
   await update_codegen_async();
 }

--- a/bin/update-codegen.hack
+++ b/bin/update-codegen.hack
@@ -10,10 +10,12 @@
 
 namespace Facebook\HHAST\__Private;
 
-require_once(__DIR__.'/../vendor/autoload.hack');
-
 <<__EntryPoint>>
 async function update_codegen_async(): Awaitable<noreturn> {
+  (() ==> {
+    // HHAST-generated to avoid pseudomain local leaks
+    require_once(__DIR__.'/../vendor/autoload.hack');
+  })();
   \Facebook\AutoloadMap\initialize();
   $status = await CodegenCLI::runAsync();
   exit($status);

--- a/src/Migrations/BaseMigration.hack
+++ b/src/Migrations/BaseMigration.hack
@@ -9,6 +9,7 @@
 
 namespace Facebook\HHAST;
 
+use namespace HH\Lib\C;
 use type Facebook\HHAST\Script;
 
 <<__ConsistentConstruct>>
@@ -21,4 +22,27 @@ abstract class BaseMigration {
   }
 
   abstract public function migrateFile(string $path, Script $ast): Script;
+
+  protected static async function expressionFromCodeAsync(
+    string $code,
+  ): Awaitable<IExpression> {
+    $script = await from_file_async(
+      File::fromPathAndContents('/dev/null', '$_='.$code.';'),
+    );
+    return $script->getDeclarations()
+      ->getChildren()
+      |> C\firstx($$) as ExpressionStatement
+      |> $$->getExpression() as BinaryExpression
+      |> $$->getRightOperand();
+  }
+
+  protected static async function statementFromCodeAsync(
+    string $code,
+  ): Awaitable<IStatement> {
+    $script = await from_file_async(
+      File::fromPathAndContents('/dev/null', $code),
+    );
+    return $script->getDeclarations()->getChildren()
+      |> C\firstx($$) as IStatement;
+  }
 }

--- a/src/Migrations/HSLMigration.hack
+++ b/src/Migrations/HSLMigration.hack
@@ -689,7 +689,6 @@ final class HSLMigration extends BaseMigration {
   }
 
   protected function expressionFromCode(string $code): IExpression {
-    return $this->nodeFromCode('$_ = '.$code.';', BinaryExpression::class)
-      ->getRightOperand();
+    return \HH\Asio\join(self::expressionFromCodeAsync($code));
   }
 }

--- a/src/Migrations/TopLevelRequiresMigration.hack
+++ b/src/Migrations/TopLevelRequiresMigration.hack
@@ -1,0 +1,117 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{C, Str, Vec};
+
+/** Move requires to top-level `<<__EntryPoint>>` functions, or FIXME them. */
+final class TopLevelRequiresMigration extends BaseMigration {
+  <<__Override>>
+  public function migrateFile(string $_path, Script $script): Script {
+    $decls = $script->getDeclarations();
+    $includes = $decls->getChildrenOfType(InclusionDirective::class);
+    if (C\is_empty($includes)) {
+      return $script;
+    }
+    if (
+      C\every(
+        $includes,
+        $incl ==> Str\contains(
+          $incl->getFirstTokenx()->getLeading()->getCode(),
+          '/* HH_FIXME[1002]',
+        ),
+      )
+    ) {
+      return $script;
+    }
+
+    $entrypoint = $decls->getChildrenOfType(FunctionDeclaration::class)
+      |> Vec\filter(
+        $$,
+        $f ==> C\any(
+          $f->getAttributeSpec()?->getAttributes()?->getChildrenOfItems() ??
+            vec[],
+          $attr ==>
+            ($attr->getType() as NameToken)->getText() === '__EntryPoint',
+        ),
+      )
+      |> C\first($$);
+
+    if ($entrypoint) {
+      return $this->moveToEntryPoint($script, $includes, $entrypoint);
+    }
+    return $this->addFixmes($script, $includes);
+  }
+
+  private function addFixmes(
+    Script $script,
+    Container<InclusionDirective> $includes,
+  ): Script {
+    foreach ($includes as $include) {
+      $t = $include->getFirstTokenx();
+      $script = $script->replace(
+        $t,
+        $t->withLeading(new NodeList(
+          Vec\concat(
+            $t->getLeading()->toVec(),
+            vec[
+              new FixMe(
+                '/* HH_FIXME[1002] HHAST: move to <<__EntryPoint>> function */',
+              ),
+              new WhiteSpace(' '),
+            ],
+          ),
+        )),
+      );
+    }
+    return $script;
+  }
+
+  private function moveToEntryPoint(
+    Script $script,
+    Container<InclusionDirective> $includes,
+    FunctionDeclaration $entrypoint,
+  ): Script {
+    // Figure out leading whitespace
+    $body = $entrypoint->getBody();
+    if (!$body is CompoundStatement) {
+      // Invalid, but e.g. `<<__EntryPoint>> function foo(): void;`
+      return $this->addFixmes($script, $includes);
+    }
+
+    $leading = $body->getStatements()?->toVec() ?? vec[]
+      |> C\first($$)
+      |> $$?->getFirstTokenx()?->getLeadingWhitespace()
+      |> $$?->getText() ?? '  ';
+
+    $body = $body->withStatements(
+      new NodeList(
+        Vec\map(
+          $includes,
+          $incl ==> {
+            $t = $incl->getFirstTokenx();
+            return $incl->replace(
+              $t,
+              $t->withLeading(new NodeList(vec[new WhiteSpace($leading)])),
+            );
+          },
+        )
+          |> Vec\concat($$, $body->getStatements()?->toVec() ?? vec[]),
+      ),
+    );
+
+    return $script->withDeclarations(
+      $script->getDeclarations()
+        ->filterChildren($decl ==> !C\contains($includes, $decl))
+        ->replaceChild($entrypoint, $entrypoint->withBody($body)),
+    );
+  }
+
+}

--- a/src/__Private/MigrationCLI.hack
+++ b/src/__Private/MigrationCLI.hack
@@ -22,6 +22,7 @@ use type Facebook\HHAST\{
   InstanceofIsMigration,
   IsRefinementMigration,
   OptionalShapeFieldsMigration,
+  TopLevelRequiresMigration,
 };
 
 use type Facebook\CLILib\{CLIWithRequiredArguments, ExitException};
@@ -236,6 +237,13 @@ class MigrationCLI extends CLIWithRequiredArguments {
         },
         'Replace `$x instanceof Foo` with an `is` expression or `is_a()` call',
         '--instanceof-is',
+      ),
+      CLIOptions\flag(
+        () ==> {
+          $this->migrations[] = TopLevelRequiresMigration::class;
+        },
+        'Migrate top-level require()s to <<__EntryPoint>> functions or FIXME',
+        '--top-level-requires',
       ),
       CLIOptions\flag(
         () ==> {

--- a/src/__Private/MigrationCLI.hack
+++ b/src/__Private/MigrationCLI.hack
@@ -242,7 +242,7 @@ class MigrationCLI extends CLIWithRequiredArguments {
         () ==> {
           $this->migrations[] = TopLevelRequiresMigration::class;
         },
-        'Migrate top-level require()s to <<__EntryPoint>> functions or FIXME',
+        'Migrate top-level require()s to <<__EntryPoint>> functions',
         '--top-level-requires',
       ),
       CLIOptions\flag(

--- a/src/nodes/NodeList.hack
+++ b/src/nodes/NodeList.hack
@@ -161,6 +161,21 @@ final class NodeList<+Titem as Node> extends Node {
     return new self(Vec\filter_nulls(/* HH_FIXME[4110] */ $children));
   }
 
+  public function replaceChild<Tchild super Titem as Node>(
+    Tchild $old,
+    Tchild $new,
+  ): NodeList<Tchild> {
+    if ($old === $new) {
+      return $this;
+    }
+    if (!C\contains($this->_children, $old)) {
+      return $this;
+    }
+    return new NodeList(
+      Vec\map($this->_children, $c ==> $c === $old ? $new : $c),
+    );
+  }
+
   public function insertBefore<Tchild super Titem as Node>(
     Tchild $before,
     Tchild $child,
@@ -187,6 +202,13 @@ final class NodeList<+Titem as Node> extends Node {
     ));
   }
 
+  public function filterChildren((function(Titem): bool) $filter): this {
+    $new = Vec\filter($this->_children, $filter);
+    if ($new === $this->_children) {
+      return $this;
+    }
+    return new NodeList($new);
+  }
 
   public function withoutChild<Tchild super Titem>(Tchild $child): this {
     $new = Vec\filter($this->_children, $c ==> $c !== $child);

--- a/tests/TopLevelRequiresMigrationTest.hack
+++ b/tests/TopLevelRequiresMigrationTest.hack
@@ -18,7 +18,7 @@ final class TopLevelRequiresMigrationTest extends MigrationTest {
   public function getExamples(): vec<(string)> {
     $prefix = __DIR__.'/examples/';
     $dir = $prefix.'migrations/TopLevelRequires/';
-    return Vec\concat(\glob($dir.'*.php.in'), \glob($dir.'*.hack.hack'))
+    return Vec\concat(\glob($dir.'*.php.in'), \glob($dir.'*.hack.in'))
       |> Vec\map(
         $$,
         $file ==>

--- a/tests/TopLevelRequiresMigrationTest.hack
+++ b/tests/TopLevelRequiresMigrationTest.hack
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{Str, Vec};
+
+final class TopLevelRequiresMigrationTest extends MigrationTest {
+  const type TMigration = TopLevelRequiresMigration;
+
+  <<__Override>>
+  public function getExamples(): vec<(string)> {
+    $prefix = __DIR__.'/examples/';
+    $dir = $prefix.'migrations/TopLevelRequires/';
+    return Vec\concat(\glob($dir.'*.php.in'), \glob($dir.'*.hack.hack'))
+      |> Vec\map(
+        $$,
+        $file ==>
+          tuple(Str\strip_suffix(Str\strip_prefix($file, $prefix), '.in')),
+      );
+  }
+}

--- a/tests/examples/migrations/TopLevelRequires/all_types.php.expect
+++ b/tests/examples/migrations/TopLevelRequires/all_types.php.expect
@@ -1,0 +1,10 @@
+<?hh
+
+<<__EntryPoint>>
+function main(): void {
+  include('a');
+  include_once('b');
+  require('c');
+  require_once('d');
+  foo();
+}

--- a/tests/examples/migrations/TopLevelRequires/all_types.php.expect
+++ b/tests/examples/migrations/TopLevelRequires/all_types.php.expect
@@ -2,9 +2,12 @@
 
 <<__EntryPoint>>
 function main(): void {
-  include('a');
-  include_once('b');
-  require('c');
-  require_once('d');
+  (() ==> {
+    // HHAST-generated to avoid pseudomain local leaks
+    include('a');
+    include_once('b');
+    require('c');
+    require_once('d');
+  })();
   foo();
 }

--- a/tests/examples/migrations/TopLevelRequires/all_types.php.in
+++ b/tests/examples/migrations/TopLevelRequires/all_types.php.in
@@ -1,0 +1,11 @@
+<?hh
+
+include('a');
+include_once('b');
+require('c');
+require_once('d');
+
+<<__EntryPoint>>
+function main(): void {
+  foo();
+}

--- a/tests/examples/migrations/TopLevelRequires/eight_spaces.php.expect
+++ b/tests/examples/migrations/TopLevelRequires/eight_spaces.php.expect
@@ -2,6 +2,9 @@
 
 <<__EntryPoint>>
 function main(): void {
-        require_once('foo');
+        (() ==> {
+                // HHAST-generated to avoid pseudomain local leaks
+                require_once('foo');
+        })();
         bar();
 }

--- a/tests/examples/migrations/TopLevelRequires/eight_spaces.php.expect
+++ b/tests/examples/migrations/TopLevelRequires/eight_spaces.php.expect
@@ -1,0 +1,7 @@
+<?hh
+
+<<__EntryPoint>>
+function main(): void {
+        require_once('foo');
+        bar();
+}

--- a/tests/examples/migrations/TopLevelRequires/eight_spaces.php.in
+++ b/tests/examples/migrations/TopLevelRequires/eight_spaces.php.in
@@ -1,0 +1,8 @@
+<?hh
+
+require_once('foo');
+
+<<__EntryPoint>>
+function main(): void {
+        bar();
+}

--- a/tests/examples/migrations/TopLevelRequires/empty_entrypoint.php.expect
+++ b/tests/examples/migrations/TopLevelRequires/empty_entrypoint.php.expect
@@ -2,5 +2,8 @@
 
 <<__EntryPoint>>
 function main(): void {
-  require_once('foo');
+  (() ==> {
+    // HHAST-generated to avoid pseudomain local leaks
+    require_once('foo');
+  })();
 }

--- a/tests/examples/migrations/TopLevelRequires/empty_entrypoint.php.expect
+++ b/tests/examples/migrations/TopLevelRequires/empty_entrypoint.php.expect
@@ -1,0 +1,6 @@
+<?hh
+
+<<__EntryPoint>>
+function main(): void {
+  require_once('foo');
+}

--- a/tests/examples/migrations/TopLevelRequires/empty_entrypoint.php.in
+++ b/tests/examples/migrations/TopLevelRequires/empty_entrypoint.php.in
@@ -1,0 +1,7 @@
+<?hh
+
+require_once('foo');
+
+<<__EntryPoint>>
+function main(): void {
+}

--- a/tests/examples/migrations/TopLevelRequires/has_class_extends.hack.expect
+++ b/tests/examples/migrations/TopLevelRequires/has_class_extends.hack.expect
@@ -1,0 +1,7 @@
+require_once('Foo.hack');
+
+class Bar extends Foo {}
+
+<<__EntryPoint>>
+function main(): void {
+}

--- a/tests/examples/migrations/TopLevelRequires/has_class_extends.hack.in
+++ b/tests/examples/migrations/TopLevelRequires/has_class_extends.hack.in
@@ -1,0 +1,7 @@
+require_once('Foo.hack');
+
+class Bar extends Foo {}
+
+<<__EntryPoint>>
+function main(): void {
+}

--- a/tests/examples/migrations/TopLevelRequires/has_class_implements.hack.expect
+++ b/tests/examples/migrations/TopLevelRequires/has_class_implements.hack.expect
@@ -1,0 +1,7 @@
+require_once('Foo.hack');
+
+class Bar implements Foo {}
+
+<<__EntryPoint>>
+function main(): void {
+}

--- a/tests/examples/migrations/TopLevelRequires/has_class_implements.hack.in
+++ b/tests/examples/migrations/TopLevelRequires/has_class_implements.hack.in
@@ -1,0 +1,7 @@
+require_once('Foo.hack');
+
+class Bar implements Foo {}
+
+<<__EntryPoint>>
+function main(): void {
+}

--- a/tests/examples/migrations/TopLevelRequires/has_class_with_no_parents.hack.expect
+++ b/tests/examples/migrations/TopLevelRequires/has_class_with_no_parents.hack.expect
@@ -1,0 +1,10 @@
+
+class Bar {}
+
+<<__EntryPoint>>
+function main(): void {
+  (() ==> {
+    // HHAST-generated to avoid pseudomain local leaks
+    require_once('foo.hack');
+  })();
+}

--- a/tests/examples/migrations/TopLevelRequires/has_class_with_no_parents.hack.in
+++ b/tests/examples/migrations/TopLevelRequires/has_class_with_no_parents.hack.in
@@ -1,0 +1,7 @@
+require_once('foo.hack');
+
+class Bar {}
+
+<<__EntryPoint>>
+function main(): void {
+}

--- a/tests/examples/migrations/TopLevelRequires/no_entrypoint.php.expect
+++ b/tests/examples/migrations/TopLevelRequires/no_entrypoint.php.expect
@@ -1,5 +1,5 @@
 <?hh
-/* HH_FIXME[1002] HHAST: move to <<__EntryPoint>> function */ require_once('foo');
+require_once('foo');
 
 foo();
 

--- a/tests/examples/migrations/TopLevelRequires/no_entrypoint.php.expect
+++ b/tests/examples/migrations/TopLevelRequires/no_entrypoint.php.expect
@@ -1,0 +1,7 @@
+<?hh
+/* HH_FIXME[1002] HHAST: move to <<__EntryPoint>> function */ require_once('foo');
+
+foo();
+
+function bar() {
+}

--- a/tests/examples/migrations/TopLevelRequires/no_entrypoint.php.in
+++ b/tests/examples/migrations/TopLevelRequires/no_entrypoint.php.in
@@ -1,0 +1,7 @@
+<?hh
+require_once('foo');
+
+foo();
+
+function bar() {
+}


### PR DESCRIPTION
- if there is a valid `<<__EntryPoint>>` function, move the requires there inside a lambda
- otherwise ~~, add an easily greppable `/* HH_FIXME[1002] `~~ assume it's not in strict mode and leave it alone