### PR TITLE
Migrate PHP array literals to varray and darray

### DIFF
--- a/codegen/syntax/DarrayIntrinsicExpression.hack
+++ b/codegen/syntax/DarrayIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fb0afb7d1e926c5bf9e745f3d1fa64d9>>
+ * @generated SignedSource<<9139e2c67f928d824444fec43d5032c3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -10,7 +10,7 @@ use namespace HH\Lib\Dict;
 <<__ConsistentConstruct>>
 final class DarrayIntrinsicExpression
   extends Node
-  implements ILambdaBody, IExpression {
+  implements IContainer, ILambdaBody, IExpression {
 
   const string SYNTAX_KIND = 'darray_intrinsic_expression';
 

--- a/codegen/syntax/TupleExpression.hack
+++ b/codegen/syntax/TupleExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4beb04155c0aec545d3f442c948e2ff1>>
+ * @generated SignedSource<<0c1b9ae09517fc406614728f01585e57>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -218,9 +218,9 @@ final class TupleExpression extends Node implements ILambdaBody, IExpression {
 
   /**
    * @return NodeList<ListItem<ArrayCreationExpression>> |
-   * NodeList<ListItem<IContainer>> | NodeList<ListItem<IExpression>> |
-   * NodeList<ListItem<BinaryExpression>> | NodeList<ListItem<CastExpression>>
-   * | NodeList<ListItem<DarrayIntrinsicExpression>> |
+   * NodeList<ListItem<IContainer>> | NodeList<ListItem<BinaryExpression>> |
+   * NodeList<ListItem<CastExpression>> | NodeList<ListItem<IExpression>> |
+   * NodeList<ListItem<DarrayIntrinsicExpression>> |
    * NodeList<ListItem<FunctionCallExpression>> |
    * NodeList<ListItem<LiteralExpression>> |
    * NodeList<ListItem<MemberSelectionExpression>> |
@@ -236,9 +236,9 @@ final class TupleExpression extends Node implements ILambdaBody, IExpression {
 
   /**
    * @return NodeList<ListItem<ArrayCreationExpression>> |
-   * NodeList<ListItem<IContainer>> | NodeList<ListItem<IExpression>> |
-   * NodeList<ListItem<BinaryExpression>> | NodeList<ListItem<CastExpression>>
-   * | NodeList<ListItem<DarrayIntrinsicExpression>> |
+   * NodeList<ListItem<IContainer>> | NodeList<ListItem<BinaryExpression>> |
+   * NodeList<ListItem<CastExpression>> | NodeList<ListItem<IExpression>> |
+   * NodeList<ListItem<DarrayIntrinsicExpression>> |
    * NodeList<ListItem<FunctionCallExpression>> |
    * NodeList<ListItem<LiteralExpression>> |
    * NodeList<ListItem<MemberSelectionExpression>> |

--- a/codegen/syntax/VarrayIntrinsicExpression.hack
+++ b/codegen/syntax/VarrayIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a1e7713891cf144452e0e8068efc1110>>
+ * @generated SignedSource<<86b4cd692effb508e240fdcae21a9cec>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -10,7 +10,7 @@ use namespace HH\Lib\Dict;
 <<__ConsistentConstruct>>
 final class VarrayIntrinsicExpression
   extends Node
-  implements ILambdaBody, IExpression {
+  implements IContainer, ILambdaBody, IExpression {
 
   const string SYNTAX_KIND = 'varray_intrinsic_expression';
 
@@ -281,8 +281,9 @@ final class VarrayIntrinsicExpression
   }
 
   /**
-   * @return NodeList<ListItem<IExpression>> |
+   * @return NodeList<ListItem<IContainer>> |
    * NodeList<ListItem<ArrayIntrinsicExpression>> |
+   * NodeList<ListItem<IExpression>> |
    * NodeList<ListItem<ConditionalExpression>> |
    * NodeList<ListItem<DarrayIntrinsicExpression>> |
    * NodeList<ListItem<IHackArray>> |
@@ -300,8 +301,9 @@ final class VarrayIntrinsicExpression
   }
 
   /**
-   * @return NodeList<ListItem<IExpression>> |
+   * @return NodeList<ListItem<IContainer>> |
    * NodeList<ListItem<ArrayIntrinsicExpression>> |
+   * NodeList<ListItem<IExpression>> |
    * NodeList<ListItem<ConditionalExpression>> |
    * NodeList<ListItem<DarrayIntrinsicExpression>> |
    * NodeList<ListItem<IHackArray>> |

--- a/codegen/syntax/VectorIntrinsicExpression.hack
+++ b/codegen/syntax/VectorIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a3a922ed336618a80c248b70eec54a00>>
+ * @generated SignedSource<<54613ee8ad83a759b16c9b9886e308e7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -281,7 +281,7 @@ final class VectorIntrinsicExpression
   }
 
   /**
-   * @return NodeList<ListItem<IExpression>> |
+   * @return NodeList<ListItem<IExpression>> | NodeList<ListItem<IContainer>> |
    * NodeList<ListItem<BinaryExpression>> |
    * NodeList<ListItem<CollectionLiteralExpression>> |
    * NodeList<ListItem<ConditionalExpression>> |
@@ -303,7 +303,7 @@ final class VectorIntrinsicExpression
   }
 
   /**
-   * @return NodeList<ListItem<IExpression>> |
+   * @return NodeList<ListItem<IExpression>> | NodeList<ListItem<IContainer>> |
    * NodeList<ListItem<BinaryExpression>> |
    * NodeList<ListItem<CollectionLiteralExpression>> |
    * NodeList<ListItem<ConditionalExpression>> |

--- a/src/Migrations/PHPArrayLiteralsMigration.hack
+++ b/src/Migrations/PHPArrayLiteralsMigration.hack
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{C, Str, Vec};
+
+final class PHPArrayLiteralsMigration extends StepBasedMigration {
+  private function convertUnkeyedArrayToVarray(
+    ArrayIntrinsicExpression $in,
+  ): IContainer {
+    $members = $in->getMembers();
+    if ($members === null || $members->isEmpty()) {
+      return $in;
+    }
+
+    if (
+      C\any(
+        $members->getChildrenOfItems() as nonnull,
+        $item ==> $item is ElementInitializer /* `key => value` */,
+      )
+    ) {
+      return $in;
+    }
+
+    $kw = $in->getKeyword();
+    $lp = $in->getLeftParenx();
+    $rp = $in->getRightParenx();
+
+    return new VarrayIntrinsicExpression(
+      new VarrayToken($kw->getLeading(), $kw->getTrailing()),
+      null,
+      new LeftBracketToken($lp->getLeading(), $lp->getTrailing()),
+      /* HH_IGNORE_ERROR[4110] array members are not IExpression because of
+        ElementInitializers, but we know we don't have any here */
+      $members,
+      new RightBracketToken($rp->getLeading(), $rp->getTrailing()),
+    );
+  }
+
+  private function convertArrayToDarray(
+    ArrayIntrinsicExpression $in,
+  ): DarrayIntrinsicExpression {
+    $highest_int_key = new \HH\Lib\Ref(-1);
+
+    $members = Vec\map(
+      $in->getMembers()?->getChildren() ?? vec[],
+      $list_item ==> {
+        $item = $list_item->getItem();
+        if ($item is ElementInitializer) {
+          $key = $item->getKey() ?as LiteralExpression
+            |> $$?->getExpression() ?as DecimalLiteralToken
+            |> $$?->getText()
+            |> Str\to_int($$ ?? '');
+          if ($key is int) {
+            if ($key > $highest_int_key->value) {
+              $highest_int_key->value = $key;
+            }
+          }
+          return new ListItem($item, $list_item->getSeparator());
+        }
+        $key = $highest_int_key->value + 1;
+        $highest_int_key->value = $key;
+        return new ElementInitializer(
+          new LiteralExpression(
+            new DecimalLiteralToken(
+              $item->getFirstTokenx()->getLeading(),
+              null,
+              (string)$key,
+            ),
+          ),
+          new EqualGreaterThanToken(
+            new NodeList(vec[new WhiteSpace(' ')]),
+            null,
+          ),
+          ($item as IExpression)->replaceDescendant(
+            $item->getFirstTokenx(),
+            $item->getFirstTokenx()
+              ->withLeading(new NodeList(vec[new WhiteSpace(' ')])),
+          ),
+        )
+          |> new ListItem($$, $list_item->getSeparator());
+      },
+    );
+
+    $kw = $in->getKeyword();
+    $lp = $in->getLeftParenx();
+    $rp = $in->getRightParenx();
+    return new DarrayIntrinsicExpression(
+      new DarrayToken($kw->getLeading(), $kw->getTrailing()),
+      null,
+      new LeftBracketToken($lp->getLeading(), $lp->getTrailing()),
+      NodeList::createNonEmptyListOrNull($members),
+      new RightBracketToken($rp->getLeading(), $rp->getTrailing()),
+    );
+  }
+
+  /** [123] => array(123) */
+  private function convertArrayCreationToIntrinsic(
+    ArrayCreationExpression $in,
+  ): ArrayIntrinsicExpression {
+    $lb = $in->getLeftBracket();
+    $rb = $in->getRightBracket();
+    return new ArrayIntrinsicExpression(
+      new ArrayToken($lb->getLeading(), null),
+      new LeftParenToken(null, $lb->getTrailing()),
+      $in->getMembers(),
+      new RightParenToken($rb->getLeading(), $rb->getTrailing()),
+    );
+  }
+
+  <<__Override>>
+  public function getSteps(): Traversable<IMigrationStep> {
+    return vec[
+      new TypedMigrationStep(
+        'replace [] literals with array() literals',
+        ArrayCreationExpression::class,
+        ArrayIntrinsicExpression::class,
+        $node ==> $this->convertArrayCreationToIntrinsic($node),
+      ),
+      new TypedMigrationStep(
+        'convert non-empty unkeyed arrays to varrays',
+        ArrayIntrinsicExpression::class,
+        IContainer::class,
+        $node ==> $this->convertUnkeyedArrayToVarray($node),
+      ),
+      new TypedMigrationStep(
+        'convert any remaining arrays to darrays',
+        ArrayIntrinsicExpression::class,
+        DarrayIntrinsicExpression::class,
+        $node ==> $this->convertArrayToDarray($node),
+      ),
+    ];
+  }
+}

--- a/src/__Private/MigrationCLI.hack
+++ b/src/__Private/MigrationCLI.hack
@@ -22,6 +22,7 @@ use type Facebook\HHAST\{
   ImplicitShapeSubtypesMigration,
   IsRefinementMigration,
   OptionalShapeFieldsMigration,
+  PHPArrayLiteralsMigration,
   TopLevelRequiresMigration,
 };
 
@@ -276,6 +277,13 @@ class MigrationCLI extends CLIWithRequiredArguments {
         },
         'Migrate /* HH_FIXME[4110] */ to the equivalent new error codes',
         '--migrate-fixme-4110',
+      ),
+      CLIOptions\flag(
+        () ==> {
+          $this->migrations[] = PHPArrayLiteralsMigration::class;
+        },
+        'Migrate [] and array() literals to varray[] and darray[]',
+        '--migrate-php-arrays',
       ),
       CLIOptions\flag(
         () ==> {

--- a/src/__Private/codegen/CodegenBase.hack
+++ b/src/__Private/codegen/CodegenBase.hack
@@ -172,6 +172,8 @@ abstract class CodegenBase {
       HHAST\IContainer::class => keyset[
         HHAST\IPHPArray::class,
         HHAST\IHackArray::class,
+        HHAST\DarrayIntrinsicExpression::class,
+        HHAST\VarrayIntrinsicExpression::class,
         HHAST\CollectionLiteralExpression::class,
       ],
       HHAST\IHasOperator::class => keyset[
@@ -227,7 +229,9 @@ abstract class CodegenBase {
       ],
       HHAST\IExpression::class => Keyset\union(
         keyset[
+          // Constants aren't here as they need to be wrapped in NameExpressions
           HHAST\AnonymousFunction::class,
+          HHAST\IHasOperator::class,
           HHAST\VariableToken::class,
           HHAST\XHPChildrenDeclaration::class,
           HHAST\XHPChildrenParenthesizedList::class,

--- a/src/nodes/NodeList.hack
+++ b/src/nodes/NodeList.hack
@@ -41,8 +41,7 @@ final class NodeList<+Titem as Node> extends Node {
     return $this->_children;
   }
 
-  public function getChildrenOfItems<T>(
-  ): vec<T> where Titem as ListItem<T> {
+  public function getChildrenOfItems<T>(): vec<T> where Titem as ListItem<T> {
     return Vec\map($this->getChildren(), $child ==> $child->getItem());
   }
 

--- a/tests/PHPArrayLiteralsMigrationTest.hack
+++ b/tests/PHPArrayLiteralsMigrationTest.hack
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{Str, Vec};
+
+final class PHPArrayLiteralsMigrationTest extends StepBasedMigrationTest {
+  const type TMigration = PHPArrayLiteralsMigration;
+
+  <<__Override>>
+  public function getExamples(): vec<(string)> {
+    $examples = \glob(__DIR__.'/examples/migrations/PHPArrayLiterals/*.hack.in')
+      |> Vec\map(
+        $$,
+        $file ==> tuple(
+          Str\strip_suffix($file, '.in')
+            |> Str\strip_prefix($$, __DIR__.'/examples/'),
+        ),
+      );
+    if (\HHVM_VERSION_ID < 44400) {
+      return $examples;
+    }
+    return Vec\filter(
+      $examples,
+      $ex ==> !Str\contains($ex[0], 'square_brackets'),
+    );
+  }
+}

--- a/tests/examples/migrations/PHPArrayLiterals/array_parens.hack.expect
+++ b/tests/examples/migrations/PHPArrayLiterals/array_parens.hack.expect
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2016, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+$_varray = varray[1, 2, 3];
+$empty_darray = darray[];
+$_darray = darray[1 => 'a', 2 => 'b', 3 => 'c'];
+$_darray = darray[0 => 'a', 1 => 'b', 2 => 'c'];
+$_darray = darray[0 => 'first', 'a' => 'second', 1 => 'third', 123 => 'fourth', 124 => 'fifth'];
+$_darray = darray[1 => 'a', 2 => 'b', 3 => 'c'];
+
+$_multiline_varray = varray[
+  'foo',
+  'bar',
+  'baz',
+];
+$_multiline_darray = darray[
+  0 => 'first',
+  'a' => 'second',
+  1 => 'third',
+  123 => 'fourth',
+  124 => 'fifth',
+];
+
+$nested = varray[1, 2, varray[3, 4], darray[5 => 6]];

--- a/tests/examples/migrations/PHPArrayLiterals/array_parens.hack.in
+++ b/tests/examples/migrations/PHPArrayLiterals/array_parens.hack.in
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2016, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+$_varray = array(1, 2, 3);
+$empty_darray = array();
+$_darray = array(1 => 'a', 2 => 'b', 3 => 'c');
+$_darray = array(0 => 'a', 1 => 'b', 2 => 'c');
+$_darray = array('first', 'a' => 'second', 'third', 123 => 'fourth', 'fifth');
+$_darray = array(1 => 'a', 'b', 'c');
+
+$_multiline_varray = array(
+  'foo',
+  'bar',
+  'baz',
+);
+$_multiline_darray = array(
+  'first',
+  'a' => 'second',
+  'third',
+  123 => 'fourth',
+  'fifth',
+);
+
+$nested = array(1, 2, array(3, 4), array(5 => 6));

--- a/tests/examples/migrations/PHPArrayLiterals/square_brackets.hack.expect
+++ b/tests/examples/migrations/PHPArrayLiterals/square_brackets.hack.expect
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c] 2016, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+$_varray = varray[1, 2, 3];
+$empty_darray = darray[];
+$_darray = darray[1 => 'a', 2 => 'b', 3 => 'c'];
+$_darray = darray[0 => 'a', 1 => 'b', 2 => 'c'];
+$_darray = darray[0 => 'first', 'a' => 'second', 1 => 'third', 123 => 'fourth', 124 => 'fifth'];
+$_darray = darray[1 => 'a', 2 => 'b', 3 => 'c'];
+
+$_multiline_varray = varray[
+  'foo',
+  'bar',
+  'baz',
+];
+$_multiline_darray = darray[
+  0 => 'first',
+  'a' => 'second',
+  1 => 'third',
+  123 => 'fourth',
+  124 => 'fifth',
+];
+
+$nested = varray[1, 2, varray[3, 4], darray[5 => 6]];

--- a/tests/examples/migrations/PHPArrayLiterals/square_brackets.hack.in
+++ b/tests/examples/migrations/PHPArrayLiterals/square_brackets.hack.in
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c] 2016, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+$_varray = [1, 2, 3];
+$empty_darray = [];
+$_darray = [1 => 'a', 2 => 'b', 3 => 'c'];
+$_darray = [0 => 'a', 1 => 'b', 2 => 'c'];
+$_darray = ['first', 'a' => 'second', 'third', 123 => 'fourth', 'fifth'];
+$_darray = [1 => 'a', 'b', 'c'];
+
+$_multiline_varray = [
+  'foo',
+  'bar',
+  'baz',
+];
+$_multiline_darray = [
+  'first',
+  'a' => 'second',
+  'third',
+  123 => 'fourth',
+  'fifth',
+];
+
+$nested = [1, 2, [3, 4], [5 => 6]];


### PR DESCRIPTION
Also extend IExpression and IContainer so more types are valid.

The square brackets migration is not supported on 4.44 or above, as they
can not be parsed.

fixes #259