### PR TITLE
[PU] Starting linter for PU syntax

### DIFF
--- a/src/Linters/PocketUniversesLinter.hack
+++ b/src/Linters/PocketUniversesLinter.hack
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2019-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class PocketLinterMessage {
+  const string Message =
+    'This is a reserved syntax for the Pocket Universes prototype.\n'.
+    'Only use it if you know  what you are doing.\n'.
+    'We advise you to remove it.';
+}
+
+// Displays warning for the :@atom_name case
+final class PocketAtomExpressionLinter extends ASTLinter {
+  const type TNode = PocketAtomExpression;
+  const type TContext = Script;
+
+  <<__Override>>
+  public function getLintErrorForNode(
+    Script $_context,
+    PocketAtomExpression $expr,
+  ): ?ASTLintError {
+    return new ASTLintError($this, PocketLinterMessage::Message, $expr);
+  }
+}
+
+// Displays warning for the Class:@Enum::foo case
+final class PocketIdentifierExpressionLinter extends ASTLinter {
+  const type TNode = PocketIdentifierExpression;
+  const type TContext = Script;
+
+  <<__Override>>
+  public function getLintErrorForNode(
+    Script $_context,
+    PocketIdentifierExpression $expr,
+  ): ?ASTLintError {
+    return new ASTLintError($this, PocketLinterMessage::Message, $expr);
+  }
+}
+
+// Displays warning for any Pocket Universes declaration/definition
+final class PocketEnumDeclarationLinter extends ASTLinter {
+  const type TNode = PocketEnumDeclaration;
+  const type TContext = Script;
+
+  <<__Override>>
+  public function getLintErrorForNode(
+    Script $_context,
+    PocketEnumDeclaration $expr,
+  ): ?ASTLintError {
+    return new ASTLintError($this, PocketLinterMessage::Message, $expr);
+  }
+}

--- a/src/Linters/PocketUniversesLinter.hack
+++ b/src/Linters/PocketUniversesLinter.hack
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019-present, Facebook, Inc.
+ *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.
  *
  *  This source code is licensed under the MIT license found in the

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -78,6 +78,9 @@ final class LintRunConfig {
     HHAST\GroupUseStatementsLinter::class,
     HHAST\GroupUseStatementAlphabetizationLinter::class,
     HHAST\NoWhitespaceAtEndOfLineLinter::class,
+    HHAST\PocketAtomExpressionLinter::class,
+    HHAST\PocketIdentifierExpressionLinter::class,
+    HHAST\PocketEnumDeclarationLinter::class,
   ];
 
   const vec<classname<BaseLinter>> NON_DEFAULT_LINTERS = vec[

--- a/tests/PocketAtomExpressionLinterTest.hack
+++ b/tests/PocketAtomExpressionLinterTest.hack
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2019-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class PocketAtomExpressionLinterTest extends TestCase {
+    use LinterTestTrait;
+
+    protected function getLinter(string $file): PocketAtomExpressionLinter {
+        return PocketAtomExpressionLinter::fromPath($file);
+    }
+
+    public function getCleanExamples(): vec<(string)> {
+        return vec[tuple('<?hh if (true) {} else if (false) {}')];
+    }
+}

--- a/tests/PocketAtomExpressionLinterTest.hack
+++ b/tests/PocketAtomExpressionLinterTest.hack
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019-present, Facebook, Inc.
+ *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.
  *
  *  This source code is licensed under the MIT license found in the

--- a/tests/PocketIdentifierExpressionLinterTest.hack
+++ b/tests/PocketIdentifierExpressionLinterTest.hack
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2019-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class PocketIdentifierExpressionLinterTest extends TestCase {
+    use LinterTestTrait;
+
+    protected function getLinter(
+        string $file,
+    ): PocketIdentifierExpressionLinter {
+        return PocketIdentifierExpressionLinter::fromPath($file);
+    }
+
+    public function getCleanExamples(): vec<(string)> {
+        return vec[tuple('<?hh if (true) {} else if (false) {}')];
+    }
+}

--- a/tests/PocketIdentifierExpressionLinterTest.hack
+++ b/tests/PocketIdentifierExpressionLinterTest.hack
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019-present, Facebook, Inc.
+ *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.
  *
  *  This source code is licensed under the MIT license found in the

--- a/tests/examples/PocketAtomExpressionLinter/atom.hack.expect
+++ b/tests/examples/PocketAtomExpressionLinter/atom.hack.expect
@@ -1,0 +1,7 @@
+[
+    {
+        "blame": ":@bar",
+        "blame_pretty": ":@bar",
+        "description": "This is a reserved syntax for the Pocket Universes prototype.\\nOnly use it if you know  what you are doing.\\nWe advise you to remove it."
+    }
+]

--- a/tests/examples/PocketAtomExpressionLinter/atom.hack.in
+++ b/tests/examples/PocketAtomExpressionLinter/atom.hack.in
@@ -1,0 +1,13 @@
+/*
+ *  Copyright (c) 2019-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+function foo(): void {
+    $x = :@bar;
+    var_dump($x);
+}

--- a/tests/examples/PocketIdentifierExpressionLinter/pu_ident.hack.expect
+++ b/tests/examples/PocketIdentifierExpressionLinter/pu_ident.hack.expect
@@ -1,11 +1,7 @@
 [
     {
-        "blame": "PocketIdentifierExpressionLinter ",
-        "blame_pretty": "Pocket Universes Identifier ",
-        "description": [
-            "This is a reserved syntax for the Pocket Universes prototype.",
-            "Only use it if you know  what you are doing.",
-            "We advise you to remove it."
-        ].join("\n")
+        "blame": "static:@E::name",
+        "blame_pretty": "static:@E::name",
+        "description": "This is a reserved syntax for the Pocket Universes prototype.\\nOnly use it if you know  what you are doing.\\nWe advise you to remove it."
     }
 ]

--- a/tests/examples/PocketIdentifierExpressionLinter/pu_ident.hack.expect
+++ b/tests/examples/PocketIdentifierExpressionLinter/pu_ident.hack.expect
@@ -1,0 +1,11 @@
+[
+    {
+        "blame": "PocketIdentifierExpressionLinter ",
+        "blame_pretty": "Pocket Universes Identifier ",
+        "description": [
+            "This is a reserved syntax for the Pocket Universes prototype.",
+            "Only use it if you know  what you are doing.",
+            "We advise you to remove it."
+        ].join("\n")
+    }
+]

--- a/tests/examples/PocketIdentifierExpressionLinter/pu_ident.hack.in
+++ b/tests/examples/PocketIdentifierExpressionLinter/pu_ident.hack.in
@@ -8,7 +8,7 @@
  */
 
 class C {
-    enum E {
+    final enum E {
         case string name;
         :@foo (
             name = "foo"

--- a/tests/examples/PocketIdentifierExpressionLinter/pu_ident.hack.in
+++ b/tests/examples/PocketIdentifierExpressionLinter/pu_ident.hack.in
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2019-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+class C {
+    enum E {
+        case string name;
+        :@foo (
+            name = "foo"
+        );
+    }
+
+    public static function bar() {
+        var_dump(static:@E::name(:@foo));
+    }
+}


### PR DESCRIPTION
Disclaimer: CI will fail on this request since it requires Hack's experimental flag to work ok. I'm working on updating that so it is no longer needed, and I'll let you know when it's the case.

Creating linter to warn users if some of their files is using
reserved syntax for Pocket Universes.

Most of the syntax should just be erased from files right now.
It might happen that : and @ are close together, which will trigger
the linter, e.g. `function foo():@soft_annotation {...}`. In such cases,
the fix is to add a space in between

**Test is not working at the moment**, failing with this error:
```
~/hhast$ ./vendor/bin/hacktest tests/PocketAtomExpressionLinterTest.hack

Fatal error: Uncaught exception 'Facebook\HackTest\InvalidTestClassException' with message 'There must be exactly one test class in /home/ubuntu/hhast/tests/PocketAtomExpressionLinterTest.hack' in /home/ubuntu/hhast/vendor/hhvm/hacktest/src/Retriever/ClassRetriever.hack:72
Stack trace:
#0 /home/ubuntu/hhast/vendor/hhvm/hacktest/src/Runner/HackTestRunner.hack(42): Facebook\HackTest\ClassRetriever->getTestClassName()
#1 /home/ubuntu/hhast/vendor/hhvm/hsl/src/vec/transform.php(107): Closure$Facebook\HackTest\HackTestRunner::runAsync()
#2 /home/ubuntu/hhast/vendor/hhvm/hacktest/src/Runner/HackTestRunner.hack(42): HH\Lib\Vec\map()
#3 /home/ubuntu/hhast/vendor/hhvm/hacktest/src/HackTestCLI.hack(93): Facebook\HackTest\HackTestRunner::runAsync()
#4 /home/ubuntu/hhast/vendor/facebook/hh-clilib/src/CLIBase.hack(181): Facebook\HackTest\HackTestCLI->mainAsync()
#5 /home/ubuntu/hhast/vendor/hhvm/hacktest/bin/hacktest.hack(38): Facebook\CLILib\CLIBase::runAsync()
#6 /home/ubuntu/hhast/vendor/hhvm/hacktest/bin/hacktest(19): Facebook\HackTest\hack_test_main_async()
#7 (): Facebook\HackTest\hack_test_main_async_UNSAFE()
#8 (): Closure$__SystemLib\enter_async_entry_point()
#9 (): HH\Asio\join()
#10 (): __SystemLib\enter_async_entry_point()
#11 {main}
```

I'm not sure I understand why I get this error since I only have a single class in this file. Maybe it will ring a bell to more experienced developers :)

Also I added dummy code to `getCleanExamples` because the framework was complaining if the returned vector was empty. Maybe there's a better way to silence that since I don't need clean examples in here.