### PR TITLE
Write require_once linter, addresses issue #160

### DIFF
--- a/src/Linters/PreferRequireOnceLinter.hack
+++ b/src/Linters/PreferRequireOnceLinter.hack
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2019-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class PreferRequireOnceLinter extends AutoFixingASTLinter {
+  const type TContext = Script;
+  const type TNode = InclusionExpression;
+
+  <<__Override>>
+  protected function getTitleForFix(LintError $_): string {
+    return 'Prefer "require_once" over "include(_once)"" and "require"';
+  }
+
+  <<__Override>>
+  public function getLintErrorForNode(
+    Script $_context,
+    InclusionExpression $node,
+  ): ?ASTLintError {
+    if ($node is Require_onceToken) {
+      return null;
+    }
+
+    return new ASTLintError(
+      $this,
+      'Use require_once to require/include files',
+      $node,
+      () ==> $this->getFixedNode($node),
+    );
+  }
+
+  /**
+   * Could I get a helping hand here?
+   * I want this to replace `include_once __DIR__ . '/../file.hack'` with `require_once __DIR__ . '/../file.hack'`.
+   * However, this destroys the space between the IncludeToken and the __DIR__.
+   * This makes the file fail to parse, since `require_once__DIR__` is not a valid token.
+   * It also consumes all the indentation.
+   */
+  public function getFixedNode(InclusionExpression $node): ?Node {
+    return $node->withRequire(new Require_onceToken(null, null));
+  }
+}

--- a/src/Linters/PreferRequireOnceLinter.hack
+++ b/src/Linters/PreferRequireOnceLinter.hack
@@ -23,7 +23,7 @@ final class PreferRequireOnceLinter extends AutoFixingASTLinter {
     Script $_context,
     InclusionExpression $node,
   ): ?ASTLintError {
-    if ($node is Require_onceToken) {
+    if ($node->getRequire() is Require_onceToken) {
       return null;
     }
 
@@ -35,15 +35,11 @@ final class PreferRequireOnceLinter extends AutoFixingASTLinter {
     );
   }
 
-  /**
-   * Could I get a helping hand here?
-   * I want this to replace `include_once __DIR__ . '/../file.hack'` with `require_once __DIR__ . '/../file.hack'`.
-   * It consumes all the indentation.
-   * Is there something that feels like Node::getLeadingWhitespace()?
-   */
   public function getFixedNode(InclusionExpression $node): ?Node {
+    $left_trivia = $node->getRequire()->getLeading();
+    $right_trivia = $node->getRequire()->getTrailing();
     return $node->withRequire(
-      new Require_onceToken(null, new NodeList(vec[new WhiteSpace(' ')])),
+      new Require_onceToken($left_trivia, $right_trivia),
     );
   }
 }

--- a/src/Linters/PreferRequireOnceLinter.hack
+++ b/src/Linters/PreferRequireOnceLinter.hack
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019-present, Facebook, Inc.
+ *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.
  *
  *  This source code is licensed under the MIT license found in the
@@ -38,11 +38,12 @@ final class PreferRequireOnceLinter extends AutoFixingASTLinter {
   /**
    * Could I get a helping hand here?
    * I want this to replace `include_once __DIR__ . '/../file.hack'` with `require_once __DIR__ . '/../file.hack'`.
-   * However, this destroys the space between the IncludeToken and the __DIR__.
-   * This makes the file fail to parse, since `require_once__DIR__` is not a valid token.
-   * It also consumes all the indentation.
+   * It consumes all the indentation.
+   * Is there something that feels like Node::getLeadingWhitespace()?
    */
   public function getFixedNode(InclusionExpression $node): ?Node {
-    return $node->withRequire(new Require_onceToken(null, null));
+    return $node->withRequire(
+      new Require_onceToken(null, new NodeList(vec[new WhiteSpace(' ')])),
+    );
   }
 }

--- a/src/Linters/PreferRequireOnceLinter.hack
+++ b/src/Linters/PreferRequireOnceLinter.hack
@@ -14,11 +14,6 @@ final class PreferRequireOnceLinter extends AutoFixingASTLinter {
   const type TNode = InclusionExpression;
 
   <<__Override>>
-  protected function getTitleForFix(LintError $_): string {
-    return 'Prefer "require_once" over "include(_once)"" and "require"';
-  }
-
-  <<__Override>>
   public function getLintErrorForNode(
     Script $_context,
     InclusionExpression $node,
@@ -29,7 +24,7 @@ final class PreferRequireOnceLinter extends AutoFixingASTLinter {
 
     return new ASTLintError(
       $this,
-      'Use require_once to require/include files',
+      'Prefer "require_once" over "include(_once)" and "require"',
       $node,
       () ==> $this->getFixedNode($node),
     );
@@ -41,5 +36,10 @@ final class PreferRequireOnceLinter extends AutoFixingASTLinter {
     return $node->withRequire(
       new Require_onceToken($left_trivia, $right_trivia),
     );
+  }
+
+  <<__Override>>
+  protected function getTitleForFix(LintError $_): string {
+    return 'Change to "require_once"';
   }
 }

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -83,6 +83,7 @@ final class LintRunConfig {
     HHAST\PocketEnumDeclarationLinter::class,
     HHAST\NoByRefCallArgumentsLinter::class,
     HHAST\NoByRefParameterDeclarationsLinter::class,
+    HHAST\PreferRequireOnceLinter::class,
   ];
 
   const vec<classname<BaseLinter>> NON_DEFAULT_LINTERS = vec[

--- a/tests/PreferRequireOnceLinterTest.hack
+++ b/tests/PreferRequireOnceLinterTest.hack
@@ -10,17 +10,23 @@
 
 namespace Facebook\HHAST;
 
-final class __MyBaseTest__PreferLambdasLinterTest extends TestCase {
+final class PreferRequireOnceLinterTest extends TestCase {
   use AutoFixingLinterTestTrait<ASTLintError>;
 
-  protected function getLinter(string $file): PreferLambdasLinter {
-    return PreferLambdasLinter::fromPath($file);
+  protected function getLinter(string $file): PreferRequireOnceLinter {
+    return PreferRequireOnceLinter::fromPath($file);
   }
 
   public function getCleanExamples(): vec<(string)> {
     return vec[
-      tuple('<?hh $fn = () ==> 5; '),
-      tuple('<?hh $fn = ($a, $b) ==> { return $a === $b; };'),
+      tuple(<<<REQUIRE_ONCE_FILE
+<?hh // strict
+
+function no_top_level_require_allowed_in_future_maybe(): void {
+  require_once __DIR__ . '/dont_run_this_code.hack';
+}
+REQUIRE_ONCE_FILE
+      ),
     ];
   }
 }

--- a/tests/PreferRequireOnceLinterTest.hack
+++ b/tests/PreferRequireOnceLinterTest.hack
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+
+namespace Facebook\HHAST;
+
+final class __MyBaseTest__PreferLambdasLinterTest extends TestCase {
+  use AutoFixingLinterTestTrait<ASTLintError>;
+
+  protected function getLinter(string $file): PreferLambdasLinter {
+    return PreferLambdasLinter::fromPath($file);
+  }
+
+  public function getCleanExamples(): vec<(string)> {
+    return vec[
+      tuple('<?hh $fn = () ==> 5; '),
+      tuple('<?hh $fn = ($a, $b) ==> { return $a === $b; };'),
+    ];
+  }
+}

--- a/tests/examples/PreferRequireOnceLinter/prefer_require_once_linter.php.autofix.expect
+++ b/tests/examples/PreferRequireOnceLinter/prefer_require_once_linter.php.autofix.expect
@@ -1,0 +1,21 @@
+<?hh
+
+function dont_execute_me(): void {
+  // We get changed
+  if (0 === 1) {
+    require_once __DIR__.'/../vendor/common.hack';
+    require_once __DIR__.'/../vendor/common.hack';
+    /*0*/ require_once /*1*/ __DIR__ /*3*/. /*4*/'/../vendor/common.hack';
+  }
+
+  // I don't get changed
+  if (0 === 1) {
+    require_once 'file.hack';
+  }
+}
+
+trait PreferRequireOnceLinterTestingTraitWithRequireExtends {
+  // We are left alone too
+  require extends Exception;
+  require implements JsonSerializable;
+}

--- a/tests/examples/PreferRequireOnceLinter/prefer_require_once_linter.php.autofix.expect
+++ b/tests/examples/PreferRequireOnceLinter/prefer_require_once_linter.php.autofix.expect
@@ -2,16 +2,12 @@
 
 function dont_execute_me(): void {
   // We get changed
-  if (0 === 1) {
-    require_once __DIR__.'/../vendor/common.hack';
-    require_once __DIR__.'/../vendor/common.hack';
-    /*0*/ require_once /*1*/ __DIR__ /*3*/. /*4*/'/../vendor/common.hack';
-  }
+  require_once __DIR__.'/../vendor/common.hack';
+  require_once __DIR__.'/../vendor/common.hack';
+  /*0*/ require_once /*1*/ __DIR__ /*3*/. /*4*/'/../vendor/common.hack';
 
   // I don't get changed
-  if (0 === 1) {
-    require_once 'file.hack';
-  }
+  require_once 'file.hack';
 }
 
 trait PreferRequireOnceLinterTestingTraitWithRequireExtends {

--- a/tests/examples/PreferRequireOnceLinter/prefer_require_once_linter.php.expect
+++ b/tests/examples/PreferRequireOnceLinter/prefer_require_once_linter.php.expect
@@ -1,17 +1,17 @@
 [
     {
-        "blame": "    include __DIR__.'\/..\/vendor\/common.hack'",
-        "blame_pretty": "    include __DIR__.'\/..\/vendor\/common.hack'",
-        "description": "Use require_once to require\/include files"
+        "blame": "  \/\/ We get changed\n  include __DIR__.'\/..\/vendor\/common.hack'",
+        "blame_pretty": "  \/\/ We get changed\n  include __DIR__.'\/..\/vendor\/common.hack'",
+        "description": "Prefer \"require_once\" over \"include(_once)\" and \"require\""
     },
     {
-        "blame": "    require __DIR__.'\/..\/vendor\/common.hack'",
-        "blame_pretty": "    require __DIR__.'\/..\/vendor\/common.hack'",
-        "description": "Use require_once to require\/include files"
+        "blame": "  require __DIR__.'\/..\/vendor\/common.hack'",
+        "blame_pretty": "  require __DIR__.'\/..\/vendor\/common.hack'",
+        "description": "Prefer \"require_once\" over \"include(_once)\" and \"require\""
     },
     {
-        "blame": "    \/*0*\/ include_once \/*1*\/ __DIR__ \/*3*\/. \/*4*\/'\/..\/vendor\/common.hack'",
-        "blame_pretty": "    \/*0*\/ include_once \/*1*\/ __DIR__ \/*3*\/. \/*4*\/'\/..\/vendor\/common.hack'",
-        "description": "Use require_once to require\/include files"
+        "blame": "  \/*0*\/ include_once \/*1*\/ __DIR__ \/*3*\/. \/*4*\/'\/..\/vendor\/common.hack'",
+        "blame_pretty": "  \/*0*\/ include_once \/*1*\/ __DIR__ \/*3*\/. \/*4*\/'\/..\/vendor\/common.hack'",
+        "description": "Prefer \"require_once\" over \"include(_once)\" and \"require\""
     }
 ]

--- a/tests/examples/PreferRequireOnceLinter/prefer_require_once_linter.php.expect
+++ b/tests/examples/PreferRequireOnceLinter/prefer_require_once_linter.php.expect
@@ -1,0 +1,17 @@
+[
+    {
+        "blame": "    include __DIR__.'\/..\/vendor\/common.hack'",
+        "blame_pretty": "    include __DIR__.'\/..\/vendor\/common.hack'",
+        "description": "Use require_once to require\/include files"
+    },
+    {
+        "blame": "    require __DIR__.'\/..\/vendor\/common.hack'",
+        "blame_pretty": "    require __DIR__.'\/..\/vendor\/common.hack'",
+        "description": "Use require_once to require\/include files"
+    },
+    {
+        "blame": "    \/*0*\/ include_once \/*1*\/ __DIR__ \/*3*\/. \/*4*\/'\/..\/vendor\/common.hack'",
+        "blame_pretty": "    \/*0*\/ include_once \/*1*\/ __DIR__ \/*3*\/. \/*4*\/'\/..\/vendor\/common.hack'",
+        "description": "Use require_once to require\/include files"
+    }
+]

--- a/tests/examples/PreferRequireOnceLinter/prefer_require_once_linter.php.in
+++ b/tests/examples/PreferRequireOnceLinter/prefer_require_once_linter.php.in
@@ -2,16 +2,12 @@
 
 function dont_execute_me(): void {
   // We get changed
-  if (0 === 1) {
-    include __DIR__.'/../vendor/common.hack';
-    require __DIR__.'/../vendor/common.hack';
-    /*0*/ include_once /*1*/ __DIR__ /*3*/. /*4*/'/../vendor/common.hack';
-  }
+  include __DIR__.'/../vendor/common.hack';
+  require __DIR__.'/../vendor/common.hack';
+  /*0*/ include_once /*1*/ __DIR__ /*3*/. /*4*/'/../vendor/common.hack';
 
   // I don't get changed
-  if (0 === 1) {
-    require_once 'file.hack';
-  }
+  require_once 'file.hack';
 }
 
 trait PreferRequireOnceLinterTestingTraitWithRequireExtends {

--- a/tests/examples/PreferRequireOnceLinter/prefer_require_once_linter.php.in
+++ b/tests/examples/PreferRequireOnceLinter/prefer_require_once_linter.php.in
@@ -1,0 +1,21 @@
+<?hh
+
+function dont_execute_me(): void {
+  // We get changed
+  if (0 === 1) {
+    include __DIR__.'/../vendor/common.hack';
+    require __DIR__.'/../vendor/common.hack';
+    /*0*/ include_once /*1*/ __DIR__ /*3*/. /*4*/'/../vendor/common.hack';
+  }
+
+  // I don't get changed
+  if (0 === 1) {
+    require_once 'file.hack';
+  }
+}
+
+trait PreferRequireOnceLinterTestingTraitWithRequireExtends {
+  // We are left alone too
+  require extends Exception;
+  require implements JsonSerializable;
+}


### PR DESCRIPTION
This linter is not yet done, but I want it to be known that I am writing it.

This is my very first attempt at writing a linter.
It does do the detection part well.
However, it fails on the rewriting part.
It consumes this whitespace:
```
    include     "string-like-expression";
^^^^       ^^^^^
```

I figured placing the whitespace between include and "string-like-expression" with a single space, should suffice.

However, this still kills all the indentation.

I hope that someone can drop a hint as a reply. :slightly_smiling_face: 