### PR TITLE
Only autofix unused variables in list and foreach key/value contexts

### DIFF
--- a/src/Linters/UnusedVariableLinter.hack
+++ b/src/Linters/UnusedVariableLinter.hack
@@ -44,12 +44,12 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
     }
 
     // If a variable is not classified as used then we are currently
-    // evaluating an assignment
+    // evaluating an unused assignment.
     return new ASTLintError(
       $this,
       "Variable is unused",
       $node,
-      () ==> $this->getFixedNode($node),
+      () ==> $this->getFixedNode($node, $functionish),
     );
   }
 
@@ -255,14 +255,40 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
     );
   }
 
-  public function getFixedNode(VariableExpression $node): VariableExpression {
+  /**
+   * Return a fixed node if possible.
+   *
+   * Most unused assignments require user evaluation to fix. An unused assignment
+   * that has a typo should be corrected; others should be deleted. List
+   * expressions and foreach keys/values are exceptions where it is safe to
+   * suggest renaming the variable.
+   */
+  public function getFixedNode(
+    VariableExpression $node,
+    IFunctionishDeclaration $functionish,
+  ): VariableExpression {
     $expr = $node->getExpression();
     if (!$expr is VariableToken) {
       return $node;
     }
-    return $node->withExpression(
-      $expr->withText('$_'.Str\strip_prefix($expr->getText(), '$')),
+
+    $parents = $functionish->getAncestorsOfDescendant($node);
+    $should_autofix = (
+      C\any($parents, $p ==> $p is ListExpression) ||
+      C\any(
+        $parents,
+        $p ==> $p is ForeachStatement &&
+          (($p->getValue() === $node) || ($p->getKey() === $node)),
+      )
     );
+
+    if ($should_autofix) {
+      return $node->withExpression(
+        $expr->withText('$_'.Str\strip_prefix($expr->getText(), '$')),
+      );
+    } else {
+      return $node;
+    }
   }
 
   <<__Override>>

--- a/tests/examples/UnusedVariableLinter/unused_foreach.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_foreach.php.autofix.expect
@@ -11,9 +11,15 @@ function foreach_key_value($items) {
 }
 
 function foreach_shadow($items) {
-  $_i = 0;
-  $_item = 'a';
+  $i = 0;
+  $item = 'a';
   foreach ($items as $_i => $_item) {
+  }
+}
+
+function foreach_nested($items) {
+  foreach ($items as $item) {
+    $a = $item;
   }
 }
 
@@ -29,9 +35,15 @@ class C {
   }
 
   public function foreach_shadow($items) {
-    $_i = 0;
-    $_item = 'a';
+    $i = 0;
+    $item = 'a';
     foreach ($items as $_i => $_item) {
+    }
+  }
+
+  public function foreach_nested($items) {
+    foreach ($items as $item) {
+      $a = $item;
     }
   }
 }

--- a/tests/examples/UnusedVariableLinter/unused_foreach.php.expect
+++ b/tests/examples/UnusedVariableLinter/unused_foreach.php.expect
@@ -35,6 +35,11 @@
         "description": "Variable is unused"
     },
     {
+        "blame": "    $a ",
+        "blame_pretty": "    $a ",
+        "description": "Variable is unused"
+    },
+    {
         "blame": "$item",
         "blame_pretty": "$item",
         "description": "Variable is unused"
@@ -67,6 +72,11 @@
     {
         "blame": "$item",
         "blame_pretty": "$item",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "      $a ",
+        "blame_pretty": "      $a ",
         "description": "Variable is unused"
     }
 ]

--- a/tests/examples/UnusedVariableLinter/unused_foreach.php.in
+++ b/tests/examples/UnusedVariableLinter/unused_foreach.php.in
@@ -17,6 +17,12 @@ function foreach_shadow($items) {
   }
 }
 
+function foreach_nested($items) {
+  foreach ($items as $item) {
+    $a = $item;
+  }
+}
+
 class C {
   public function foreach_value($items) {
     foreach ($items as $item) {
@@ -32,6 +38,12 @@ class C {
     $i = 0;
     $item = 'a';
     foreach ($items as $i => $item) {
+    }
+  }
+
+  public function foreach_nested($items) {
+    foreach ($items as $item) {
+      $a = $item;
     }
   }
 }

--- a/tests/examples/UnusedVariableLinter/unused_subscript.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_subscript.php.autofix.expect
@@ -1,30 +1,30 @@
 <?hh
 
 function subscript_expressions(): void {
-  $_a = dict[];
+  $a = dict[];
   $b = 'b';
   $c = 'c';
   $d = 'd';
-  $_a['a'] = 1;
-  $_a[$b] = 5;
-  $_a[$c.$d] = 10;
-  $_a[1]['a']['b'] = 10;
-  $_a[1]['c'][] = 10;
+  $a['a'] = 1;
+  $a[$b] = 5;
+  $a[$c.$d] = 10;
+  $a[1]['a']['b'] = 10;
+  $a[1]['c'][] = 10;
 
   return;
 }
 
 class C {
   public function subscript_expressions(): void {
-    $_a = dict[];
+    $a = dict[];
     $b = 'b';
     $c = 'c';
     $d = 'd';
-    $_a['a'] = 1;
-    $_a[$b] = 5;
-    $_a[$c.$d] = 10;
-    $_a[1]['a']['b'] = 10;
-    $_a[1]['c'][] = 10;
+    $a['a'] = 1;
+    $a[$b] = 5;
+    $a[$c.$d] = 10;
+    $a[1]['a']['b'] = 10;
+    $a[1]['c'][] = 10;
 
     return;
   }

--- a/tests/examples/UnusedVariableLinter/unused_variable.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_variable.php.autofix.expect
@@ -1,32 +1,32 @@
 <?hh
 
 function simple(int $bar): int {
-  $_baz = $bar;
+  $baz = $bar;
   return $bar;
 }
 
 function with_mutation(): void {
-  $_b = 0;
-  $_b += 1;
+  $b = 0;
+  $b += 1;
 
-  $_c = 'hello';
-  $_c .= ' world';
+  $c = 'hello';
+  $c .= ' world';
 
   return;
 }
 
 class C {
   public function simple(int $bar): int {
-    $_baz = $bar;
+    $baz = $bar;
     return $bar;
   }
 
   public function with_mutation(): void {
-    $_b = 0;
-    $_b += 1;
+    $b = 0;
+    $b += 1;
 
-    $_c = 'hello';
-    $_c .= ' world';
+    $c = 'hello';
+    $c .= ' world';
 
     return;
   }


### PR DESCRIPTION
Based on a discussion with @jjergus in #190, this PR eliminates autofixes for unused variables in most cases. Currently the `UnusedVariableLinter` suggests renaming unused var `$a` to `$_a`, mirroring the UnusedParameterLinter. This is rarely the correct fix. Here are some examples:

**Example 1. The correct fix is to delete the statement where `$a` is assigned.**

```Hack
function pure_unused(): void {
  $a = 5;
  /* other code */
}
```

**Example 2. The correct fix is to fix the typo in `$offest`.**

```Hack
function unused_via_typo(bool $bool): int {
  $offset = 0;
  if ($bool) {
    $offest = 1;
  }
  return $offset;
}
```

**Example 3. The correct fix is to change the call to `exec` to use `$safe_cmd`.**

```Hack
function unused_via_error(string $unsafe_cmd): void {
  $safe_cmd = make_safe($unsafe_cmd);
  exec($unsafe_cmd);
}
```

It retains autofixes for unused variables in list expressions or foreach keys/values.