### PR TITLE
RefToInoutMigration: implement optionalToRequired

### DIFF
--- a/src/Migrations/add_arguments.hack
+++ b/src/Migrations/add_arguments.hack
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{C, Vec};
+use function Facebook\HHAST\__Private\whitespace_from_nodelist;
+
+/**
+ * Adds the provided arguments to the provided function call, preserving
+ * whitespace before/after arguments as much as possible.
+ */
+function add_arguments(
+  Script $root,
+  FunctionCallExpression $call,
+  vec<IExpression> $args_to_add,
+): FunctionCallExpression {
+  $arg_list = $call->getArgumentList();
+  invariant(
+    $arg_list is nonnull && $arg_list->getCount() > 0,
+    '%s() requires a call node with at least one previously existing argument.',
+    __FUNCTION__,
+  );
+
+  if (C\is_empty($args_to_add)) {
+    return $call;
+  }
+
+  $arg_items = $arg_list->getChildren();
+  $whitespace = whitespace_from_nodelist($root, $arg_list);
+
+  // We want a trailing comma iff the last argument previously had one.
+  $had_trailing_comma = C\lastx($arg_items)->getSeparator() is nonnull;
+
+  // Add a comma after the last previously-existing argument, if missing.
+  if (!$had_trailing_comma) {
+    $last_token = C\lastx($arg_items)->getLastTokenx();
+    $arg_items[C\count($arg_items) - 1] = C\lastx($arg_items)
+      ->withSeparator(new CommaToken(null, $last_token->getTrailing()))
+      ->replace($last_token, $last_token->withTrailing(null));
+  }
+
+  // Trim whitespace (but not other trivia) after the last argument. It will be
+  // replaced by $whitespace['between'] later.
+  $last_token = C\lastx($arg_items)->getLastTokenx();
+  $trivia = $last_token->getTrailing()->getChildren();
+  for ($take_cnt = C\count($trivia); $take_cnt > 0; --$take_cnt) {
+    if (
+      !$trivia[$take_cnt - 1] is WhiteSpace &&
+      !$trivia[$take_cnt - 1] is EndOfLine
+    ) {
+      break;
+    }
+  }
+  $arg_items[C\count($arg_items) - 1] = C\lastx($arg_items)->replace(
+    $last_token,
+    $last_token->withTrailing(
+      NodeList::createMaybeEmptyList(Vec\take($trivia, $take_cnt)),
+    ),
+  );
+
+  // Finally, we're done with all the preprocessing and we can actually add the
+  // specified arguments.
+  foreach ($args_to_add as $arg) {
+    $arg_items[] = new ListItem(
+      $arg->replace(
+        $arg->getFirstTokenx(),
+        $arg->getFirstTokenx()->withLeading($whitespace['between']),
+      ),
+      new CommaToken(null, null),
+    );
+  }
+
+  if (!$had_trailing_comma) {
+    $arg_items[C\count($arg_items) - 1] =
+      C\lastx($arg_items)->withSeparator(null);
+  }
+
+  return $call->replace($arg_list, NodeList::createMaybeEmptyList($arg_items))
+    ->replace(
+      $call->getRightParen(),
+      $call->getRightParen()->withLeading($whitespace['after_last']),
+    );
+}

--- a/src/Migrations/prepend_statement.hack
+++ b/src/Migrations/prepend_statement.hack
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{C, Vec};
+use function Facebook\HHAST\__Private\whitespace_from_nodelist;
+
+/**
+ * Adds the provided statement to the closest reasonable position _before_ the
+ * specified node. For example, if the `$before` node is part of a larger
+ * statement, the provided `$statement` will not be added directly before the
+ * node, but it will be added before the whole larger statement.
+ *
+ * Tries to make the formatting consistent with the rest of the block into which
+ * the statement is inserted.
+ */
+function prepend_statement(
+  Script $root,
+  IStatement $new_statement,
+  Node $before,
+): Script {
+  // Find the closest parent block.
+  $ancestors = $root->getAncestorsOfDescendant($before);
+  for ($i = C\count($ancestors) - 1; $i >= 0; --$i) {
+    if ($ancestors[$i] is IStatement) {
+      break;
+    }
+  }
+  for (--$i; $i >= 0; --$i) {
+    if ($ancestors[$i] is NodeList<_>) {
+      break;
+    }
+  }
+  invariant(
+    $i >= 0,
+    'Failed to find any parent NodeList of any parent Statement.',
+  );
+
+  $parent_block = $ancestors[$i] as NodeList<_>;
+  $statements = $parent_block->getChildren();
+  for ($cur_idx = 0; $cur_idx < C\count($statements); ++$cur_idx) {
+    if ($statements[$cur_idx] === $ancestors[$i + 1]) {
+      break;
+    }
+  }
+  invariant(
+    $cur_idx < C\count($statements),
+    'Failed to find the current statement in the parent block. This should '.
+    'never happen.',
+  );
+
+  // Move leading trivia (both whitespace and comments) from the current
+  // statement to the statement being prepended -- i.e. we want to insert the
+  // new statement _inbetween_ the current statement and its leading trivia.
+  $new_statement = $new_statement->replace(
+    $new_statement->getFirstTokenx(),
+    $new_statement->getFirstTokenx()
+      ->withLeading($statements[$cur_idx]->getFirstTokenx()->getLeading()),
+  );
+
+  $statements[$cur_idx] = $statements[$cur_idx]->replace(
+    $statements[$cur_idx]->getFirstTokenx(),
+    $statements[$cur_idx]->getFirstTokenx()->withLeading(null),
+  );
+
+  // Put an autodetected (via whitespace_from_nodelist) amount of whitespace
+  // between the current statement and the prepended one.
+  $new_statement = $new_statement->replace(
+    $new_statement->getLastTokenx(),
+    $new_statement->getLastTokenx()
+      ->withTrailing(whitespace_from_nodelist($root, $parent_block)['between']),
+  );
+
+  return $root->replace(
+    $parent_block,
+    NodeList::createMaybeEmptyList(
+      Vec\concat(
+        Vec\take($statements, $cur_idx),
+        vec[$new_statement],
+        Vec\drop($statements, $cur_idx),
+      ),
+    ),
+  );
+}

--- a/src/__Private/whitespace_from_nodelist.hack
+++ b/src/__Private/whitespace_from_nodelist.hack
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private;
+
+use namespace HH\Lib\{C, Vec};
+use type Facebook\HHAST\{EndOfLine, Node, NodeList, Script, Trivia, WhiteSpace};
+
+/**
+ * Analyzes the whitespace in the provided NodeList and returns sets of
+ * whitespace Trivia that should be used when adding items to the list. Using
+ * the returned values for new list items should make their formatting (e.g.
+ * indentation) consistent with the rest of the list, although this can't be
+ * guaranteed, especially if the original list is not formatted consistently.
+ */
+function whitespace_from_nodelist(
+  Script $root,
+  NodeList<Node> $list,
+): shape('between' => NodeList<Trivia>, 'after_last' => NodeList<Trivia>) {
+  invariant(
+    !$list->isEmpty(),
+    'Cannot analyze whitespace inside an empty list.',
+  );
+
+  // To preserve formatting, we'll copy whitespace from around the last item.
+  // The choice of the last item is somewhat arbitrary, but since appending to
+  // the end of a list is likely most common, it's probably the best option. If
+  // the list is formatted consistently, the choice shouldn't matter anyway.
+  $ret = shape();
+
+  // Whitespace between items: If there is an EndOfLine, we take the last
+  // EndOfLine + any whitespace immediately after it (i.e. we exactly preserve
+  // the current indentation). If there is no EndOfLine, we take whitespace from
+  // immediately after the previous item. In both cases, we stop when we hit the
+  // first non-whitespace trivium (e.g. a comment).
+  $token = C\lastx($list->getChildren())->getFirstTokenx();
+  $trivia = Vec\concat(
+    ($root->getPreviousToken($token) as nonnull)->getTrailing()->getChildren(),
+    $token->getLeading()->getChildren(),
+  );
+  if (!C\is_empty($trivia)) {
+    for ($start_idx = C\count($trivia) - 1; $start_idx > 0; --$start_idx) {
+      if ($trivia[$start_idx] is EndOfLine) {
+        break;
+      }
+    }
+    $trivia = Vec\drop($trivia, $start_idx);
+  }
+  for ($take_cnt = 0; $take_cnt < C\count($trivia); ++$take_cnt) {
+    if (!$trivia[$take_cnt] is WhiteSpace && !$trivia[$take_cnt] is EndOfLine) {
+      break;
+    }
+  }
+  $ret['between'] =
+    NodeList::createMaybeEmptyList(Vec\take($trivia, $take_cnt));
+
+  // Special case for a single-line single-item list: If no other whitespace was
+  // detected, we arbitrarily choose one space.
+  if ($list->getCount() === 1 && $ret['between']->isEmpty()) {
+    $ret['between'] = NodeList::createMaybeEmptyList(vec[new WhiteSpace(' ')]);
+  }
+
+  // Whitespace after the last item: We take any whitespace that immediately
+  // preceeds the function call's closing paren. Note that this is NOT the same
+  // as taking whitespace following the last item, because there might be
+  // non-whitespace trivia (comments) inbetween.
+  $token = C\lastx($list->getChildren())->getLastTokenx();
+  $trivia = Vec\concat(
+    $token->getTrailing()->getChildren(),
+    ($root->getNextToken($token) as nonnull)->getLeading()->getChildren(),
+  );
+  for ($start_idx = C\count($trivia); $start_idx > 0; --$start_idx) {
+    if (
+      !$trivia[$start_idx - 1] is WhiteSpace &&
+      !$trivia[$start_idx - 1] is EndOfLine
+    ) {
+      break;
+    }
+  }
+  $ret['after_last'] =
+    NodeList::createMaybeEmptyList(Vec\drop($trivia, $start_idx));
+
+  return $ret;
+}

--- a/src/nodes/Script.hack
+++ b/src/nodes/Script.hack
@@ -34,6 +34,11 @@ final class Script extends ScriptGeneratedBase {
     return $this->getTokens()[$idx - 1];
   }
 
+  public function getNextToken(Token $token): ?Token {
+    $idx = $this->getTokenIndices()[$token->getUniqueID()];
+    return $this->getTokens()[$idx + 1] ?? null;
+  }
+
   const type TNamespace = shape(
     'name' => ?string,
     'children' => NodeList<Node>,

--- a/tests/examples/migrations/ref_to_inout.hack.expect
+++ b/tests/examples/migrations/ref_to_inout.hack.expect
@@ -60,6 +60,138 @@ function foo(): void {
 
   // By-ref to inout without renaming.
   \reset(inout $arr);
+
+  $out = null;
+  \preg_replace_callback('/([a-z])/', fun('Str\\uppercase'), $str, -1, inout $out);
+
+  // Missing arguments after migration from optional by-ref to required inout.
+  $__unused_inout = null;
+  \preg_replace_callback('/([a-z])/', fun('Str\\uppercase'), $str, -1, inout $__unused_inout);
+
+  $__unused_inout = null;
+  \preg_replace_callback(
+    '/([a-z])/',
+    fun('Str\\uppercase'),
+    $str,
+    -1,
+    inout $__unused_inout,
+  );
+
+  // Edge cases (non-standard formatting, comments inside, etc.)
+  $__unused_inout = null;
+  \preg_replace_callback('/foo/','bar',$str,-1,inout $__unused_inout);
+  $__unused_inout = null;
+  \preg_replace_callback('/foo/', 'bar', $str, -1, inout $__unused_inout,);
+  $__unused_inout = null;
+  \preg_replace_callback('/foo/', 'bar', $str, -1, inout $__unused_inout, );
+  $__unused_inout = null;
+  \preg_replace_callback('/foo/', 'bar', $str, /* hi */ -1, inout $__unused_inout);
+  $__unused_inout = null;
+  \preg_replace_callback('/foo/', 'bar', $str, /* hi */ -1, inout $__unused_inout );
+  $__unused_inout = null;
+  \preg_replace_callback('/foo/', 'bar', $str, /* hi */ -1, inout $__unused_inout,);
+  $__unused_inout = null;
+  \preg_replace_callback('/foo/', 'bar', $str, /* hi */ -1, inout $__unused_inout, );
+  $__unused_inout = null;
+  \preg_replace_callback('/foo/', 'bar', /* hi */$str, -1, inout $__unused_inout);
+  $__unused_inout = null;
+  \preg_replace_callback(
+    '/foo/', 'bar', $str, -1, inout $__unused_inout,
+  );
+  $__unused_inout = null;
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    $str,
+    -1,
+    inout $__unused_inout
+  );
+  $__unused_inout = null;
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    $str,  // hello
+    -1,
+    inout $__unused_inout
+  );
+  $__unused_inout = null;
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    $str,  // hello
+    -1,
+    inout $__unused_inout,
+  );
+  $__unused_inout = null;
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    $str,
+    -1,
+    inout $__unused_inout);
+  $__unused_inout = null;
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    $str,
+    -1,
+    inout $__unused_inout, );
+  $__unused_inout = null;
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    // hello
+    $str,
+    -1,
+    inout $__unused_inout,
+  );
+  $__unused_inout = null;
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    /* hi */ $str,
+    -1,
+    inout $__unused_inout,
+  );
+  $__unused_inout = null;
+  \preg_replace_callback(
+    /* hi */ '/foo/',  // hello
+    /* hi */ 'bar',  // hello
+    /* hi */ $str,  // hello
+    -1,
+    inout $__unused_inout,
+  );
+  $__unused_inout = null;
+  \preg_replace_callback(
+
+    /* hi */ '/foo/',  // hello
+
+    /* hi */ 'bar',  // hello
+
+    /* hi */ $str,  // hello
+    -1,
+    inout $__unused_inout,
+
+  );
+
+  // Inside a complicated statement.
+  while (true) {
+    do {
+      $__unused_inout = null;
+      $__unused_inout = null;
+      $_ = true
+        ? \preg_replace_callback('/foo/', 'bar', $str, -1, inout $__unused_inout)
+        : \preg_replace_callback('/foo/', 'bar', $str, -1, inout $__unused_inout);
+    } while (false);
+  }
+
+  // Fun edge case: Braceless if.
+  $__unused_inout = null;
+  if (true)
+    \preg_replace_callback('/foo/', 'bar', $str, -1, inout $__unused_inout);
+
+  // Compund statement with non-standard formatting.
+  for (;;) { $__unused_inout = null; \preg_replace_callback('/foo/', 'bar', $str, -1, inout $__unused_inout); }
 }
 
 } // end of MyNamespace

--- a/tests/examples/migrations/ref_to_inout.hack.in
+++ b/tests/examples/migrations/ref_to_inout.hack.in
@@ -61,6 +61,95 @@ function foo(): void {
 
   // By-ref to inout without renaming.
   \reset(&$arr);
+
+  $out = null;
+  \preg_replace_callback('/([a-z])/', fun('Str\\uppercase'), $str, -1, &$out);
+
+  // Missing arguments after migration from optional by-ref to required inout.
+  \preg_replace_callback('/([a-z])/', fun('Str\\uppercase'), $str);
+
+  \preg_replace_callback(
+    '/([a-z])/',
+    fun('Str\\uppercase'),
+    $str,
+  );
+
+  // Edge cases (non-standard formatting, comments inside, etc.)
+  \preg_replace_callback('/foo/','bar',$str);
+  \preg_replace_callback('/foo/', 'bar', $str,);
+  \preg_replace_callback('/foo/', 'bar', $str, );
+  \preg_replace_callback('/foo/', 'bar', $str /* hi */);
+  \preg_replace_callback('/foo/', 'bar', $str /* hi */ );
+  \preg_replace_callback('/foo/', 'bar', $str, /* hi */);
+  \preg_replace_callback('/foo/', 'bar', $str, /* hi */ );
+  \preg_replace_callback('/foo/', 'bar', /* hi */$str);
+  \preg_replace_callback(
+    '/foo/', 'bar', $str,
+  );
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    $str
+  );
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    $str  // hello
+  );
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    $str,  // hello
+  );
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    $str);
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    $str, );
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    // hello
+    $str,
+  );
+  \preg_replace_callback(
+    '/foo/',
+    'bar',
+    /* hi */ $str,
+  );
+  \preg_replace_callback(
+    /* hi */ '/foo/',  // hello
+    /* hi */ 'bar',  // hello
+    /* hi */ $str,  // hello
+  );
+  \preg_replace_callback(
+
+    /* hi */ '/foo/',  // hello
+
+    /* hi */ 'bar',  // hello
+
+    /* hi */ $str,  // hello
+
+  );
+
+  // Inside a complicated statement.
+  while (true) {
+    do {
+      $_ = true
+        ? \preg_replace_callback('/foo/', 'bar', $str)
+        : \preg_replace_callback('/foo/', 'bar', $str);
+    } while (false);
+  }
+
+  // Fun edge case: Braceless if.
+  if (true)
+    \preg_replace_callback('/foo/', 'bar', $str);
+
+  // Compund statement with non-standard formatting.
+  for (;;) { \preg_replace_callback('/foo/', 'bar', $str); }
 }
 
 } // end of MyNamespace


### PR DESCRIPTION
This implements the missing logic for migrating things like `preg_replace_callback`, where an optional by-ref parameter became a non-optional inout parameter.

e.g. from:

```php
\preg_replace_callback(
  '/([a-z])/',
  fun('Str\\uppercase'),
  $str,
);
```

to:

```php
$__unused_inout = null;
\preg_replace_callback(
  '/([a-z])/',
  fun('Str\\uppercase'),
  $str,
  -1,
  inout $__unused_inout,
);
```

Unsurprisingly, most of the code here is to deal with whitespace and comments (see examples in the test).

I've put a lot of the code into reusable functions (`add_arguments`, `prepend_statement`, `whitespace_from_nodelist`), hopefully they could be useful for future migrations too.