### PR TITLE
Fix LicenseHeaderLinter for .hack files

### DIFF
--- a/src/Linters/LicenseHeaderLinter.hack
+++ b/src/Linters/LicenseHeaderLinter.hack
@@ -73,7 +73,9 @@ final class LicenseHeaderLinter extends AutoFixingASTLinter {
   }
 
   public function getFixedNode(Script $node): Script {
-    $first = $node->getDeclarations()->getChildren()[1]->getFirstTokenx();
+    $children = $node->getDeclarations()->getChildren();
+    $first = (($children[0] is MarkupSection) ? $children[1] : $children[0])
+      ->getFirstTokenx();
     $leading = $first->getLeading()->toVec();
 
     $key = C\find_key(

--- a/tests/examples/LicenseHeaderLinter/no_markup_header.hack.autofix.expect
+++ b/tests/examples/LicenseHeaderLinter/no_markup_header.hack.autofix.expect
@@ -1,0 +1,12 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Foo;
+
+class Bar {}

--- a/tests/examples/LicenseHeaderLinter/no_markup_header.hack.expect
+++ b/tests/examples/LicenseHeaderLinter/no_markup_header.hack.expect
@@ -1,0 +1,7 @@
+[
+    {
+        "blame": "namespace Foo;\n\nclass Bar {}\n",
+        "blame_pretty": "namespace Foo;\n\nclass Bar {}\n",
+        "description": "Incorrect or missing license header"
+    }
+]

--- a/tests/examples/LicenseHeaderLinter/no_markup_header.hack.in
+++ b/tests/examples/LicenseHeaderLinter/no_markup_header.hack.in
@@ -1,0 +1,3 @@
+namespace Foo;
+
+class Bar {}


### PR DESCRIPTION
It skipped the first statement, on the assumption it was a
MarkupSection (ended by `<?hh`).

fixes #193