### PR TITLE
add --preg-with-matches migration

### DIFF
--- a/src/Migrations/PregWithMatchesMigration.hack
+++ b/src/Migrations/PregWithMatchesMigration.hack
@@ -10,6 +10,7 @@
 namespace Facebook\HHAST;
 
 use namespace HH\Lib\C;
+use function Facebook\HHAST\resolve_function;
 
 /**
  * Migrates preg_match() and preg_match_all() calls with a by-ref $matches
@@ -29,29 +30,35 @@ final class PregWithMatchesMigration extends BaseMigration {
     ) {
       // Only replace calls to functions from the root namespace.
       $receiver = $node->getReceiver();
-      if (!$receiver is QualifiedName) {
-        continue;
-      }
-
-      $parts = $receiver->getParts()->getChildren();
-      if (
-        C\count($parts) === 2 &&
-        $parts[0]->getItem() is null &&
-        $parts[0]->getSeparator() is BackslashToken &&
-        $parts[1]->getItem() is NameToken &&
-        $parts[1]->getSeparator() is null
-      ) {
-        $name_token = $parts[1]->getItem() as NameToken;
+      if ($receiver is NameToken) {
+        $fn_name = $receiver->getText();
+      } else if ($receiver is QualifiedName) {
+        $fn_name = '';
+        foreach ($receiver->getParts()->getChildren() as $part) {
+          invariant(
+            $part->getSeparator() is null ||
+              $part->getSeparator() is BackslashToken,
+            'Unexpected separator inside qualified function name: "%s"',
+            ($part->getSeparator() as nonnull)->getText(),
+          );
+          $fn_name .= $part->getItem()?->getText() ?? '';
+          $fn_name .= $part->getSeparator()?->getText() ?? '';
+        }
       } else {
-        continue;
+        invariant_violation(
+          'Unsupported function call receiver type %s.',
+          \get_class($receiver),
+        );
       }
 
-      if (!C\contains_key(self::REPLACEMENTS, $name_token->getText())) {
+      $resolved_name = resolve_function($fn_name, $root, $node);
+
+      if (!C\contains_key(self::REPLACEMENTS, $resolved_name)) {
         continue;
       }
 
       // We only need to migrate calls that have a by-ref/inout 3rd argument.
-      $args = $node->getArgumentList() as nonnull->getChildren();
+      $args = ($node->getArgumentList() as nonnull)->getChildren();
       if (C\count($args) < 3) {
         continue;
       }
@@ -61,12 +68,17 @@ final class PregWithMatchesMigration extends BaseMigration {
         $arg3 is DecoratedExpression && $arg3->getDecorator() is InoutToken ||
         $arg3 is PrefixUnaryExpression && $arg3->getOperator() is AmpersandToken
       ) {
+        $leading = $receiver->getFirstTokenx()->getLeading();
+        $trailing = $receiver->getLastTokenx()->getTrailing();
+        $new_name = self::REPLACEMENTS[$resolved_name];
+
         $root = $root->replace(
-          $name_token,
-          new NameToken(
-            $name_token->getLeading(),
-            $name_token->getTrailing(),
-            self::REPLACEMENTS[$name_token->getText()],
+          $receiver,
+          new QualifiedName(
+            NodeList::createMaybeEmptyList(vec[
+              new ListItem(null, new BackslashToken($leading, null)),
+              new ListItem(new NameToken(null, $trailing, $new_name), null),
+            ]),
           ),
         );
 
@@ -75,9 +87,8 @@ final class PregWithMatchesMigration extends BaseMigration {
           // If there is nothing between "&" and the next token, insert a space.
           $trailing = $arg3->getOperator()->getTrailing();
           if (
-            $trailing->getCount() === 0 &&
-            $arg3->getOperand()->getFirstTokenx()->getLeading()->getCount() ===
-              0
+            $trailing->isEmpty() &&
+            $arg3->getOperand()->getFirstTokenx()->getLeading()->isEmpty()
           ) {
             $trailing =
               NodeList::createMaybeEmptyList(vec[new WhiteSpace(' ')]);

--- a/src/Migrations/PregWithMatchesMigration.hack
+++ b/src/Migrations/PregWithMatchesMigration.hack
@@ -1,0 +1,96 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\C;
+
+/**
+ * Migrates preg_match() and preg_match_all() calls with a by-ref $matches
+ * argument to preg_match_with_matches() and preg_match_all_with_matches().
+ */
+final class PregWithMatchesMigration extends BaseMigration {
+
+  const dict<string, string> REPLACEMENTS = dict[
+    'preg_match' => 'preg_match_with_matches',
+    'preg_match_all' => 'preg_match_all_with_matches',
+  ];
+
+  <<__Override>>
+  public function migrateFile(string $_path, Script $root): Script {
+    foreach (
+      $root->getDescendantsOfType(FunctionCallExpression::class) as $node
+    ) {
+      // Only replace calls to functions from the root namespace.
+      $receiver = $node->getReceiver();
+      if (!$receiver is QualifiedName) {
+        continue;
+      }
+
+      $parts = $receiver->getParts()->getChildren();
+      if (
+        C\count($parts) === 2 &&
+        $parts[0]->getItem() is null &&
+        $parts[0]->getSeparator() is BackslashToken &&
+        $parts[1]->getItem() is NameToken &&
+        $parts[1]->getSeparator() is null
+      ) {
+        $name_token = $parts[1]->getItem() as NameToken;
+      } else {
+        continue;
+      }
+
+      if (!C\contains_key(self::REPLACEMENTS, $name_token->getText())) {
+        continue;
+      }
+
+      // We only need to migrate calls that have a by-ref/inout 3rd argument.
+      $args = $node->getArgumentList() as nonnull->getChildren();
+      if (C\count($args) < 3) {
+        continue;
+      }
+
+      $arg3 = $args[2]->getItemx();
+      if (
+        $arg3 is DecoratedExpression && $arg3->getDecorator() is InoutToken ||
+        $arg3 is PrefixUnaryExpression && $arg3->getOperator() is AmpersandToken
+      ) {
+        $root = $root->replace(
+          $name_token,
+          new NameToken(
+            $name_token->getLeading(),
+            $name_token->getTrailing(),
+            self::REPLACEMENTS[$name_token->getText()],
+          ),
+        );
+
+        // If it's by-ref, migrate to inout.
+        if ($arg3 is PrefixUnaryExpression) {
+          // If there is nothing between "&" and the next token, insert a space.
+          $trailing = $arg3->getOperator()->getTrailing();
+          if (
+            $trailing->getCount() === 0 &&
+            $arg3->getOperand()->getFirstTokenx()->getLeading()->getCount() ===
+              0
+          ) {
+            $trailing =
+              NodeList::createMaybeEmptyList(vec[new WhiteSpace(' ')]);
+          }
+
+          $root = $root->replace(
+            $arg3->getOperator(),
+            new InoutToken($arg3->getOperator()->getLeading(), $trailing),
+          );
+        }
+      }
+    }
+
+    return $root;
+  }
+}

--- a/src/__Private/Resolution/get_current_uses.hack
+++ b/src/__Private/Resolution/get_current_uses.hack
@@ -17,6 +17,7 @@ function get_current_uses(
 ): shape(
   'namespaces' => dict<string, string>,
   'types' => dict<string, string>,
+  'functions' => dict<string, string>,
 ) {
   $namespaces = $root->getNamespaces();
   if (!$namespaces) {
@@ -32,5 +33,9 @@ function get_current_uses(
     }
   }
 
-  return shape('namespaces' => dict[], 'types' => dict[]);
+  return shape(
+    'namespaces' => dict[],
+    'types' => dict[],
+    'functions' => dict[],
+  );
 }

--- a/src/__Private/Resolution/resolve_name.hack
+++ b/src/__Private/Resolution/resolve_name.hack
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private\Resolution;
+
+use namespace HH\Lib\{C, Str, Vec};
+use type Facebook\HHAST\{Node, Script};
+
+function resolve_name(
+  string $name,
+  Script $root,
+  Node $node,
+  dict<string, string> $used_namespaces,
+): string {
+  if (Str\starts_with($name, '\\')) {
+    return Str\strip_prefix($name, '\\');
+  }
+  invariant(
+    !Str\contains($name, '<'),
+    'Call on the class name without generics',
+  );
+
+  $autoimports = keyset[
+    'Awaitable',
+    'ConstMap',
+    'ConstSet',
+    'ConstVector',
+    'Container',
+    'ImmMap',
+    'ImmSet',
+    'ImmVector',
+    'KeyedContainer',
+    'KeyedTraversable',
+    'Map',
+    'Set',
+    'Stringish',
+    'Traversable',
+    'Vector',
+  ];
+  if (C\contains_key($autoimports, $name)) {
+    return 'HH\\'.$name;
+  }
+
+  $ns = get_current_namespace($root, $node);
+
+  if (Str\contains($name, '\\')) {
+    $maybe_aliased = $name
+      |> \explode("\\", $$)
+      |> C\firstx($$);
+    if (C\contains_key($used_namespaces, $maybe_aliased)) {
+      return $name
+        |> \explode('\\', $$)
+        |> Vec\drop($$, 1)
+        |> Str\join($$, '\\')
+        |> $used_namespaces[$maybe_aliased].'\\'.$$;
+    }
+
+    if ($ns !== null) {
+      return $ns.'\\'.$name;
+    }
+    return $name;
+  }
+
+  if ($ns !== null) {
+    return $ns.'\\'.$name;
+  }
+
+  return $name;
+}

--- a/src/__Private/Resolution/resolve_name.hack
+++ b/src/__Private/Resolution/resolve_name.hack
@@ -51,11 +51,11 @@ function resolve_name(
 
   if (Str\contains($name, '\\')) {
     $maybe_aliased = $name
-      |> \explode("\\", $$)
+      |> Str\split($$, '\\')
       |> C\firstx($$);
     if (C\contains_key($used_namespaces, $maybe_aliased)) {
       return $name
-        |> \explode('\\', $$)
+        |> Str\split($$, '\\')
         |> Vec\drop($$, 1)
         |> Str\join($$, '\\')
         |> $used_namespaces[$maybe_aliased].'\\'.$$;

--- a/src/nodes/Script.hack
+++ b/src/nodes/Script.hack
@@ -40,6 +40,7 @@ final class Script extends ScriptGeneratedBase {
     'uses' => shape(
       'namespaces' => dict<string, string>,
       'types' => dict<string, string>,
+      'functions' => dict<string, string>,
     ),
   );
 
@@ -79,6 +80,7 @@ final class Script extends ScriptGeneratedBase {
             'namespaces' =>
               Dict\merge($outer['namespaces'], $inner['namespaces']),
             'types' => Dict\merge($outer['types'], $inner['types']),
+            'functions' => Dict\merge($outer['functions'], $inner['functions']),
           ),
         );
       },

--- a/src/resolve_function.hack
+++ b/src/resolve_function.hack
@@ -12,12 +12,12 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\C;
 use namespace Facebook\HHAST\__Private\Resolution;
 
-function resolve_type(string $type, Script $root, Node $node): string {
+function resolve_function(string $name, Script $root, Node $node): string {
   $uses = Resolution\get_current_uses($root, $node);
 
-  if (C\contains_key($uses['types'], $type)) {
-    return $uses['types'][$type];
+  if (C\contains_key($uses['functions'], $name)) {
+    return $uses['functions'][$name];
   }
 
-  return Resolution\resolve_name($type, $root, $node, $uses['namespaces']);
+  return Resolution\resolve_name($name, $root, $node, $uses['namespaces']);
 }

--- a/tests/PregWithMatchesMigrationTest.hack
+++ b/tests/PregWithMatchesMigrationTest.hack
@@ -1,0 +1,14 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class PregWithMatchesMigrationTest extends MigrationTest {
+  const type TMigration = PregWithMatchesMigration;
+}

--- a/tests/ResolutionTest.hack
+++ b/tests/ResolutionTest.hack
@@ -79,6 +79,7 @@ final class ResolutionTest extends TestCase {
     shape(
       'namespaces' => dict<string, string>,
       'types' => dict<string, string>,
+      'functions' => dict<string, string>,
     ),
   )> {
     return [
@@ -95,20 +96,28 @@ final class ResolutionTest extends TestCase {
             'Bar' => 'Bar',
             'Baz' => 'Baz',
           ],
+          'functions' => dict[
+            'Foo' => 'Foo',
+            'Bar' => 'Bar',
+            'Baz' => 'Baz',
+          ],
         ),
       ),
       tuple(
-        '<?hh use namespace Foo, type Bar; class Target {}',
+        '<?hh use namespace Foo, type Bar, function Baz; class Target {}',
         shape(
           'namespaces' => dict['Foo' => 'Foo'],
           'types' => dict['Bar' => 'Bar'],
+          'functions' => dict['Baz' => 'Baz'],
         ),
       ),
       tuple(
-        '<?hh use Foo as Bar, type Herp as Derp; class Target {}',
+        '<?hh use Foo as Bar, type Herp as Derp, function Hot as Cold; '.
+        'class Target {}',
         shape(
           'namespaces' => dict['Bar' => 'Foo'],
           'types' => dict['Bar' => 'Foo', 'Derp' => 'Herp'],
+          'functions' => dict['Bar' => 'Foo', 'Cold' => 'Hot'],
         ),
       ),
       tuple(
@@ -117,13 +126,25 @@ final class ResolutionTest extends TestCase {
         shape(
           'namespaces' => dict[],
           'types' => dict['Foo' => 'Foo', 'Derp' => 'Herp\\Derp'],
+          'functions' => dict[],
         ),
       ),
       tuple(
-        '<?hh use type NS\\{Foo, Bar}; class Target{}',
+        '<?hh use type NS\\{Foo, Bar}; use function NS\\{Herp, Derp}; '.
+        'class Target{}',
         shape(
           'namespaces' => dict[],
           'types' => dict['Foo' => 'NS\\Foo', 'Bar' => 'NS\\Bar'],
+          'functions' => dict['Herp' => 'NS\\Herp', 'Derp' => 'NS\\Derp'],
+        ),
+      ),
+      // Verify meaningless "\" are stripped.
+      tuple(
+        '<?hh use namespace \\Foo, type \\Bar, function \\Baz; class Target{}',
+        shape(
+          'namespaces' => dict['Foo' => 'Foo'],
+          'types' => dict['Bar' => 'Bar'],
+          'functions' => dict['Baz' => 'Baz'],
         ),
       ),
     ];

--- a/tests/examples/migrations/preg_with_matches.hack.expect
+++ b/tests/examples/migrations/preg_with_matches.hack.expect
@@ -1,0 +1,44 @@
+<?hh // strict
+
+/**
+ * Copyright (c) 2016, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional
+ * grant of patent rights can be found in the PATENTS file in the same
+ * directory.
+ *
+ */
+
+function foo(): void {
+  $matches = null;
+
+  \preg_match('/foo/', 'bar');
+  \preg_match_all('/foo/', 'bar');
+
+  \preg_match_with_matches('/foo/', 'bar', inout $matches);
+  \preg_match_all_with_matches('/foo/', 'bar', inout $matches);
+
+  \preg_match_with_matches('/foo/', 'bar', inout $matches);
+  \preg_match_all_with_matches('/foo/', 'bar', inout $matches);
+
+  \preg_match_with_matches('/foo/', 'bar', inout $matches, \PREG_UNMATCHED_AS_NULL, 42);
+  \preg_match_all_with_matches(
+    '/foo/',
+    'bar',
+    inout $matches,
+    \PREG_SET_ORDER | \PREG_OFFSET_CAPTURE,
+  );
+
+  \ // Weird formatting is preserved.
+  preg_match_with_matches /* So long and thanks for all the fish. */ (
+    '/foo/',
+    'bar',
+    inout/* no space here */$matches,
+  );
+
+  // Not in the root namespace.
+  preg_match('/foo/', 'bar', &$matches);
+  MyNamespace\preg_match_all('/foo/', 'bar', &$matches);
+}

--- a/tests/examples/migrations/preg_with_matches.hack.expect
+++ b/tests/examples/migrations/preg_with_matches.hack.expect
@@ -11,6 +11,11 @@
  *
  */
 
+namespace MyNamespace {
+
+use function preg_match as analbumcover;
+use function \preg_match_all as catchthesemen;
+
 function foo(): void {
   $matches = null;
 
@@ -31,14 +36,25 @@ function foo(): void {
     \PREG_SET_ORDER | \PREG_OFFSET_CAPTURE,
   );
 
-  \ // Weird formatting is preserved.
-  preg_match_with_matches /* So long and thanks for all the fish. */ (
+  \preg_match_with_matches /* ...but trivia at the end is preserved. */ (
     '/foo/',
     'bar',
     inout/* no space here */$matches,
   );
 
+  // Aliased.
+  \preg_match_with_matches('/foo/', 'bar', inout $matches);
+  \preg_match_all_with_matches('/foo/', 'bar', inout $matches);
+
   // Not in the root namespace.
   preg_match('/foo/', 'bar', &$matches);
   MyNamespace\preg_match_all('/foo/', 'bar', &$matches);
+}
+
+} // end of MyNamespace
+
+
+function bar(): void {
+  $matches = null;
+  \preg_match_with_matches('/foo/', 'bar', inout $matches);
 }

--- a/tests/examples/migrations/preg_with_matches.hack.in
+++ b/tests/examples/migrations/preg_with_matches.hack.in
@@ -1,0 +1,44 @@
+<?hh // strict
+
+/**
+ * Copyright (c) 2016, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional
+ * grant of patent rights can be found in the PATENTS file in the same
+ * directory.
+ *
+ */
+
+function foo(): void {
+  $matches = null;
+
+  \preg_match('/foo/', 'bar');
+  \preg_match_all('/foo/', 'bar');
+
+  \preg_match('/foo/', 'bar', &$matches);
+  \preg_match_all('/foo/', 'bar', &$matches);
+
+  \preg_match('/foo/', 'bar', inout $matches);
+  \preg_match_all('/foo/', 'bar', inout $matches);
+
+  \preg_match('/foo/', 'bar', inout $matches, \PREG_UNMATCHED_AS_NULL, 42);
+  \preg_match_all(
+    '/foo/',
+    'bar',
+    &$matches,
+    \PREG_SET_ORDER | \PREG_OFFSET_CAPTURE,
+  );
+
+  \ // Weird formatting is preserved.
+  preg_match /* So long and thanks for all the fish. */ (
+    '/foo/',
+    'bar',
+    &/* no space here */$matches,
+  );
+
+  // Not in the root namespace.
+  preg_match('/foo/', 'bar', &$matches);
+  MyNamespace\preg_match_all('/foo/', 'bar', &$matches);
+}

--- a/tests/examples/migrations/preg_with_matches.hack.in
+++ b/tests/examples/migrations/preg_with_matches.hack.in
@@ -11,6 +11,11 @@
  *
  */
 
+namespace MyNamespace {
+
+use function preg_match as analbumcover;
+use function \preg_match_all as catchthesemen;
+
 function foo(): void {
   $matches = null;
 
@@ -31,14 +36,26 @@ function foo(): void {
     \PREG_SET_ORDER | \PREG_OFFSET_CAPTURE,
   );
 
-  \ // Weird formatting is preserved.
-  preg_match /* So long and thanks for all the fish. */ (
+  \ // Trivia in the middle of the function name is lost...
+  preg_match /* ...but trivia at the end is preserved. */ (
     '/foo/',
     'bar',
     &/* no space here */$matches,
   );
 
+  // Aliased.
+  analbumcover('/foo/', 'bar', &$matches);
+  catchthesemen('/foo/', 'bar', inout $matches);
+
   // Not in the root namespace.
   preg_match('/foo/', 'bar', &$matches);
   MyNamespace\preg_match_all('/foo/', 'bar', &$matches);
+}
+
+} // end of MyNamespace
+
+
+function bar(): void {
+  $matches = null;
+  preg_match('/foo/', 'bar', &$matches);
 }


### PR DESCRIPTION
I considered migrating to `Regex\first_match` or `Regex\every_match` where possible, but the API is quite different (returns null/nonnull vs 1/0, matches are returned instead of assigned to a variable) so the migration would end up much more complicated and still produce suboptimal code (stuff like `($matches = Regex\first_match(...)) is nonnull ? 1 : 0`, but even worse because assignments as expressions are not allowed anymore).