### PR TITLE
add (limited) support for method calls

### DIFF
--- a/tests/examples/migrations/ref_to_inout.hack.expect
+++ b/tests/examples/migrations/ref_to_inout.hack.expect
@@ -232,6 +232,19 @@ function foo(): void {
     0,
     inout $__unused_inout
   );
+
+  // Method calls.
+  $df = new IntlDateFormatter();
+  $df->localtime('now', inout $pos);
+  $df->localtime('now', inout $pos);
+  (new IntlDateFormatter())->localtime('now', inout $pos);
+
+  $not_date_formatter->localtime();
+  $not_date_formatter->localtime(42);
+  $not_date_formatter->localtime(42, $var);
+
+  $a = $b = null;
+  (new IntlTimeZone())->getOffset(1234567890, true, inout $a, inout $b);
 }
 
 } // end of MyNamespace

--- a/tests/examples/migrations/ref_to_inout.hack.in
+++ b/tests/examples/migrations/ref_to_inout.hack.in
@@ -177,6 +177,19 @@ function foo(): void {
     \GRAPHEME_EXTR_MAXBYTES  // one default value provided
     // one missing default value
   );
+
+  // Method calls.
+  $df = new IntlDateFormatter();
+  $df->localtime('now', &$pos);
+  $df->localtime('now', inout $pos);
+  (new IntlDateFormatter())->localtime('now', &$pos);
+
+  $not_date_formatter->localtime();
+  $not_date_formatter->localtime(42);
+  $not_date_formatter->localtime(42, $var);
+
+  $a = $b = null;
+  (new IntlTimeZone())->getOffset(1234567890, true, &$a, &$b);
 }
 
 } // end of MyNamespace


### PR DESCRIPTION
Only looks at the method name, so may result in false positives -- but that's OK for now (see comments inline).

If we need to implement more complicated transformations for methods later, we may need to fix that.