### PR TITLE
Make the version error correct using \HHVM_VERSION

### DIFF
--- a/codegen/version.hack
+++ b/codegen/version.hack
@@ -1,10 +1,12 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ca9af36c1f9867e7412eebc1bc56ecab>>
+ * @generated SignedSource<<4fb5cf4d0865121cdcc3f0e902b53697>>
  */
 namespace Facebook\HHAST;
 
 const string SCHEMA_VERSION = '2020-04-14-0002';
 
-const int HHVM_VERSION_ID = 405400;
+const int HHVM_VERSION_ID = 405300;
+
+const string HHVM_VERSION = '4.53.0';

--- a/src/SchemaVersionError.hack
+++ b/src/SchemaVersionError.hack
@@ -17,11 +17,9 @@ final class SchemaVersionError extends ParseError {
       $targetFile,
       null,
       Str\format(
-        "AST version mismatch: expected '%s' (%d.%d.%d), but got '%s'",
+        "AST version mismatch: expected '%s' (%s), but got '%s'",
         SCHEMA_VERSION,
-        \intdiv(HHVM_VERSION_ID, 10000),
-        \intdiv(HHVM_VERSION_ID, 100) % 100,
-        HHVM_VERSION_ID % 100,
+        HHVM_VERSION,
         $version,
       ),
     );

--- a/src/SchemaVersionError.hack
+++ b/src/SchemaVersionError.hack
@@ -19,9 +19,9 @@ final class SchemaVersionError extends ParseError {
       Str\format(
         "AST version mismatch: expected '%s' (%d.%d.%d), but got '%s'",
         SCHEMA_VERSION,
-        \HHVM_VERSION_MAJOR,
-        \HHVM_VERSION_MINOR,
-        \HHVM_VERSION_PATCH,
+        \intdiv(HHVM_VERSION_ID, 10000),
+        \intdiv(HHVM_VERSION_ID, 100) % 100,
+        HHVM_VERSION_ID % 100,
         $version,
       ),
     );

--- a/src/SchemaVersionError.hack
+++ b/src/SchemaVersionError.hack
@@ -19,9 +19,9 @@ final class SchemaVersionError extends ParseError {
       Str\format(
         "AST version mismatch: expected '%s' (%d.%d.%d), but got '%s'",
         SCHEMA_VERSION,
-        \intdiv(HHVM_VERSION_ID, 10000),
-        \intdiv(HHVM_VERSION_ID, 100) % 100,
-        HHVM_VERSION_ID % 100,
+        \HHVM_VERSION_MAJOR,
+        \HHVM_VERSION_MINOR,
+        \HHVM_VERSION_PATCH,
         $version,
       ),
     );

--- a/src/__Private/codegen/CodegenVersion.hack
+++ b/src/__Private/codegen/CodegenVersion.hack
@@ -33,6 +33,11 @@ final class CodegenVersion extends CodegenBase {
           ->setType('int')
           ->setValue(\HHVM_VERSION_ID, HackBuilderValues::export()),
       )
+      ->addConstant(
+        $cg->codegenConstant('HHVM_VERSION')
+          ->setType('string')
+          ->setValue(\HHVM_VERSION, HackBuilderValues::export()),
+      )
       ->save();
   }
 }


### PR DESCRIPTION
before
AST version mismatch: expected '2020-04-06-0001' (40.53.0), but got '2020-04-14-0002

after
AST version mismatch: expected '2020-04-06-0001' (4.53.0), but got '2020-04-14-0002