### PR TITLE
Add hhast-migrate --add-xhp-children-declaration-method

### DIFF
--- a/codegen/syntax/ClassishDeclaration.hack
+++ b/codegen/syntax/ClassishDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d2014e76f7a9b91b2b31630796651f89>>
+ * @generated SignedSource<<f74cab8b2c080af76af44a54f7acf81a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -10,7 +10,7 @@ use namespace HH\Lib\Dict;
 <<__ConsistentConstruct>>
 abstract class ClassishDeclarationGeneratedBase
   extends Node
-  implements IHasAttributeSpec {
+  implements IDeclaration, IHasAttributeSpec {
 
   const string SYNTAX_KIND = 'classish_declaration';
 

--- a/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
@@ -327,7 +327,7 @@ final class AddXHPChildrenDeclarationMethodMigration
       return self::makeCall('anyOf', null, $parts);
     }
 
-    if ($in is NameExpression || $in is EmptyToken) {
+    if ($in is NameExpression || $in is EmptyToken || $in is NameToken) {
       $name = $in is NameExpression ? $in->getWrappedNode() : $in;
       if (
         $name is NameToken || $name is EmptyToken || $name is XHPClassNameToken

--- a/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
@@ -75,11 +75,19 @@ final class AddXHPChildrenDeclarationMethodMigration
     if (!self::scopeNeedsUseNamespace($decls)) {
       return $in;
     }
+
+    $use = self::getUseNamespace();
+    $ws = $decls->getFirstTokenx()->getLeadingWhitespace();
+    if ($ws !== null) {
+      $t = $use->getFirstTokenx();
+      $use = $use->replace($t, $t->withLeading(new NodeList(vec[$ws])));
+    }
+
     return $in->withBody(
       $body->withDeclarations(
         $decls->insertBefore(
           C\firstx($decls->getChildrenOfType(IDeclaration::class)),
-          self::getUseNamespace(),
+          $use,
         ),
       ),
     );

--- a/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
@@ -11,7 +11,7 @@ namespace Facebook\HHAST;
 
 use namespace HH\Lib\{C, Vec};
 
-final class XHPChildrenDeclarationMethodMigration extends StepBasedMigration {
+final class AddXHPChildrenDeclarationMethodMigration extends StepBasedMigration {
   private static function scopeNeedsUseNamespace(NodeList<Node> $in): bool {
     $classes = $in->getChildrenOfType(ClassishDeclaration::class);
     return C\any(

--- a/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
@@ -185,7 +185,6 @@ final class AddXHPChildrenDeclarationMethodMigration
     );
   }
 
-
   private static function addChildrenDeclarationMethod(
     ClassishBody $in,
   ): ClassishBody {

--- a/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
@@ -344,9 +344,7 @@ final class AddXHPChildrenDeclarationMethodMigration
             new LessThanToken(null, null),
             new NodeList(vec[
               new ListItem(
-                new SimpleTypeSpecifier(
-                  $in is NameExpression ? $in->getWrappedNode() : $in,
-                ),
+                new SimpleTypeSpecifier(new NameToken(null, null, $name)),
                 null,
               ),
             ]),

--- a/src/Migrations/XHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/XHPChildrenDeclarationMethodMigration.hack
@@ -32,6 +32,18 @@ final class XHPChildrenDeclarationMethodMigration extends StepBasedMigration {
     }
 
     $before = C\firstx($decls->getChildrenOfType(IDeclaration::class));
+    $t = $before->getFirstTokenx();
+    $use = self::getUseNamespace();
+    if ($t->getLeading() !== $t->getLeadingWhitespace()) {
+      $ut = $use->getFirstTokenx();
+      return $in->withDeclarations(
+        $in->getDeclarations()->insertBefore(
+          $before,
+          $use->replace($ut, $ut->withLeading($t->getLeading())),
+        ),
+      )
+        ->replace($t, $t->withLeading(null));
+    }
     return $in->withDeclarations(
       $decls->insertBefore($before, self::getUseNamespace()),
     );
@@ -91,7 +103,10 @@ final class XHPChildrenDeclarationMethodMigration extends StepBasedMigration {
         ),
         null,
       )]),
-      new SemicolonToken(null, new NodeList(vec[new EndOfLine("\n")])),
+      new SemicolonToken(
+        null,
+        new NodeList(vec[new EndOfLine("\n"), new EndOfLine("\n")]),
+      ),
     );
   }
 
@@ -146,7 +161,9 @@ final class XHPChildrenDeclarationMethodMigration extends StepBasedMigration {
     return new FunctionDeclarationHeader(
       new NodeList(vec[
         new ProtectedToken(
-          new NodeList(vec[new WhiteSpace($leading_whitespace)]),
+          new NodeList(
+            vec[new EndOfLine("\n"), new WhiteSpace($leading_whitespace)],
+          ),
           $s,
         ),
         new StaticToken(null, $s),

--- a/src/Migrations/XHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/XHPChildrenDeclarationMethodMigration.hack
@@ -272,6 +272,8 @@ final class XHPChildrenDeclarationMethodMigration extends StepBasedMigration {
         "Got an XHP child binary expression with unexpected operator '%s'",
         $in->getOperator()->getText(),
       );
+      // `foo | bar | baz` is `((foo | bar) | baz)` in the AST; flatten them out
+      // for readability
       $next = $in;
       $parts = vec[];
       while ($next is BinaryExpression && $next->getOperator() is BarToken) {

--- a/src/Migrations/XHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/XHPChildrenDeclarationMethodMigration.hack
@@ -1,0 +1,333 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{C, Vec};
+
+final class XHPChildrenDeclarationMethodMigration extends StepBasedMigration {
+  private static function scopeNeedsUseNamespace(NodeList<Node> $in): bool {
+    $classes = $in->getChildrenOfType(ClassishDeclaration::class);
+    return C\any(
+      $classes,
+      $class ==> $class->getBody()
+        ->getChildrenOfType(XHPChildrenDeclaration::class) !==
+        vec[],
+    );
+  }
+
+  private static function addUseNamespaceToScript(Script $in): Script {
+    $decls = $in->getDeclarations();
+    if (!self::scopeNeedsUseNamespace($decls)) {
+      return $in;
+    }
+
+    $before = C\firstx($decls->getChildrenOfType(IDeclaration::class));
+    return $in->withDeclarations(
+      $decls->insertBefore($before, self::getUseNamespace()),
+    );
+  }
+
+  private static function addUseNamespaceToNamespaceBlock(
+    NamespaceDeclaration $in,
+  ): NamespaceDeclaration {
+    // Can't use XHP in namespaces, so if we're not in the root namespace,
+    // we have nothing to do.
+    if ($in->hasName()) {
+      return $in;
+    }
+
+    // Don't have to worry about empty bodies as `namespace;` is invalid,
+    // and `namespace foo;` is caught above.
+
+    $body = $in->getBody() as NamespaceBody;
+    $decls = $body->getDeclarationsx();
+    if (!self::scopeNeedsUseNamespace($decls)) {
+      return $in;
+    }
+    return $in->withBody(
+      $body->withDeclarations(
+        $decls->insertBefore(
+          C\firstx($decls->getChildrenOfType(IDeclaration::class)),
+          self::getUseNamespace(),
+        ),
+      ),
+    );
+  }
+
+  <<__Memoize>>
+  private static function getUseNamespace(): NamespaceUseDeclaration {
+    $s = new NodeList(vec[new WhiteSpace(' ')]);
+    return new NamespaceUseDeclaration(
+      new UseToken(null, $s),
+      new NamespaceToken(null, $s),
+      new NodeList(vec[new ListItem(
+        new NamespaceUseClause(
+          null,
+          new QualifiedName(
+            new NodeList(vec[
+              new ListItem(
+                new NameToken(null, null, 'Facebook'),
+                new BackslashToken(null, null),
+              ),
+              new ListItem(
+                new NameToken(null, null, 'XHP'),
+                new BackslashToken(null, null),
+              ),
+              new ListItem(new NameToken(null, $s, 'ChildValidation'), null),
+            ]),
+          ),
+          new AsToken(null, $s, 'as'),
+          new NameToken(null, null, 'XHPChild'),
+        ),
+        null,
+      )]),
+      new SemicolonToken(null, new NodeList(vec[new EndOfLine("\n")])),
+    );
+  }
+
+  private static function addChildrenDeclarationMethod(
+    ClassishBody $in,
+  ): ClassishBody {
+    $decl = $in->getElements()
+      ?->getChildrenOfType(XHPChildrenDeclaration::class) ??
+      vec[];
+    if (C\is_empty($decl)) {
+      return $in;
+    }
+    $decl = C\firstx($decl);
+
+
+    $indent = $decl->getFirstTokenx()->getLeadingWhitespace()?->getText() ??
+      '  ';
+    $s = new NodeList(vec[new WhiteSpace(' ')]);
+    $meth = new MethodishDeclaration(
+      null,
+      self::getFunctionDeclarationHeader($indent),
+      new CompoundStatement(
+        new LeftBraceToken(null, new NodeList(vec[new EndOfLine("\n")])),
+        new NodeList(vec[
+          new ReturnStatement(
+            new ReturnToken(
+              new NodeList(vec[new WhiteSpace($indent.$indent)]),
+              $s,
+            ),
+            self::convertChildrenExpression($decl->getExpression()),
+            new SemicolonToken(null, new NodeList(vec[new EndOfLine("\n")])),
+          ),
+        ]),
+        new RightBraceToken(
+          new NodeList(vec[new WhiteSpace($indent)]),
+          new NodeList(vec[
+            new EndOfLine("\n"),
+            new EndOfLine("\n"),
+          ]),
+        ),
+      ),
+      /* semicolon = */ null,
+    );
+    return $in->withElements($in->getElementsx()->insertAfter($decl, $meth));
+  }
+
+  <<__Memoize>>
+  private static function getFunctionDeclarationHeader(
+    string $leading_whitespace,
+  ): FunctionDeclarationHeader {
+    $s = new NodeList(vec[new WhiteSpace(' ')]);
+    return new FunctionDeclarationHeader(
+      new NodeList(vec[
+        new ProtectedToken(
+          new NodeList(vec[new WhiteSpace($leading_whitespace)]),
+          $s,
+        ),
+        new StaticToken(null, $s),
+      ]),
+      new FunctionToken(null, $s),
+      new NameToken(null, null, 'getChildrenDeclaration'),
+      null,
+      new LeftParenToken(null, null),
+      null,
+      new RightParenToken(null, null),
+      new ColonToken(null, $s),
+      new SimpleTypeSpecifier(
+        new QualifiedName(
+          new NodeList(vec[
+            new ListItem(
+              new NameToken(null, null, 'XHPChild'),
+              new BackslashToken(null, null),
+            ),
+            new ListItem(new NameToken(null, $s, 'Constraint'), null),
+          ]),
+        ),
+      ),
+      null,
+    );
+  }
+
+  private static function convertChildrenExpression(
+    Node $in,
+  ): FunctionCallExpression {
+    if ($in is XHPChildrenParenthesizedList) {
+      $count = $in->getXhpChildren()->getCount();
+      invariant($count >= 1, "Got empty XHP children parenthesized list");
+      if ($count === 1) {
+        return self::convertChildrenExpression(
+          C\onlyx($in->getXhpChildren()->getChildrenOfItems()),
+        );
+      }
+      $children = Vec\map(
+        $in->getXhpChildren()->getChildrenOfItems(),
+        $node ==> self::convertChildrenExpression($node),
+      );
+      return self::makeCall('sequence', null, $children);
+      // TODO: tuple
+    }
+
+    if ($in is PostfixUnaryExpression) {
+      // TODO: ?+*
+      $op = $in->getOperator();
+      if ($op is PlusToken) {
+        $fun = 'atLeastOneOf';
+      } else if ($op is QuestionToken) {
+        $fun = 'optional';
+      } else if ($op is StarToken) {
+        $fun = 'anyNumberOf';
+      } else {
+        invariant_violation(
+          "Got an XHP postfix unary expression with unexpected operator '%s'",
+          $in->getOperator()->getText(),
+        );
+      }
+      return self::makeCall(
+        $fun,
+        null,
+        vec[self::convertChildrenExpression($in->getOperand())],
+      );
+    }
+
+    if ($in is BinaryExpression) {
+      invariant(
+        $in->getOperator() is BarToken,
+        "Got an XHP child binary expression with unexpected operator '%s'",
+        $in->getOperator()->getText(),
+      );
+      $next = $in;
+      $parts = vec[];
+      while ($next is BinaryExpression && $next->getOperator() is BarToken) {
+        $parts[] = $next->getRightOperand();
+        $next = $next->getLeftOperand();
+      }
+      $parts[] = $next;
+      $parts = Vec\reverse($parts)
+        |> Vec\map($parts, $part ==> self::convertChildrenExpression($part));
+      return self::makeCall('anyOf', null, $parts);
+    }
+
+    if ($in is NameExpression || $in is EmptyToken) {
+      $name = $in is NameExpression ? $in->getWrappedNode() : $in;
+      if (
+        $name is NameToken || $name is EmptyToken || $name is XHPClassNameToken
+      ) {
+        $name = $name->getText();
+        if ($name === 'pcdata' || $name === 'empty' || $name === 'any') {
+          return self::makeCall($name);
+        }
+
+        // Class name
+        return self::makeCall(
+          'ofType',
+          new TypeArguments(
+            new LessThanToken(null, null),
+            new NodeList(vec[
+              new ListItem(
+                new SimpleTypeSpecifier(
+                  $in is NameExpression ? $in->getWrappedNode() : $in,
+                ),
+                null,
+              ),
+            ]),
+            new GreaterThanToken(null, null),
+          ),
+        );
+      }
+
+      if ($name is XHPCategoryNameToken) {
+        return self::makeCall('category', null, vec[new LiteralExpression(
+          new SingleQuotedStringLiteralToken(
+            null,
+            null,
+            "'".$name->getText()."'",
+          ),
+        )]);
+      }
+
+      invariant_violation(
+        "Unhandled XHP child name type: %s",
+        \get_class($name),
+      );
+    }
+
+    invariant_violation(
+      "Unhandled XHP children expression: %s",
+      \get_class($in),
+    );
+  }
+
+  private static function makeCall(
+    string $name,
+    ?TypeArguments $generics = null,
+    vec<IExpression> $arguments = vec[],
+  ): FunctionCallExpression {
+    $sep = C\count($arguments) > 1
+      ? new CommaToken(null, new NodeList(vec[new WhiteSpace(' ')]))
+      : null;
+    return new FunctionCallExpression(
+      new QualifiedName(
+        new NodeList(vec[
+          new ListItem(
+            new NameToken(null, null, 'XHPChild'),
+            new BackslashToken(null, null),
+          ),
+          new ListItem(new NameToken(null, null, $name), null),
+        ]),
+      ),
+      $generics,
+      new LeftParenToken(null, null),
+      C\is_empty($arguments)
+        ? null
+        : new NodeList(Vec\map($arguments, $arg ==> new ListItem($arg, $sep))),
+      new RightParenToken(null, null),
+    );
+  }
+
+  <<__Override>>
+  public function getSteps(): Traversable<IMigrationStep> {
+    return vec[
+      new TypedMigrationStep(
+        'Add `use` statement to top level of file if needed',
+        Script::class,
+        Script::class,
+        $node ==> self::addUseNamespaceToScript($node),
+      ),
+      new TypedMigrationStep(
+        'Add `use` statement to namespace blocks as needed',
+        NamespaceDeclaration::class,
+        NamespaceDeclaration::class,
+        $node ==> self::addUseNamespaceToNamespaceBlock($node),
+      ),
+      new TypedMigrationStep(
+        'Add `getChildrenDeclaration()` method',
+        ClassishBody::class,
+        ClassishBody::class,
+        $node ==> self::addChildrenDeclarationMethod($node),
+      ),
+      // 4. add trait use
+    ];
+  }
+}

--- a/src/Migrations/XHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/XHPChildrenDeclarationMethodMigration.hack
@@ -266,6 +266,7 @@ final class XHPChildrenDeclarationMethodMigration extends StepBasedMigration {
     }
 
     if ($in is BinaryExpression) {
+      // foo | bar | baz
       invariant(
         $in->getOperator() is BarToken,
         "Got an XHP child binary expression with unexpected operator '%s'",
@@ -279,7 +280,7 @@ final class XHPChildrenDeclarationMethodMigration extends StepBasedMigration {
       }
       $parts[] = $next;
       $parts = Vec\reverse($parts)
-        |> Vec\map($parts, $part ==> self::convertChildrenExpression($part));
+        |> Vec\map($$, $part ==> self::convertChildrenExpression($part));
       return self::makeCall('anyOf', null, $parts);
     }
 

--- a/src/Migrations/XHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/XHPChildrenDeclarationMethodMigration.hack
@@ -16,9 +16,12 @@ final class XHPChildrenDeclarationMethodMigration extends StepBasedMigration {
     $classes = $in->getChildrenOfType(ClassishDeclaration::class);
     return C\any(
       $classes,
-      $class ==> $class->getBody()
-        ->getChildrenOfType(XHPChildrenDeclaration::class) !==
-        vec[],
+      $class ==> !C\is_empty(
+        $class->getBody()
+          ->getElements()
+          ?->getChildrenOfType(XHPChildrenDeclaration::class) ??
+          vec[],
+      ),
     );
   }
 

--- a/src/Migrations/XHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/XHPChildrenDeclarationMethodMigration.hack
@@ -242,11 +242,9 @@ final class XHPChildrenDeclarationMethodMigration extends StepBasedMigration {
         $node ==> self::convertChildrenExpression($node),
       );
       return self::makeCall('sequence', null, $children);
-      // TODO: tuple
     }
 
     if ($in is PostfixUnaryExpression) {
-      // TODO: ?+*
       $op = $in->getOperator();
       if ($op is PlusToken) {
         $fun = 'atLeastOneOf';

--- a/src/__Private/MigrationCLI.hack
+++ b/src/__Private/MigrationCLI.hack
@@ -24,6 +24,7 @@ use type Facebook\HHAST\{
   OptionalShapeFieldsMigration,
   PHPArrayLiteralsMigration,
   TopLevelRequiresMigration,
+  XHPChildrenDeclarationMethodMigration,
 };
 
 use type Facebook\CLILib\{CLIWithRequiredArguments, ExitException};
@@ -277,6 +278,13 @@ class MigrationCLI extends CLIWithRequiredArguments {
         },
         'Migrate [] and array() literals to varray[] and darray[]',
         '--php-arrays',
+      ),
+      CLIOptions\flag(
+        () ==> {
+          $this->migrations[] = XHPChildrenDeclarationMethodMigration::class;
+        },
+        'Add getChildrenDeclaration() method to XHP classes with a children declaration',
+        '--add-xhp-children-declaration-method',
       ),
       CLIOptions\flag(
         () ==> {

--- a/src/__Private/MigrationCLI.hack
+++ b/src/__Private/MigrationCLI.hack
@@ -13,6 +13,7 @@ use namespace Facebook\{HHAST, TypeAssert};
 use namespace HH\Lib\{C, Dict, Str, Vec};
 use type Facebook\HHAST\{
   AddFixmesMigration,
+  AddXHPChildrenDeclarationMethodMigration,
   BaseMigration,
   DollarBraceEmbeddedVariableMigration,
   ExplicitPartialModeMigration,
@@ -24,7 +25,6 @@ use type Facebook\HHAST\{
   OptionalShapeFieldsMigration,
   PHPArrayLiteralsMigration,
   TopLevelRequiresMigration,
-  XHPChildrenDeclarationMethodMigration,
 };
 
 use type Facebook\CLILib\{CLIWithRequiredArguments, ExitException};
@@ -281,7 +281,7 @@ class MigrationCLI extends CLIWithRequiredArguments {
       ),
       CLIOptions\flag(
         () ==> {
-          $this->migrations[] = XHPChildrenDeclarationMethodMigration::class;
+          $this->migrations[] = AddXHPChildrenDeclarationMethodMigration::class;
         },
         'Add getChildrenDeclaration() method to XHP classes with a children declaration',
         '--add-xhp-children-declaration-method',

--- a/src/__Private/codegen/CodegenBase.hack
+++ b/src/__Private/codegen/CodegenBase.hack
@@ -142,6 +142,10 @@ abstract class CodegenBase {
         HHAST\SingleLineComment::class,
         HHAST\DelimitedComment::class,
       ],
+      HHAST\IDeclaration::class => keyset[
+        HHAST\ClassishDeclaration::class,
+        // IFunctionishDeclaration
+      ],
       HHAST\IFunctionishDeclaration::class => keyset[
         HHAST\FunctionDeclaration::class,
         HHAST\MethodishDeclaration::class,

--- a/src/nodes/IDeclaration.hack
+++ b/src/nodes/IDeclaration.hack
@@ -9,6 +9,6 @@
 
 namespace Facebook\HHAST;
 
-interface IFunctionishDeclaration extends IHasFunctionBody, IDeclaration {
+interface IDeclaration {
   require extends Node;
 }

--- a/tests/AddXHPChildrenDeclarationMethodMigrationTest.hack
+++ b/tests/AddXHPChildrenDeclarationMethodMigrationTest.hack
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{Str, Vec};
+
+final class AddXHPChildrenDeclarationMethodMigrationTest
+  extends StepBasedMigrationTest {
+  const type TMigration = AddXHPChildrenDeclarationMethodMigration;
+
+  <<__Override>>
+  public function getExamples(): vec<(string)> {
+    return \glob(
+      __DIR__.'/examples/migrations/AddXHPChildrenDeclarationMethod/*.hack.in',
+    )
+      |> Vec\map(
+        $$,
+        $file ==> tuple(
+          Str\strip_suffix($file, '.in')
+            |> Str\strip_prefix($$, __DIR__.'/examples/'),
+        ),
+      );
+  }
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/basic_behavior.hack.expect
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/basic_behavior.hack.expect
@@ -1,0 +1,37 @@
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+class :empty-children {
+  use XHPChildDeclarationConsistencyValidation;
+  children empty;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\empty();
+  }
+
+}
+
+class :any-children {
+  use XHPChildDeclarationConsistencyValidation;
+  children any;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\any();
+  }
+
+}
+
+class :has-children {
+  use XHPChildDeclarationConsistencyValidation;
+  children (
+    pcdata,
+    (pcdata+, %flow)*,
+    :any_children?,
+    SomeOtherType,
+    (a | b | c)
+  );
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(XHPChild\pcdata(), XHPChild\anyNumberOf(XHPChild\sequence(XHPChild\atLeastOneOf(XHPChild\pcdata()), XHPChild\category('%flow'), )), XHPChild\optional(XHPChild\ofType<:any_children>()), XHPChild\ofType<SomeOtherType>(), XHPChild\anyOf(XHPChild\ofType<a>(), XHPChild\ofType<b>(), XHPChild\ofType<c>(), ), );
+  }
+
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/basic_behavior.hack.in
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/basic_behavior.hack.in
@@ -1,0 +1,17 @@
+class :empty-children {
+  children empty;
+}
+
+class :any-children {
+  children any;
+}
+
+class :has-children {
+  children (
+    pcdata,
+    (pcdata+, %flow)*,
+    :any_children?,
+    SomeOtherType,
+    (a | b | c)
+  );
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/leading_trivia.hack.expect
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/leading_trivia.hack.expect
@@ -1,0 +1,13 @@
+/** Foo bar baz */
+
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+class :has-children {
+  use XHPChildDeclarationConsistencyValidation;
+  children (foo, bar);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(XHPChild\ofType<foo>(), XHPChild\ofType<bar>(), );
+  }
+
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/leading_trivia.hack.in
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/leading_trivia.hack.in
@@ -1,0 +1,5 @@
+/** Foo bar baz */
+
+class :has-children {
+  children (foo, bar);
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/namespace_blocks.hack.expect
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/namespace_blocks.hack.expect
@@ -1,0 +1,26 @@
+namespace Foo {
+  // XHP not currently supported here
+}
+
+namespace { 
+  class :herp {
+  }
+}
+
+namespace Bar {
+  // XHP not currently supported here
+}
+
+namespace { 
+  use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+  class :derp {
+    use XHPChildDeclarationConsistencyValidation;
+    children (foo);
+
+    protected static function getChildrenDeclaration(): XHPChild\Constraint {
+        return XHPChild\ofType<foo>();
+    }
+
+  }
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/namespace_blocks.hack.in
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/namespace_blocks.hack.in
@@ -1,0 +1,18 @@
+namespace Foo {
+  // XHP not currently supported here
+}
+
+namespace { 
+  class :herp {
+  }
+}
+
+namespace Bar {
+  // XHP not currently supported here
+}
+
+namespace { 
+  class :derp {
+    children (foo);
+  }
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/no_children.hack.expect
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/no_children.hack.expect
@@ -1,0 +1,5 @@
+// Foo
+
+class bar {}
+
+class :baz {}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/no_children.hack.in
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/no_children.hack.in
@@ -1,0 +1,5 @@
+// Foo
+
+class bar {}
+
+class :baz {}


### PR DESCRIPTION
I'm not handling formatting: this is complicated enough that doing so feels like it would be reimplementing hackfmt in hhast. I'm expecting (and going to document) users should use `git diff | hackfmt --diff` after this.

In addition to the unit tests:

```
fredemmott@fredemmott-mm1 xhp-lib % gh pr status

Relevant pull requests in hhvm/xhp-lib

Current branch
  #217  Child validation: support `x:composable-element... [fredemmott:composable-element-children]
   - Checks passing
... snip ....
fredemmott@fredemmott-mm1 xhp-lib % ~/code/hhast/bin/hhast-migrate --add-xhp-children-declaration-method src
fredemmott@fredemmott-mm1 xhp-lib % hh_client
No errors!
fredemmott@fredemmott-mm1 xhp-lib % vendor/bin/hacktest tests
...............................................................................S.SSS.S.S.....................SSSS......SS....

Summary: 125 test(s), 113 passed, 0 failed, 12 skipped, 0 error(s).
fredemmott@fredemmott-mm1 xhp-lib % git diff src | gist --type patch
https://gist.github.com/9f28565846ca5f02f1eba5ccb3348e04
fredemmott@fredemmott-mm1 xhp-lib % git diff src | hackfmt --diff
No root specified, trying to guess one
Guessed root: /Users/fredemmott/code/xhp-lib
fredemmott@fredemmott-mm1 xhp-lib % git diff src | gist --type patch
https://gist.github.com/0b41410e20a36ea4be419be48cb8a5d8
```
