### PR TITLE
disallow_array_literal

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -7,3 +7,5 @@ disallow_destruct = true
 user_attributes=
 disable_static_local_variables = true
 disable_instanceof_refinement = true
+
+disallow_array_literal = true

--- a/.hhconfig
+++ b/.hhconfig
@@ -8,4 +8,5 @@ user_attributes=
 disable_static_local_variables = true
 disable_instanceof_refinement = true
 
-disallow_array_literal = true
+; Once the minimum hhvm version hits 4.25 this setting can be safely enabled
+disallow_array_literal = false

--- a/src/Linters/AutoFixingLinterTrait.hack
+++ b/src/Linters/AutoFixingLinterTrait.hack
@@ -23,7 +23,7 @@ trait AutoFixingLinterTrait<Terror as LintError>
   }
 
   public function getCodeActionForError(Terror $error): ?LSP\CodeAction {
-    $fixed = $this->getFixedFile([$error]);
+    $fixed = $this->getFixedFile(varray[$error]);
     if ($fixed === null) {
       return null;
     }

--- a/src/Migrations/TopLevelRequiresMigration.hack
+++ b/src/Migrations/TopLevelRequiresMigration.hack
@@ -95,7 +95,7 @@ final class TopLevelRequiresMigration extends BaseMigration {
 
     $body = $body->withStatements(
       new NodeList(
-        Vec\concat(vec[$lambda], $body->getStatements()?->getChildren() ?? []),
+        Vec\concat(vec[$lambda], $body->getStatements()?->getChildren() ?? varray[]),
       ),
     );
 

--- a/src/__Private/Inspector/InspectorCLI.hack
+++ b/src/__Private/Inspector/InspectorCLI.hack
@@ -76,7 +76,7 @@ final class InspectorCLI extends CLIWithRequiredArguments {
     print $output."\n";
 
     if ($this->open) {
-      \pcntl_exec('/usr/bin/open', [$output]);
+      \pcntl_exec('/usr/bin/open', varray[$output]);
     }
 
     return 0;

--- a/src/__Private/execute_async.hack
+++ b/src/__Private/execute_async.hack
@@ -19,8 +19,8 @@ async function execute_async(string ...$args): Awaitable<vec<string>> {
     |> Vec\map($$, $arg ==> \escapeshellarg($arg))
     |> Str\join($$, ' ');
 
-  $spec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
-  $pipes = [];
+  $spec = darray[0 => varray['pipe', 'r'], 1 => varray['pipe', 'w'], 2 => varray['pipe', 'w']];
+  $pipes = varray[];
 
   $proc = \proc_open($command, $spec, inout $pipes);
   invariant($proc, "Failed to execute: %s", $command);

--- a/tests/LSPServerTest.hack
+++ b/tests/LSPServerTest.hack
@@ -71,7 +71,7 @@ final class LSPServerTest extends TestCase {
   public function provideExampleExchanges(): array<array<string>> {
     return \array_map(
       function($file) {
-        return [\basename($file, '.json')];
+        return varray[\basename($file, '.json')];
       },
       \glob(__DIR__.'/lsp/*.json'),
     );

--- a/tests/LinterTestTrait.hack
+++ b/tests/LinterTestTrait.hack
@@ -29,7 +29,7 @@ trait LinterTestTrait {
       |> Vec\map($$, $path ==> \basename($path, '.in'))
       |> Vec\map($$, $path ==> Str\strip_suffix($path, '.php'))
       |> Vec\map($$, $path ==> Str\strip_suffix($path, '.hack'))
-      |> Vec\map($$, $arg ==> [$arg]);
+      |> Vec\map($$, $arg ==> varray[$arg]);
   }
 
   final protected function getFullFixtureName(string $name): string {

--- a/tests/NodeAtPositionTest.hack
+++ b/tests/NodeAtPositionTest.hack
@@ -15,7 +15,7 @@ use type Facebook\HackTest\DataProvider;
 final class NodeAtPositionTest extends TestCase {
   public function getExamples(
   ): array<(string, (int, int), classname<Node>, string)> {
-    return [
+    return varray[
       tuple(
         "<?hh\nreturn 123;\n",
         tuple(2, 1),

--- a/tests/OffsetFromPositionTest.hack
+++ b/tests/OffsetFromPositionTest.hack
@@ -14,7 +14,7 @@ use type Facebook\HackTest\DataProvider;
 
 final class OffsetFromPositionTest extends TestCase {
   public function getExamples(): array<(string, (int, int), int)> {
-    return [
+    return varray[
       tuple("<?hh // strict \n", tuple(1, 1), 0),
       tuple("<?hh // strict \n", tuple(1, 3), 2),
       tuple("<?hh\nbar();\n", tuple(2, 1), 5),

--- a/tests/ResolutionTest.hack
+++ b/tests/ResolutionTest.hack
@@ -82,7 +82,7 @@ final class ResolutionTest extends TestCase {
       'functions' => dict<string, string>,
     ),
   )> {
-    return [
+    return varray[
       tuple(
         '<?hh use Foo; use Bar, Baz; class Target {}',
         shape(
@@ -167,7 +167,7 @@ final class ResolutionTest extends TestCase {
   }
 
   public function getTypeResolutionExamples(): array<(string, string, string)> {
-    return [
+    return varray[
       tuple('<?hh class Target {}', 'Foo', 'Foo'),
       tuple('<?hh use Foo\\Bar; class Target {}', 'Bar', 'Foo\\Bar'),
       tuple('<?hh use Foo as Bar; class Target {}', 'Bar', 'Foo'),

--- a/tests/TestLib/TemporaryProject.hack
+++ b/tests/TestLib/TemporaryProject.hack
@@ -33,10 +33,10 @@ final class TemporaryProject implements \IAsyncDisposable {
       \touch($path.'/.hhconfig');
     }
 
-    $pipes = [];
+    $pipes = varray[];
     $this->hhServer = \proc_open(
       'hh_server '.\escapeshellarg($path).' >/dev/null 2>/dev/null',
-      [],
+      darray[],
       inout $pipes,
     );
     \file_put_contents($path.'/test.php', \file_get_contents($source_path));


### PR DESCRIPTION
I want to enable this setting in my project to discourage the use of plain php arrays.

This requires that all the dependencies also meet the `disallow_array_literal` requirement.

I replaced all `array(...)` and `[...]` expressions with their `darray`/`varray` counterpart.