### PR TITLE
fix DontAwaitInALoopLinter edge cases

### DIFF
--- a/tests/examples/DontAwaitInALoopLinter/excluded.hack.expect
+++ b/tests/examples/DontAwaitInALoopLinter/excluded.hack.expect
@@ -1,0 +1,47 @@
+[
+    {
+        "blame": "await foo() ",
+        "blame_pretty": "Line 16:   foreach (await foo() as $_) {\nLine 17:     foreach (await foo() as $_) {",
+        "description": "Don't use await in a loop"
+    },
+    {
+        "blame": "      await foo() ",
+        "blame_pretty": "Line 16:   foreach (await foo() as $_) {\nLine 20:       await foo() as $_",
+        "description": "Don't use await in a loop"
+    },
+    {
+        "blame": "      await foo()",
+        "blame_pretty": "Line 16:   foreach (await foo() as $_) {\nLine 19:     foreach (\nLine 22:       await foo();",
+        "description": "Don't use await in a loop"
+    },
+    {
+        "blame": "    await foo()",
+        "blame_pretty": "Line 16:   foreach (await foo() as $_) {\nLine 24:     await foo();",
+        "description": "Don't use await in a loop"
+    },
+    {
+        "blame": "await foo()",
+        "blame_pretty": "Line 31:   for (await foo(); false; ) {\nLine 32:     for (await foo(); false; ) {",
+        "description": "Don't use await in a loop"
+    },
+    {
+        "blame": "      await foo()",
+        "blame_pretty": "Line 31:   for (await foo(); false; ) {\nLine 35:       await foo();",
+        "description": "Don't use await in a loop"
+    },
+    {
+        "blame": "      await foo()",
+        "blame_pretty": "Line 31:   for (await foo(); false; ) {\nLine 34:     for (\nLine 38:       await foo();",
+        "description": "Don't use await in a loop"
+    },
+    {
+        "blame": "    await foo()",
+        "blame_pretty": "Line 31:   for (await foo(); false; ) {\nLine 40:     await foo();",
+        "description": "Don't use await in a loop"
+    },
+    {
+        "blame": "        await foo()",
+        "blame_pretty": "Line 43:       while (false) {\nLine 44:         await foo();",
+        "description": "Don't use await in a loop"
+    }
+]

--- a/tests/examples/DontAwaitInALoopLinter/excluded.hack.in
+++ b/tests/examples/DontAwaitInALoopLinter/excluded.hack.in
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2017, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional
+ * grant of patent rights can be found in the PATENTS file in the same
+ * directory.
+ *
+ */
+
+async function excluded_loop_awaits_async(): Awaitable<void> {
+  foreach (await foo() as $_) {
+  }
+
+  foreach (await foo() as $_) {
+    foreach (await foo() as $_) {
+    }
+    foreach (
+      await foo() as $_
+    ) {
+      await foo();
+    }
+    await foo();
+    $_ = async () ==> await foo();
+  }
+
+  for (await foo(); false; ) {
+  }
+
+  for (await foo(); false; ) {
+    for (await foo(); false; ) {
+    }
+    for (
+      await foo();
+      false;
+    ) {
+      await foo();
+    }
+    await foo();
+    $_ = async () ==> {
+      await foo();
+      while (false) {
+        await foo();
+      }
+    };
+  }
+}


### PR DESCRIPTION
- should not complain if await-ing in the part of the for/foreach loop that doesn't actually loop
- unless that loop is itself inside another loop
- the "closest function body" boundary wasn't correctly handled in the pretty-printer

Fixes #257