### PR TITLE
Enable DataProviderTypesLinter

### DIFF
--- a/hhast-lint.json
+++ b/hhast-lint.json
@@ -15,12 +15,6 @@
       "disabledLinters": [
         "Facebook\\HHAST\\CamelCasedMethodsUnderscoredFunctionsLinter"
       ]
-    },
-    {
-      "patterns": ["tests/*"],
-      "extraLinters": [
-        "Facebook\\HHAST\\DataProviderTypesLinter"
-      ]
     }
   ]
 }

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -82,6 +82,7 @@ final class LintRunConfig {
     HHAST\PocketIdentifierExpressionLinter::class,
     HHAST\PocketEnumDeclarationLinter::class,
     HHAST\PreferRequireOnceLinter::class,
+    HHAST\DataProviderTypesLinter::class,
   ];
 
   const vec<classname<BaseLinter>> NON_DEFAULT_LINTERS = vec[


### PR DESCRIPTION
I forgot to enable this in my PR.
I have compiled a list of the lint errors across many oss libs.