### PR TITLE
Add syntax examples for edge cases

### DIFF
--- a/codegen/inferred_relationships.hack
+++ b/codegen/inferred_relationships.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f6e9c87d44515b484ca19324d2139341>>
+ * @generated SignedSource<<2f371c1600b7a0578759a5647c4781e6>>
  */
 namespace Facebook\HHAST\__Private;
 
@@ -104,6 +104,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   ],
   'anonymous_function_use_clause.anonymous_use_variables' => keyset[
     'list<list_item<token:variable>>',
+    'missing',
   ],
   'array_creation_expression.array_creation_left_bracket' => keyset[
     'token:[',
@@ -1243,6 +1244,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'token:<',
   ],
   'dictionary_type_specifier.dictionary_type_members' => keyset[
+    'list<list_item<classname_type_specifier>|list_item<simple_type_specifier>>',
     'list<list_item<dictionary_type_specifier>|list_item<simple_type_specifier>>',
     'list<list_item<keyset_type_specifier>|list_item<simple_type_specifier>>',
     'list<list_item<nullable_type_specifier>|list_item<simple_type_specifier>>',
@@ -2771,6 +2773,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   ],
   'nullable_as_expression.nullable_as_right_operand' => keyset[
     'simple_type_specifier',
+    'vector_type_specifier',
   ],
   'nullable_type_specifier.nullable_question' => keyset[
     'token:?',
@@ -3043,6 +3046,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'literal',
     'member_selection_expression',
     'missing',
+    'nullable_as_expression',
     'object_creation_expression',
     'parenthesized_expression',
     'postfix_unary_expression',
@@ -3255,6 +3259,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<end_of_file|function_declaration|markup_section|namespace_group_use_declaration|namespace_use_declaration>',
     'list<end_of_file|function_declaration|markup_section|namespace_use_declaration>',
     'list<end_of_file|function_declaration|markup_section|return_statement>',
+    'list<end_of_file|function_declaration|namespace_declaration>',
     'list<end_of_file|if_statement|markup_section>',
     'list<end_of_file|inclusion_directive|markup_section>',
     'list<end_of_file|markup_section>',
@@ -3633,6 +3638,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   'type_arguments.type_arguments_types' => keyset[
     'list<list_item<attributized_specifier>>',
     'list<list_item<classname_type_specifier>>',
+    'list<list_item<classname_type_specifier>|list_item<simple_type_specifier>>',
     'list<list_item<closure_type_specifier>>',
     'list<list_item<darray_type_specifier>>',
     'list<list_item<darray_type_specifier>|list_item<simple_type_specifier>>',

--- a/codegen/inferred_relationships.hack
+++ b/codegen/inferred_relationships.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2f371c1600b7a0578759a5647c4781e6>>
+ * @generated SignedSource<<3f66882bd48f3e2b778299774b83729c>>
  */
 namespace Facebook\HHAST\__Private;
 
@@ -1178,6 +1178,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'token:,',
   ],
   'darray_type_specifier.darray_key' => keyset[
+    'classname_type_specifier',
     'simple_type_specifier',
   ],
   'darray_type_specifier.darray_keyword' => keyset[
@@ -2565,6 +2566,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'token:,',
   ],
   'map_array_type_specifier.map_array_key' => keyset[
+    'classname_type_specifier',
     'simple_type_specifier',
   ],
   'map_array_type_specifier.map_array_keyword' => keyset[

--- a/codegen/syntax/AnonymousFunctionUseClause.hack
+++ b/codegen/syntax/AnonymousFunctionUseClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d8bb63a6d0a694e6fcbd572bb7f5e5f0>>
+ * @generated SignedSource<<4b7d0d044b1285cfe2cd44bb2c014375>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -14,13 +14,13 @@ final class AnonymousFunctionUseClause extends Node {
 
   private UseToken $_keyword;
   private LeftParenToken $_left_paren;
-  private NodeList<ListItem<VariableToken>> $_variables;
+  private ?NodeList<ListItem<VariableToken>> $_variables;
   private RightParenToken $_right_paren;
 
   public function __construct(
     UseToken $keyword,
     LeftParenToken $left_paren,
-    NodeList<ListItem<VariableToken>> $variables,
+    ?NodeList<ListItem<VariableToken>> $variables,
     RightParenToken $right_paren,
     ?__Private\SourceRef $source_ref = null,
   ) {
@@ -59,14 +59,14 @@ final class AnonymousFunctionUseClause extends Node {
     $left_paren = $left_paren as nonnull;
     $offset += $left_paren->getWidth();
     $variables = Node::fromJSON(
-      /* HH_FIXME[4110] */ $json['anonymous_use_variables'],
+      /* HH_FIXME[4110] */ $json['anonymous_use_variables'] ??
+        dict['kind' => 'missing'],
       $file,
       $offset,
       $source,
       'NodeList<ListItem<VariableToken>>',
     );
-    $variables = $variables as nonnull;
-    $offset += $variables->getWidth();
+    $offset += $variables?->getWidth() ?? 0;
     $right_paren = Node::fromJSON(
       /* HH_FIXME[4110] */ $json['anonymous_use_right_paren'],
       $file,
@@ -110,7 +110,9 @@ final class AnonymousFunctionUseClause extends Node {
     $parents[] = $this;
     $keyword = $rewriter($this->_keyword, $parents);
     $left_paren = $rewriter($this->_left_paren, $parents);
-    $variables = $rewriter($this->_variables, $parents);
+    $variables = $this->_variables === null
+      ? null
+      : $rewriter($this->_variables, $parents);
     $right_paren = $rewriter($this->_right_paren, $parents);
     if (
       $keyword === $this->_keyword &&
@@ -201,7 +203,7 @@ final class AnonymousFunctionUseClause extends Node {
   }
 
   public function withVariables(
-    NodeList<ListItem<VariableToken>> $value,
+    ?NodeList<ListItem<VariableToken>> $value,
   ): this {
     if ($value === $this->_variables) {
       return $this;
@@ -219,17 +221,17 @@ final class AnonymousFunctionUseClause extends Node {
   }
 
   /**
-   * @return NodeList<ListItem<VariableToken>>
+   * @return NodeList<ListItem<VariableToken>> | null
    */
-  public function getVariables(): NodeList<ListItem<VariableToken>> {
-    return TypeAssert\instance_of(NodeList::class, $this->_variables);
+  public function getVariables(): ?NodeList<ListItem<VariableToken>> {
+    return $this->_variables;
   }
 
   /**
    * @return NodeList<ListItem<VariableToken>>
    */
   public function getVariablesx(): NodeList<ListItem<VariableToken>> {
-    return $this->getVariables();
+    return TypeAssert\not_null($this->getVariables());
   }
 
   public function getRightParenUNTYPED(): ?Node {

--- a/codegen/syntax/DarrayTypeSpecifier.hack
+++ b/codegen/syntax/DarrayTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f17977386c49fdee28202abcbfbff83e>>
+ * @generated SignedSource<<872de38670b1a421a6582fcb80759822>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -14,7 +14,7 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
 
   private DarrayToken $_keyword;
   private LessThanToken $_left_angle;
-  private SimpleTypeSpecifier $_key;
+  private ITypeSpecifier $_key;
   private CommaToken $_comma;
   private ITypeSpecifier $_value;
   private ?Node $_trailing_comma;
@@ -23,7 +23,7 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
   public function __construct(
     DarrayToken $keyword,
     LessThanToken $left_angle,
-    SimpleTypeSpecifier $key,
+    ITypeSpecifier $key,
     CommaToken $comma,
     ITypeSpecifier $value,
     ?Node $trailing_comma,
@@ -72,7 +72,7 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
-      'SimpleTypeSpecifier',
+      'ITypeSpecifier',
     );
     $key = $key as nonnull;
     $offset += $key->getWidth();
@@ -259,7 +259,7 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
     return $this->_key;
   }
 
-  public function withKey(SimpleTypeSpecifier $value): this {
+  public function withKey(ITypeSpecifier $value): this {
     if ($value === $this->_key) {
       return $this;
     }
@@ -279,16 +279,16 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
   }
 
   /**
-   * @return SimpleTypeSpecifier
+   * @return ClassnameTypeSpecifier | SimpleTypeSpecifier
    */
-  public function getKey(): SimpleTypeSpecifier {
-    return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_key);
+  public function getKey(): ITypeSpecifier {
+    return TypeAssert\instance_of(ITypeSpecifier::class, $this->_key);
   }
 
   /**
-   * @return SimpleTypeSpecifier
+   * @return ClassnameTypeSpecifier | SimpleTypeSpecifier
    */
-  public function getKeyx(): SimpleTypeSpecifier {
+  public function getKeyx(): ITypeSpecifier {
     return $this->getKey();
   }
 

--- a/codegen/syntax/MapArrayTypeSpecifier.hack
+++ b/codegen/syntax/MapArrayTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1f7997f360b424e2914a7116d1e7d5b8>>
+ * @generated SignedSource<<58c41cdd75c86c08acd05a3cc813a735>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -14,7 +14,7 @@ final class MapArrayTypeSpecifier extends Node implements ITypeSpecifier {
 
   private ArrayToken $_keyword;
   private LessThanToken $_left_angle;
-  private SimpleTypeSpecifier $_key;
+  private ITypeSpecifier $_key;
   private CommaToken $_comma;
   private ?ITypeSpecifier $_value;
   private GreaterThanToken $_right_angle;
@@ -22,7 +22,7 @@ final class MapArrayTypeSpecifier extends Node implements ITypeSpecifier {
   public function __construct(
     ArrayToken $keyword,
     LessThanToken $left_angle,
-    SimpleTypeSpecifier $key,
+    ITypeSpecifier $key,
     CommaToken $comma,
     ?ITypeSpecifier $value,
     GreaterThanToken $right_angle,
@@ -69,7 +69,7 @@ final class MapArrayTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
-      'SimpleTypeSpecifier',
+      'ITypeSpecifier',
     );
     $key = $key as nonnull;
     $offset += $key->getWidth();
@@ -238,7 +238,7 @@ final class MapArrayTypeSpecifier extends Node implements ITypeSpecifier {
     return $this->_key;
   }
 
-  public function withKey(SimpleTypeSpecifier $value): this {
+  public function withKey(ITypeSpecifier $value): this {
     if ($value === $this->_key) {
       return $this;
     }
@@ -257,16 +257,16 @@ final class MapArrayTypeSpecifier extends Node implements ITypeSpecifier {
   }
 
   /**
-   * @return SimpleTypeSpecifier
+   * @return ClassnameTypeSpecifier | SimpleTypeSpecifier
    */
-  public function getKey(): SimpleTypeSpecifier {
-    return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_key);
+  public function getKey(): ITypeSpecifier {
+    return TypeAssert\instance_of(ITypeSpecifier::class, $this->_key);
   }
 
   /**
-   * @return SimpleTypeSpecifier
+   * @return ClassnameTypeSpecifier | SimpleTypeSpecifier
    */
-  public function getKeyx(): SimpleTypeSpecifier {
+  public function getKeyx(): ITypeSpecifier {
     return $this->getKey();
   }
 

--- a/codegen/syntax/NullableAsExpression.hack
+++ b/codegen/syntax/NullableAsExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0688f1f8ffa547fcaa797dac32239d11>>
+ * @generated SignedSource<<bf598b138bee78ac85338e970f649dfd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -16,12 +16,12 @@ final class NullableAsExpression
 
   private IExpression $_left_operand;
   private QuestionAsToken $_operator;
-  private SimpleTypeSpecifier $_right_operand;
+  private ITypeSpecifier $_right_operand;
 
   public function __construct(
     IExpression $left_operand,
     QuestionAsToken $operator,
-    SimpleTypeSpecifier $right_operand,
+    ITypeSpecifier $right_operand,
     ?__Private\SourceRef $source_ref = null,
   ) {
     $this->_left_operand = $left_operand;
@@ -62,7 +62,7 @@ final class NullableAsExpression
       $file,
       $offset,
       $source,
-      'SimpleTypeSpecifier',
+      'ITypeSpecifier',
     );
     $right_operand = $right_operand as nonnull;
     $offset += $right_operand->getWidth();
@@ -175,7 +175,7 @@ final class NullableAsExpression
     return $this->_right_operand;
   }
 
-  public function withRightOperand(SimpleTypeSpecifier $value): this {
+  public function withRightOperand(ITypeSpecifier $value): this {
     if ($value === $this->_right_operand) {
       return $this;
     }
@@ -187,19 +187,16 @@ final class NullableAsExpression
   }
 
   /**
-   * @return SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier | VectorTypeSpecifier
    */
-  public function getRightOperand(): SimpleTypeSpecifier {
-    return TypeAssert\instance_of(
-      SimpleTypeSpecifier::class,
-      $this->_right_operand,
-    );
+  public function getRightOperand(): ITypeSpecifier {
+    return TypeAssert\instance_of(ITypeSpecifier::class, $this->_right_operand);
   }
 
   /**
-   * @return SimpleTypeSpecifier
+   * @return SimpleTypeSpecifier | VectorTypeSpecifier
    */
-  public function getRightOperandx(): SimpleTypeSpecifier {
+  public function getRightOperandx(): ITypeSpecifier {
     return $this->getRightOperand();
   }
 }

--- a/codegen/syntax/ReturnStatement.hack
+++ b/codegen/syntax/ReturnStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<60825e36998d68c5c50cbf13a7fadcbb>>
+ * @generated SignedSource<<17893fdfcdbc75fb590628b9812deca7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -165,8 +165,8 @@ final class ReturnStatement extends Node implements IStatement {
    * DictionaryIntrinsicExpression | FunctionCallExpression | IsExpression |
    * IssetExpression | KeysetIntrinsicExpression | LambdaExpression |
    * LiteralExpression | MemberSelectionExpression | null |
-   * ObjectCreationExpression | ParenthesizedExpression |
-   * PostfixUnaryExpression | PrefixUnaryExpression | QualifiedName |
+   * NullableAsExpression | ObjectCreationExpression | ParenthesizedExpression
+   * | PostfixUnaryExpression | PrefixUnaryExpression | QualifiedName |
    * RecordCreationExpression | SafeMemberSelectionExpression |
    * ScopeResolutionExpression | ShapeExpression | SubscriptExpression |
    * NameToken | TupleExpression | VariableExpression |
@@ -184,9 +184,10 @@ final class ReturnStatement extends Node implements IStatement {
    * ConditionalExpression | DarrayIntrinsicExpression |
    * DictionaryIntrinsicExpression | FunctionCallExpression | IsExpression |
    * IssetExpression | KeysetIntrinsicExpression | LambdaExpression |
-   * LiteralExpression | MemberSelectionExpression | ObjectCreationExpression |
-   * ParenthesizedExpression | PostfixUnaryExpression | PrefixUnaryExpression |
-   * QualifiedName | RecordCreationExpression | SafeMemberSelectionExpression |
+   * LiteralExpression | MemberSelectionExpression | NullableAsExpression |
+   * ObjectCreationExpression | ParenthesizedExpression |
+   * PostfixUnaryExpression | PrefixUnaryExpression | QualifiedName |
+   * RecordCreationExpression | SafeMemberSelectionExpression |
    * ScopeResolutionExpression | ShapeExpression | SubscriptExpression |
    * NameToken | TupleExpression | VariableExpression |
    * VarrayIntrinsicExpression | VectorIntrinsicExpression | XHPExpression |

--- a/codegen/syntax/TypeArguments.hack
+++ b/codegen/syntax/TypeArguments.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9fa0df754f5405b888c907226d3b831c>>
+ * @generated SignedSource<<5c7bf2240f5c5d1093d451bacc6a579d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -158,9 +158,9 @@ final class TypeArguments extends Node {
   /**
    * @return NodeList<ListItem<AttributizedSpecifier>> |
    * NodeList<ListItem<ClassnameTypeSpecifier>> |
+   * NodeList<ListItem<ITypeSpecifier>> |
    * NodeList<ListItem<ClosureTypeSpecifier>> |
    * NodeList<ListItem<DarrayTypeSpecifier>> |
-   * NodeList<ListItem<ITypeSpecifier>> |
    * NodeList<ListItem<DictionaryTypeSpecifier>> |
    * NodeList<ListItem<GenericTypeSpecifier>> |
    * NodeList<ListItem<ISimpleCreationSpecifier>> |
@@ -183,9 +183,9 @@ final class TypeArguments extends Node {
   /**
    * @return NodeList<ListItem<AttributizedSpecifier>> |
    * NodeList<ListItem<ClassnameTypeSpecifier>> |
+   * NodeList<ListItem<ITypeSpecifier>> |
    * NodeList<ListItem<ClosureTypeSpecifier>> |
    * NodeList<ListItem<DarrayTypeSpecifier>> |
-   * NodeList<ListItem<ITypeSpecifier>> |
    * NodeList<ListItem<DictionaryTypeSpecifier>> |
    * NodeList<ListItem<GenericTypeSpecifier>> |
    * NodeList<ListItem<ISimpleCreationSpecifier>> |

--- a/src/__Private/codegen/data/AsComplexTypesSyntaxExample.hack
+++ b/src/__Private/codegen/data/AsComplexTypesSyntaxExample.hack
@@ -1,0 +1,13 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+namespace Facebook\HHAST\__Private\SyntaxExamples;
+
+function maybe_as_complex_type(mixed $x): ?vec<mixed> {
+  return $x ?as vec<_>;
+}

--- a/src/__Private/codegen/data/ClassnameArrayKeySyntaxExample.hack
+++ b/src/__Private/codegen/data/ClassnameArrayKeySyntaxExample.hack
@@ -14,6 +14,10 @@ function classname_as_immmap_key(ImmMap<classname<mixed>, string> $_): void {
 }
 function classname_as_dict_key(dict<classname<mixed>, string> $_): void {
 }
+function classname_as_darray_key(darray<classname<mixed>, string> $_): void {
+}
+function classname_as_php_array_key(array<classname<mixed>, string> $_): void {
+}
 function classname_as_set_value(Set<classname<mixed>> $_): void {
 }
 function classname_as_immset_value(ImmSet<classname<mixed>> $_): void {

--- a/src/__Private/codegen/data/ClassnameArrayKeySyntaxExample.hack
+++ b/src/__Private/codegen/data/ClassnameArrayKeySyntaxExample.hack
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+namespace Facebook\HHAST\__Private\SyntaxExamples;
+
+function classname_as_map_key(Map<classname<mixed>, string> $_): void {
+}
+function classname_as_immmap_key(ImmMap<classname<mixed>, string> $_): void {
+}
+function classname_as_dict_key(dict<classname<mixed>, string> $_): void {
+}
+function classname_as_set_value(Set<classname<mixed>> $_): void {
+}
+function classname_as_immset_value(ImmSet<classname<mixed>> $_): void {
+}
+function classname_as_keyset_value(keyset<classname<mixed>> $_): void {
+}

--- a/src/__Private/codegen/data/PHPAnonymousFunctionEmptyUseSyntaxExample.hack
+++ b/src/__Private/codegen/data/PHPAnonymousFunctionEmptyUseSyntaxExample.hack
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+namespace Facebook\HHAST\__Private\SyntaxExamples;
+
+function php_anonymous_function_with_empty_use(): void {
+  /* HH_IGNORE_ERROR[3084] HHAST bans using PHP anonymous functions, but we
+   * still need to support parsing them for now */
+  $_ = function() use () {
+  };
+}


### PR DESCRIPTION
Permitted nesting is not actually defined anywhere; both HackAST and
HHAST infer by looking at the Hack and HHVM unit tests. In HHAST's case,
there's also support for examples of specific things we know aren't
covered.

Explicitly testing `?as vec<_>` in Hack seems unnecessary: we test
`as vec<_>`, and that `?as` is maybe - no need to duplicate all the `as`
tests for `?as`.

Workflow:
1. add `*SyntaxExample.hack` files (**must** match this glob pattern)
2. check the HHVM version id from `codegen/version.hack`
3. install that version of HHVM
4. grab the source for that version of HHVM
5. `bin/update-codegen --rebuild-relationships --hhvm-path=$PATH_TO_CHECKOUT`;
   this should be executed by the version of HHVM you just installed
6. Make sure there are no changes to `codegen/version.hack`; an increase
   in the last two digits of `HHVM_VERSION_ID` is acceptable, but any
   other change indicates that codegen was rebuilt with the wrong HHVM/hh_parse
   binaries in `$PATH`
7. Review changes to `codegen/syntax/`:
   - make sure expected changes are there; if not, check:
     - file names match glob
     - examples didn't actually already pass:
       try `bin/hhast-inspect $PATH` and `bin/hhast-lint $PATH`
    - make sure there are no additional changes; if there are, check
      that `--hhvm-path=` pointed to a checkout of the correct HHVM
      branch