### PR TITLE
faster hhast-inspect (chrome fix)

### DIFF
--- a/src/__Private/Inspector/InspectorCLI.hack
+++ b/src/__Private/Inspector/InspectorCLI.hack
@@ -151,9 +151,12 @@ final class InspectorCLI extends CLIWithRequiredArguments {
   ): string {
     $trace = Vec\map($trace, $entry ==> {
       list($node, $field) = $entry;
+      $class = \get_class($node) |> Str\split($$, "\\") |> C\lastx($$);
       return Str\format(
-        'hs-%s hs-id-%d hs-id-%d-%s',
-        \get_class($node) |> Str\split($$, "\\") |> C\lastx($$),
+        'hs-%s hs-%s-%s hs-id-%d hs-id-%d-%s',
+        $class,
+        $class,
+        (string)$field,
         $node->getUniqueID(),
         $node->getUniqueID(),
         (string)$field,

--- a/src/__Private/Inspector/InspectorCLI.hack
+++ b/src/__Private/Inspector/InspectorCLI.hack
@@ -133,6 +133,8 @@ final class InspectorCLI extends CLIWithRequiredArguments {
   }
 
   private function getDataForTrace(vec<(HHAST\Node, arraykey)> $trace): string {
+    // This data is all included in the CSS class names, but there's a /lot/ of
+    // other stuff in there. Provide something less noisy for the JS
     return Vec\map($trace, $entry ==> {
       list($node, $field) = $entry;
       return Str\format(
@@ -149,6 +151,15 @@ final class InspectorCLI extends CLIWithRequiredArguments {
     vec<(HHAST\Node, arraykey)> $trace,
     HHAST\Node $innermost,
   ): string {
+    // This returns anything we might want for highlighting; this includes:
+    // - selection highlighting for parent AST nodes. As the parent
+    //   AST nodes do not have a DOM node, every DOM node that would be part of
+    //   that AST node needs a class indicating that node
+    // - selection highlighting for a particular AST field: this introduces the
+    //   need for (id, field), including in parents
+    // - syntax highlighting; this introduces the need for:
+    //   - (class)
+    //   - (class, field)
     $trace = Vec\map($trace, $entry ==> {
       list($node, $field) = $entry;
       $class = \get_class($node) |> Str\split($$, "\\") |> C\lastx($$);

--- a/src/__Private/Inspector/inspector.css
+++ b/src/__Private/Inspector/inspector.css
@@ -8,7 +8,7 @@
  */
 
 code.language-hack span.selected, .info .selected {
-  background-color: rgba(0, 255, 0, 0.7);
+  background-color: rgba(0, 255, 0, 0.7) !important;
 }
 
 code.language-hack span.infoSelected, .info .infoSelected {

--- a/src/__Private/Inspector/inspector.js
+++ b/src/__Private/Inspector/inspector.js
@@ -20,7 +20,7 @@ function selectElement(event) {
   }
   if (infoSelectedLeft) {
     infoSelectedLeft.classList.remove('infoSelected');
-    infoSelectedRight.classList.remove('infoSelected');
+    infoSelectedRight.forEach(node => node.classList.remove('infoSelected'));
     infoSelectedLeft = null;
     infoSelectedRight = null;
   }
@@ -29,7 +29,7 @@ function selectElement(event) {
   selected.classList.add('selected');
   event.stopPropagation();
 
-  const selectedNodeText = document.createTextNode(selected.dataset.node);
+  const selectedNodeText = document.createTextNode(selected.dataset.kind);
   const selectedStrong = document.createElement('strong');
   selectedStrong.classList.add('selected');
   selectedStrong.appendChild(selectedNodeText);
@@ -38,23 +38,17 @@ function selectElement(event) {
   const stack = document.createElement('ul');
   stack.appendChild(selectedLI);
 
-  var current = selected.parentElement;
-  while(current) {
-    if (!current.dataset.field) {
-      break;
-    }
-    let field = current.dataset.field;
-    current = current.parentElement;
-    if (!current.dataset.node) {
-      break;
-    }
-    let node = current.dataset.node;
-    let target = current;
-    current = current.parentElement;
+  let trace = selected.dataset.trace.split(' ').map(entry => {
+    let parts = entry.split('.');
+    return { kind: parts[0], id: parts[1], field: parts[2] };
+  }).reverse();
+
+  trace.forEach(frame => {
+    let { kind, id, field } = frame;
 
     const item = document.createElement('li');
     const nodeAnchor = document.createElement('a');
-    nodeAnchor.appendChild(document.createTextNode(node));
+    nodeAnchor.appendChild(document.createTextNode(kind));
     nodeAnchor.href = '#';
     item.appendChild(nodeAnchor);
     item.appendChild(document.createElement('br'));
@@ -64,17 +58,17 @@ function selectElement(event) {
     nodeAnchor.addEventListener('click', (event) => {
       if (infoSelectedLeft) {
         infoSelectedLeft.classList.remove('infoSelected');
-        infoSelectedRight.classList.remove('infoSelected');
+        infoSelectedRight.forEach(node => node.classList.remove('infoSelected'));
       }
       infoSelectedLeft = item;
-      infoSelectedRight = target;
+      infoSelectedRight = document.querySelectorAll('.hs-id-'+id);
       infoSelectedLeft.classList.add('infoSelected');
-      infoSelectedRight.classList.add('infoSelected');
+      infoSelectedRight.forEach(node => node.classList.add('infoSelected'));
 
       event.preventDefault();
       event.stopPropagation();
     });
-  }
+  });
 
   while (info.firstChild) {
     info.removeChild(info.firstChild);

--- a/src/__Private/Inspector/syntax.css
+++ b/src/__Private/Inspector/syntax.css
@@ -23,18 +23,18 @@
 
 /* Types */
 
-.hs-SimpleTypeSpecifier .hs-StringToken,
-.hs-SimpleTypeSpecifier .hs-NameToken,
-.hs-GenericTypeSpecifer .hs-NameToken,
-.hs-NamespaceUseClause .hs-NameToken,
-.hs-QualifiedName .hs-NameToken,
-.hs-ClassishDeclaration [data-field=name] .hs-NameToken {
+.hs-SimpleTypeSpecifier.hs-StringToken,
+.hs-SimpleTypeSpecifier.hs-NameToken,
+.hs-GenericTypeSpecifer.hs-NameToken,
+.hs-NamespaceUseClause.hs-NameToken,
+.hs-QualifiedName.hs-NameToken,
+.hs-ClassishDeclaration-name.hs-NameToken {
   color: #e5c07b;
 }
 
 /* Functions */
 
-.hs-FunctionDeclaration .hs-NameToken {
+.hs-FunctionDeclaration.hs-NameToken {
   color: #61afef;
 }
 


### PR DESCRIPTION
hhast-inspect is borderline unusable in Chrome (though works fine in
Safari):
- it is incredibly slow to render, visibly rendering a line at a time
- hit tests take several seconds before it even touches the JS

Stop mirroring the AST in the DOM; instead, only put the tokens in the
DOM, but preserve the AST data in attributes. This gives us a flat and wide DOM tree instead of a super-deep one.