### PR TITLE
handle multiple bodyless namespaces

### DIFF
--- a/src/__Private/Resolution/get_current_namespace.hack
+++ b/src/__Private/Resolution/get_current_namespace.hack
@@ -10,23 +10,14 @@
 namespace Facebook\HHAST\__Private\Resolution;
 
 use type Facebook\HHAST\{Node, Script};
-use namespace HH\Lib\C;
 
 function get_current_namespace(Script $root, Node $node): ?string {
-  $namespaces = $root->getNamespaces();
-  if (C\is_empty($namespaces)) {
-    return null;
-  }
-  if ($namespaces[0]['statement']) {
-    return $namespaces[0]['decl']->getQualifiedNameAsString();
-  }
-
-  foreach ($namespaces as $ns) {
-    $ns = $ns['decl'];
-    if ($ns->isAncestorOf($node)) {
-      $ns = $ns->getQualifiedNameAsString();
-      return ($ns === '') ? null : $ns;
+  foreach ($root->getNamespaces() as $ns) {
+    if ($ns['children']->isAncestorOf($node)) {
+      return $ns['name'];
     }
   }
+
+  // We should only get here if $node is inside a namespace declaration header.
   return null;
 }

--- a/src/__Private/Resolution/get_current_uses.hack
+++ b/src/__Private/Resolution/get_current_uses.hack
@@ -19,20 +19,13 @@ function get_current_uses(
   'types' => dict<string, string>,
   'functions' => dict<string, string>,
 ) {
-  $namespaces = $root->getNamespaces();
-  if (!$namespaces) {
-    return get_uses_directly_in_scope($root->getDeclarations());
-  }
-  if ($namespaces[0]['statement']) {
-    return $namespaces[0]['uses'];
-  }
-
-  foreach ($namespaces as $ns) {
-    if ($ns['decl']->isAncestorOf($node)) {
+  foreach ($root->getNamespaces() as $ns) {
+    if ($ns['children']->isAncestorOf($node)) {
       return $ns['uses'];
     }
   }
 
+  // We should only get here if $node is inside a namespace declaration header.
   return shape(
     'namespaces' => dict[],
     'types' => dict[],

--- a/tests/ResolutionTest.hack
+++ b/tests/ResolutionTest.hack
@@ -189,17 +189,38 @@ final class ResolutionTest extends TestCase {
       ),
       // generics
       tuple('<?hh namespace Foo; class Target<T> {}', 'T', 'T'),
+      // multiple namespaces
+      tuple(
+        'namespace Foo; namespace Bar; class Target {}',
+        'Target',
+        'Bar\\Target',
+      ),
+      tuple(
+        'namespace Foo; class Target {} namespace Bar;',
+        'Target',
+        'Foo\\Target',
+      ),
+      tuple(
+        'class Target {} namespace Foo; namespace Bar;',
+        'Target',
+        'Target',
+      ),
+      // multiple namespaces with a "use" statement
+      tuple(
+        'use type Herp\Derp; namespace Foo; namespace Bar; class Target {}',
+        'Derp',
+        'Herp\\Derp',
+      ),
+      tuple(
+        'namespace Foo; use type Herp\Derp; namespace Bar; class Target {}',
+        'Derp',
+        'Bar\\Derp',
+      ),
+      tuple(
+        'namespace Foo; namespace Bar; use type Herp\Derp; class Target {}',
+        'Derp',
+        'Herp\\Derp',
+      ),
     ];
-  }
-
-  <<DataProvider('getTypeResolutionExamples')>>
-  public async function testTypeResolution(
-    string $code,
-    string $type,
-    string $expected,
-  ): Awaitable<void> {
-    list($root, $node) = await self::getRootAndNodeAsync($code);
-    expect(resolve_type($type, $root, $node)['name'])
-      ->toBeSame($expected);
   }
 }


### PR DESCRIPTION
Right now HHAST's type resolution can't handle files with multiple namespaces without body, which is, unfortunately, legal syntax.