### PR TITLE
Consider inout and by-ref params to lambdas always used

### DIFF
--- a/tests/UnusedVariableLinterTest.hack
+++ b/tests/UnusedVariableLinterTest.hack
@@ -31,6 +31,7 @@ final class UnusedVariableLinterTest extends TestCase {
       tuple('<?hh function foo(inout $d) { $d = 5; }'),
       tuple('<?hh function foo() { $users = []; $u = ["id" => 15]; $users[$u["id"]] = 5; return $users; }'),
       tuple('<?hh function foo() { $s = "a"; echo "{$s}"; }'),
+      tuple('<?hh function foo() { return (inout vec<int> $p) ==> { $p[] = 1; }; }'),
       tuple('<?hh class C { public function foo() { $bar = 1; return $bar; } }'),
       tuple('<?hh class C { public function foo() { $_bar = 1; return 2; } }'),
       tuple('<?hh class C { public function foo() { $GLOBALS["foo"] = "bar"; } }'),

--- a/tests/UnusedVariableLinterTest.hack
+++ b/tests/UnusedVariableLinterTest.hack
@@ -32,6 +32,10 @@ final class UnusedVariableLinterTest extends TestCase {
       tuple('<?hh function foo() { $users = []; $u = ["id" => 15]; $users[$u["id"]] = 5; return $users; }'),
       tuple('<?hh function foo() { $s = "a"; echo "{$s}"; }'),
       tuple('<?hh function foo() { return (inout vec<int> $p) ==> { $p[] = 1; }; }'),
+      tuple('<?hh function foo() { return function(inout vec<int> $p) ==> { $p[] = 1; }; }',),
+      // This is a false negative, tested here for documentation
+      // It would be an improvement to detect $a = 10 as unused while not detecting $a = 5 as unused.
+      tuple('<?hh function foo() { (inout $a) ==> { $a = 5; }; $a = 10; }'),
       tuple('<?hh class C { public function foo() { $bar = 1; return $bar; } }'),
       tuple('<?hh class C { public function foo() { $_bar = 1; return 2; } }'),
       tuple('<?hh class C { public function foo() { $GLOBALS["foo"] = "bar"; } }'),


### PR DESCRIPTION
This fixes #208, where a variable inside a lambda expression that mutates an `inout` parameter of that expression is flagged as unused. This increases the potential for false negatives, an example of which is documented in the "clean" test cases.