### PR TITLE
add PHP override to .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
   "hack.hhastPath": "bin/hhast-lint",
-  "hack.useHhast": true
+  "hack.useHhast": true,
+  "files.associations": {
+    "*.php": "hack"
+  }
 }


### PR DESCRIPTION
This shouldn't be necessary because the Hack plugin is configured to recognize .php files that start with <?hh, but for some reason that doesn't work correctly when using remote VSCode.

Adding this override fixes it, and doesn't break anything elsewhere (even though it's redundant in most cases), so I think we can just add it here...?