### PR TITLE
Add `hhast-migrate --xhp-class-modifier`

### DIFF
--- a/src/Migrations/XHPClassModifierMigration.hack
+++ b/src/Migrations/XHPClassModifierMigration.hack
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\Str;
+
+final class XHPClassModifierMigration extends StepBasedMigration {
+  private static function replaceXHPClassWithModifier(
+    ClassishDeclaration $in,
+  ): ClassishDeclaration {
+    if ($in->hasXhp()) {
+      return $in;
+    }
+
+    $name = $in->getName();
+    if (!$name is XHPClassNameToken) {
+      return $in;
+    }
+
+    $kw = $in->getKeyword();
+
+    $class = Str\strip_prefix($name->getText(), ':')
+      |> Str\replace($$, '-', '_');
+
+    return $in->withXhp(
+      new XHPToken($kw->getLeading(), new NodeList(vec[new WhiteSpace(' ')])),
+    )
+      ->withKeyword($kw->withLeading(null))
+      ->withName(
+        Str\contains($class, ':')
+          ? new XHPClassNameToken(
+              $name->getLeading(),
+              $name->getTrailing(),
+              $class,
+            )
+          : $name->withText($class),
+      );
+  }
+
+  <<__Override>>
+  public function getSteps(): Traversable<IMigrationStep> {
+    return vec[
+      new TypedMigrationStep(
+        'Replace `class :foo:bar` with `xhp class foo:bar`',
+        ClassishDeclaration::class,
+        ClassishDeclaration::class,
+        $node ==> self::replaceXHPClassWithModifier($node),
+      ),
+    ];
+  }
+}

--- a/src/__Private/MigrationCLI.hack
+++ b/src/__Private/MigrationCLI.hack
@@ -27,6 +27,7 @@ use type Facebook\HHAST\{
   PHPArrayLiteralsMigration,
   RemoveXHPChildDeclarationsMigration,
   TopLevelRequiresMigration,
+  XHPClassModifierMigration,
 };
 
 use type Facebook\CLILib\{CLIWithRequiredArguments, ExitException};
@@ -301,6 +302,13 @@ class MigrationCLI extends CLIWithRequiredArguments {
         },
         'Remove `children` declarations from XHP classes, and update validation traits',
         '--remove-xhp-child-declarations',
+      ),
+      CLIOptions\flag(
+        () ==> {
+          $this->migrations[] = XHPClassModifierMigration::class;
+        },
+        'Migrate `class :foo:bar` to `xhp class foo:bar`',
+        '--xhp-class-modifier',
       ),
       CLIOptions\flag(
         () ==> {

--- a/tests/XHPClassModifierMigrationTest.hack
+++ b/tests/XHPClassModifierMigrationTest.hack
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+
+final class XHPClassModifierMigrationTest extends StepBasedMigrationTest {
+  const type TMigration = XHPClassModifierMigration;
+
+  <<__Override>>
+  public function getExamples(): vec<(string)> {
+    return vec[tuple('migrations/xhp_class_modifier.hack')];
+  }
+}

--- a/tests/examples/migrations/xhp_class_modifier.hack.expect
+++ b/tests/examples/migrations/xhp_class_modifier.hack.expect
@@ -1,0 +1,7 @@
+xhp class simple {}
+xhp class with:colon {}
+xhp class with_hyphen {}
+xhp class with_hyphen:and_colon {}
+
+abstract xhp class abstract_xhp_class {}
+abstract /* foo */ xhp class with_trivia {}

--- a/tests/examples/migrations/xhp_class_modifier.hack.in
+++ b/tests/examples/migrations/xhp_class_modifier.hack.in
@@ -1,0 +1,7 @@
+class :simple {}
+class :with:colon {}
+class :with-hyphen {}
+class :with-hyphen:and-colon {}
+
+abstract class :abstract-xhp-class {}
+abstract /* foo */ class :with-trivia {}


### PR DESCRIPTION
`class :foo:bar` -> `xhp class foo:bar`

Also re-does the demangling as it's not a runtime change, and it is
required - really needs the separate `--demangle-xhp` migration first
though, as callsites also need to be changed.