### PR TITLE
Add `bin/hhast-migrate --migration-classname FooBar`

### DIFF
--- a/src/__Private/MigrationCLI.hack
+++ b/src/__Private/MigrationCLI.hack
@@ -9,7 +9,7 @@
 
 namespace Facebook\HHAST\__Private;
 
-use namespace Facebook\HHAST;
+use namespace Facebook\{HHAST, TypeAssert};
 use namespace HH\Lib\{C, Dict, Str, Vec};
 use type Facebook\HHAST\{
   AddFixmesMigration,
@@ -49,6 +49,24 @@ class MigrationCLI extends CLIWithRequiredArguments {
   <<__Override>>
   protected function getSupportedOptions(): vec<CLIOptions\CLIOption> {
     $options = vec[
+      CLIOptions\with_required_string(
+        ($class) ==> {
+          try {
+            $this->migrations[] = TypeAssert\classname_of(
+              BaseMigration::class,
+              $class,
+            );
+          } catch (TypeAssert\IncorrectTypeException $_) {
+            throw new ExitException(1, Str\format(
+              "'%s' is not a subclass of %s",
+              $class,
+              BaseMigration::class,
+            ));
+          }
+        },
+        "Run the migration with the specified fully-qualified classname",
+        '--migration-classname',
+      ),
       CLIOptions\flag(
         () ==> {
           $this->migrations[] = HSLMigration::class;


### PR DESCRIPTION
fixes #245

```
% bin/hhast-migrate --migration-classname FooBar tests
'FooBar' is not a subclass of Facebook\HHAST\BaseMigration
% git diff src/ASTDeserializationError.hack
 diff --git a/src/ASTDeserializationError.hack b/src/ASTDeserializationError.hack
 index b670a286..9b6c9104 100644
 --- a/src/ASTDeserializationError.hack
 +++ b/src/ASTDeserializationError.hack
 @@ -19,7 +19,7 @@ final class ASTDeserializationError extends ASTError {
      \Throwable $previous,
    ) {
      $pre = Str\slice($source, 0, $offset) |> Str\split($$, "\n");
 -    $eol = Str\search($source, "\n", $offset);
 +    $eol = \strpos($source, "\n", $offset);
      $pre_line = C\lastx($pre);
      $rest = Str\slice($source, $offset, $eol === null ? null : $eol - $offset);
      $line = $pre_line.$rest;
% bin/hhast-migrate --classname "Facebook\\HHAST\\HSLMigration" src/ASTDeserializationError.hack
% git diff
% # empty, because migration undid my local change to use strpos
```