### PR TITLE
Add `hhast-migrate --demangle-xhp-class-names`

### DIFF
--- a/src/Migrations/DemangleXHP.hack
+++ b/src/Migrations/DemangleXHP.hack
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\Str;
+
+final class DemangleXHPMigration extends StepBasedMigration {
+  <<__Override>>
+  public function getSteps(): Traversable<IMigrationStep> {
+    return vec[
+      new TypedMigrationStep(
+        'Demangle XHP class names (`class :foo:bar-baz`, `:foo:bar-baz::class` etc)',
+        XHPClassNameToken::class,
+        XHPClassNameToken::class,
+        $node ==> $node->withText(Str\replace($node->getText(), '-', '_')),
+      ),
+      // We can't just demangle XHPElementNameToken as that's also used for
+      // attribute names - `<foo:bar-baz herp-derp="x" />` needs to be
+      // `<foo:bar_baz herp-derp="x" />`, not `herp_derp`.
+      new TypedMigrationStep(
+        'Demangle XHP open tags (`<foo:bar-baz>`)',
+        XHPOpen::class,
+        XHPOpen::class,
+        $node ==> $node->withName(
+          $node->getName()
+            ->withText(Str\replace($node->getName()->getText(), '-', '_')),
+        ),
+      ),
+      new TypedMigrationStep(
+        'Demangle XHP close tags (`</foo:bar-baz>`)',
+        XHPClose::class,
+        XHPClose::class,
+        $node ==> $node->withName(
+          $node->getName()
+            ->withText(Str\replace($node->getName()->getText(), '-', '_')),
+        ),
+      ),
+    ];
+  }
+}

--- a/src/__Private/MigrationCLI.hack
+++ b/src/__Private/MigrationCLI.hack
@@ -14,6 +14,7 @@ use namespace HH\Lib\{C, Dict, Str, Vec};
 use type Facebook\HHAST\{
   AddFixmesMigration,
   BaseMigration,
+  DemangleXHPMigration,
   DollarBraceEmbeddedVariableMigration,
   ExplicitPartialModeMigration,
   Fixme4110Migration,
@@ -277,6 +278,13 @@ class MigrationCLI extends CLIWithRequiredArguments {
         },
         'Migrate [] and array() literals to varray[] and darray[]',
         '--php-arrays',
+      ),
+      CLIOptions\flag(
+        () ==> {
+          $this->migrations[] = DemangleXHPMigration::class;
+        },
+        'Replace "-" in XHP class names with "_"',
+        '--demangle-xhp-class-names',
       ),
       CLIOptions\flag(
         () ==> {

--- a/tests/DemangleXHPMigrationTest.hack
+++ b/tests/DemangleXHPMigrationTest.hack
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class DemangleXHPMigrationTest extends StepBasedMigrationTest {
+  const type TMigration = DemangleXHPMigration;
+
+  <<__Override>>
+  public function getExamples(): vec<(string)> {
+    return vec[tuple('migrations/demangle_xhp.hack')];
+  }
+}

--- a/tests/examples/migrations/demangle_xhp.hack.expect
+++ b/tests/examples/migrations/demangle_xhp.hack.expect
@@ -1,0 +1,14 @@
+class :foo:bar_baz {}
+class :foo:bar_baz:herp_derp {}
+
+class :i_have_attribute {
+  attribute string foo-bar @required;
+}
+
+function example(): void {
+  $_ = :foo:bar_baz::class;
+  $_ = :foo:bar_baz:herp_derp::class;
+  $_ = <foo:bar_baz />;
+  $_ = <foo:bar_baz><foo:bar_baz:herp_derp /></foo:bar_baz>;
+  $_ = <i_have_attribute foo-bar="baz" />;
+}

--- a/tests/examples/migrations/demangle_xhp.hack.in
+++ b/tests/examples/migrations/demangle_xhp.hack.in
@@ -1,0 +1,14 @@
+class :foo:bar-baz {}
+class :foo:bar-baz:herp-derp {}
+
+class :i-have-attribute {
+  attribute string foo-bar @required;
+}
+
+function example(): void {
+  $_ = :foo:bar-baz::class;
+  $_ = :foo:bar-baz:herp-derp::class;
+  $_ = <foo:bar-baz />;
+  $_ = <foo:bar-baz><foo:bar-baz:herp-derp /></foo:bar-baz>;
+  $_ = <i-have-attribute foo-bar="baz" />;
+}


### PR DESCRIPTION
Replaces `-` with `_`, but not in attributes.

Attributes need to stay as-is, especially for `data-` and `aria-`
special-casing.

Also tested with:

```
fredemmott@fredemmott-mm1 xhp-lib % ~/code/hhast/bin/hhast-migrate --demangle-xhp-class-names src tests
fredemmott@fredemmott-mm1 xhp-lib % ~/code/hhvm-2/build/hphp/hack/bin/hh_client
No errors!
fredemmott@fredemmott-mm1 xhp-lib % tail -n 2 .hhconfig
disable_xhp_element_mangling=true
enable_xhp_class_modifer=true
```

Leaving `:` alone rather than doing a full demangle as it's likely
better for that to become a namespace separator than `__` in existing
code.