### PR TITLE
Remove dead code typehint nodes never start with `?T`

### DIFF
--- a/src/Linters/DataProviderTypesLinter.hack
+++ b/src/Linters/DataProviderTypesLinter.hack
@@ -310,7 +310,6 @@ final class DataProviderTypesLinter extends AutoFixingASTLinter {
   }
 
   private static function isGeneric(string $string): bool {
-    return (Str\starts_with($string, 'T') || Str\starts_with($string, '?T')) &&
-      \ctype_alnum($string);
+    return (Str\starts_with($string, 'T')) && \ctype_alnum($string);
   }
 }

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.autofix.expect
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.autofix.expect
@@ -24,6 +24,7 @@ final class SomeTest extends HackTest {
   public function arg_1_string_arg_2_string(): vec<(string, string)> { invariant_violation('no typechecker'); }
   public function arg_1_t_arg_2_function_t_bool<T>(): vec<(T, (function(T): bool))> { invariant_violation('no typechecker'); }
   public function arg_1_mixed_arg_2_function_nothing_bool<T>(): vec<(mixed, (function(nothing): bool))> { invariant_violation('no typechecker'); }
+  public function arg_1_mixed_2(): vec<(mixed)> { invariant_violation('no typechecker'); }
 
   <<DataProvider('arg_1_mixed')>> // equal
   public function test_mixed_1(mixed $_): void { invariant_violation('no typechecker'); }
@@ -104,6 +105,14 @@ final class SomeTest extends HackTest {
   public function test_function_mixed_bool_mixed((function(mixed): bool) $_, mixed $_,): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_mixed_arg_2_function_nothing_bool')>> // equal
   public function test_mixed_function_nothing_bool(mixed $_, (function(nothing): bool) $_): void { invariant_violation('no typechecker'); }
+  // This is a false positive because of the way the nodes are being matched.
+  // Matching of types happens on a token level, not a type level.
+  // Ideally, `?T` would be treated like a wildcard, just like other generics.
+  // What actually happens is this:
+  // `?T` splits into two tokens, `?` and `T`.
+  // `mixed` is compared to `?` and `mixed` is not assignable to a question mark.
+  <<DataProvider('arg_1_mixed_2')>>
+  public function test_nullable_t<T>(?T $_): void { invariant_violation('no typechecker'); }
 }
 
 interface IFace extends Generic<mixed>{}

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.autofix.expect
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.autofix.expect
@@ -24,6 +24,7 @@ final class SomeTest extends HackTest {
   public function arg_1_string_arg_2_string(): vec<(string, string)> { invariant_violation('no typechecker'); }
   public function arg_1_t_arg_2_function_t_bool<T>(): vec<(T, (function(T): bool))> { invariant_violation('no typechecker'); }
   public function arg_1_mixed_arg_2_function_nothing_bool<T>(): vec<(mixed, (function(nothing): bool))> { invariant_violation('no typechecker'); }
+  public function arg_1_mixed_2(): vec<(mixed)> { invariant_violation('no typechecker'); }
 
   <<DataProvider('arg_1_mixed')>> // equal
   public function test_mixed_1(mixed $_): void { invariant_violation('no typechecker'); }
@@ -104,6 +105,8 @@ final class SomeTest extends HackTest {
   public function test_function_mixed_bool_mixed((function(mixed): bool) $_, mixed $_,): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_mixed_arg_2_function_nothing_bool')>> // equal
   public function test_mixed_function_nothing_bool(mixed $_, (function(nothing): bool) $_): void { invariant_violation('no typechecker'); }
+  <<DataProvider('arg_1_mixed_2')>>
+  public function test_nullable_t<T>(?T $_): void { invariant_violation('no typechecker'); }
 }
 
 interface IFace extends Generic<mixed>{}

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.autofix.expect
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.autofix.expect
@@ -24,7 +24,6 @@ final class SomeTest extends HackTest {
   public function arg_1_string_arg_2_string(): vec<(string, string)> { invariant_violation('no typechecker'); }
   public function arg_1_t_arg_2_function_t_bool<T>(): vec<(T, (function(T): bool))> { invariant_violation('no typechecker'); }
   public function arg_1_mixed_arg_2_function_nothing_bool<T>(): vec<(mixed, (function(nothing): bool))> { invariant_violation('no typechecker'); }
-  public function arg_1_mixed_2(): vec<(mixed)> { invariant_violation('no typechecker'); }
 
   <<DataProvider('arg_1_mixed')>> // equal
   public function test_mixed_1(mixed $_): void { invariant_violation('no typechecker'); }
@@ -105,8 +104,6 @@ final class SomeTest extends HackTest {
   public function test_function_mixed_bool_mixed((function(mixed): bool) $_, mixed $_,): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_mixed_arg_2_function_nothing_bool')>> // equal
   public function test_mixed_function_nothing_bool(mixed $_, (function(nothing): bool) $_): void { invariant_violation('no typechecker'); }
-  <<DataProvider('arg_1_mixed_2')>>
-  public function test_nullable_t<T>(?T $_): void { invariant_violation('no typechecker'); }
 }
 
 interface IFace extends Generic<mixed>{}

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.expect
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.expect
@@ -58,5 +58,10 @@
         "blame": "  public function arg_1_t_arg_2_function_t_bool<T>(): vec<(T, (function(T): bool))> ",
         "blame_pretty": "  public function arg_1_t_arg_2_function_t_bool<T>(): vec<(T, (function(T): bool))> ",
         "description": "Potential type error: Parameter 2 on method test_function_mixed_bool_mixed is of type mixed, but the DataProvider provides (function(T):bool)"
+    },
+    {
+        "blame": "  public function arg_1_mixed_2(): vec<(mixed)> ",
+        "blame_pretty": "  public function arg_1_mixed_2(): vec<(mixed)> ",
+        "description": "Potential type error: Parameter 1 on method test_nullable_t is of type ?T, but the DataProvider provides mixed"
     }
 ]

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.in
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.in
@@ -24,6 +24,7 @@ final class SomeTest extends HackTest {
   public function arg_1_string_arg_2_string(): vec<(string, string)> { invariant_violation('no typechecker'); }
   public function arg_1_t_arg_2_function_t_bool<T>(): vec<(T, (function(T): bool))> { invariant_violation('no typechecker'); }
   public function arg_1_mixed_arg_2_function_nothing_bool<T>(): vec<(mixed, (function(nothing): bool))> { invariant_violation('no typechecker'); }
+  public function arg_1_mixed_2(): vec<(mixed)> { invariant_violation('no typechecker'); }
 
   <<DataProvider('arg_1_mixed')>> // equal
   public function test_mixed_1(mixed $_): void { invariant_violation('no typechecker'); }
@@ -104,6 +105,14 @@ final class SomeTest extends HackTest {
   public function test_function_mixed_bool_mixed((function(mixed): bool) $_, mixed $_,): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_mixed_arg_2_function_nothing_bool')>> // equal
   public function test_mixed_function_nothing_bool(mixed $_, (function(nothing): bool) $_): void { invariant_violation('no typechecker'); }
+  // This is a false positive because of the way the nodes are being matched.
+  // Matching of types happens on a token level, not a type level.
+  // Ideally, `?T` would be treated like a wildcard, just like other generics.
+  // What actually happens is this:
+  // `?T` splits into two tokens, `?` and `T`.
+  // `mixed` is compared to `?` and `mixed` is not assignable to a question mark.
+  <<DataProvider('arg_1_mixed_2')>>
+  public function test_nullable_t<T>(?T $_): void { invariant_violation('no typechecker'); }
 }
 
 interface IFace extends Generic<mixed>{}

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.in
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.in
@@ -24,6 +24,7 @@ final class SomeTest extends HackTest {
   public function arg_1_string_arg_2_string(): vec<(string, string)> { invariant_violation('no typechecker'); }
   public function arg_1_t_arg_2_function_t_bool<T>(): vec<(T, (function(T): bool))> { invariant_violation('no typechecker'); }
   public function arg_1_mixed_arg_2_function_nothing_bool<T>(): vec<(mixed, (function(nothing): bool))> { invariant_violation('no typechecker'); }
+  public function arg_1_mixed_2(): vec<(mixed)> { invariant_violation('no typechecker'); }
 
   <<DataProvider('arg_1_mixed')>> // equal
   public function test_mixed_1(mixed $_): void { invariant_violation('no typechecker'); }
@@ -104,6 +105,8 @@ final class SomeTest extends HackTest {
   public function test_function_mixed_bool_mixed((function(mixed): bool) $_, mixed $_,): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_mixed_arg_2_function_nothing_bool')>> // equal
   public function test_mixed_function_nothing_bool(mixed $_, (function(nothing): bool) $_): void { invariant_violation('no typechecker'); }
+  <<DataProvider('arg_1_mixed_2')>>
+  public function test_nullable_t<T>(?T $_): void { invariant_violation('no typechecker'); }
 }
 
 interface IFace extends Generic<mixed>{}

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.in
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.in
@@ -24,7 +24,6 @@ final class SomeTest extends HackTest {
   public function arg_1_string_arg_2_string(): vec<(string, string)> { invariant_violation('no typechecker'); }
   public function arg_1_t_arg_2_function_t_bool<T>(): vec<(T, (function(T): bool))> { invariant_violation('no typechecker'); }
   public function arg_1_mixed_arg_2_function_nothing_bool<T>(): vec<(mixed, (function(nothing): bool))> { invariant_violation('no typechecker'); }
-  public function arg_1_mixed_2(): vec<(mixed)> { invariant_violation('no typechecker'); }
 
   <<DataProvider('arg_1_mixed')>> // equal
   public function test_mixed_1(mixed $_): void { invariant_violation('no typechecker'); }
@@ -105,8 +104,6 @@ final class SomeTest extends HackTest {
   public function test_function_mixed_bool_mixed((function(mixed): bool) $_, mixed $_,): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_mixed_arg_2_function_nothing_bool')>> // equal
   public function test_mixed_function_nothing_bool(mixed $_, (function(nothing): bool) $_): void { invariant_violation('no typechecker'); }
-  <<DataProvider('arg_1_mixed_2')>>
-  public function test_nullable_t<T>(?T $_): void { invariant_violation('no typechecker'); }
 }
 
 interface IFace extends Generic<mixed>{}


### PR DESCRIPTION
This ?T test never triggers, since `?` is its own token.
The means that `?Tk` explodes into `?` and `Tk`.
This caused a false positive while migrating hacktest.

```
DataProviderTypes: Potential type error: Parameter 1 on method testFilterNulls is of type
KeyedTraversable<Tk,?Tv>, but the DataProvider provides KeyedTraversable<mixed,mixed>
```

The rule is that you can assign anything to a generic, but `?Tv` destroys that.