### PR TITLE
Allow "." to be used as a root.

### DIFF
--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -155,9 +155,10 @@ final class LintRunConfig {
   public function getConfigForFile(string $file_path): self::TFileConfig {
     $roots = Vec\map(
       $this->configFile['roots'],
-      $s ==> Str\strip_suffix($s, '/').'/',
+      $s ==> Str\strip_suffix($s, '/').'/' |> Str\strip_prefix($$, './'),
     );
-    $file_path = Str\strip_prefix($file_path, $this->projectRoot.'/');
+    $file_path = Str\strip_prefix($file_path, $this->projectRoot.'/')
+      |> Str\strip_prefix($$, './');
     if (
       $roots !== vec[] &&
       !C\any($roots, $root ==> Str\starts_with($file_path, $root))


### PR DESCRIPTION
We have a project with ~50 hack files at the top level folder.
We want to lint them too, so we set our roots to `["."]`.
This makes it so hhast will lint all files in all folders.
We have added a override to not scan vendor.

This works in `vendor/bin/hhast-lint` already,
but the vscode intergration doesn't play nicely with this.
The paths the errors are reported on are not normalized.
Hhast reports errors at paths like
/path/to/./project/file.hack.
The problem explorer understands the non normal path.
However, the error go away when opening the file.
This commit strips the leading `./` that is added by having . in roots.