### PR TITLE
Write a special exception for `mixed` assign to `?`

### DIFF
--- a/src/Linters/DataProviderTypesLinter.hack
+++ b/src/Linters/DataProviderTypesLinter.hack
@@ -291,7 +291,18 @@ final class DataProviderTypesLinter extends AutoFixingASTLinter {
         $to_text = $to[$i];
         if (!static::isGeneric($to_text)) {
           if ($to_text !== $from_text) {
-            return false;
+            // This is a special case which is very common in the hsl code.
+            // `mixed` assign to `?T` happens all the time.
+            // This way we skip over this typecheck.
+            // This will not allow things like this:
+            // `KeyedTraversable<mixed, mixed>` assign to `KeyedTraversable<?T, mixed>
+            // Since `?T` is one token longer than `mixed`.
+            // I also don't want to invert short circuit to true here,
+            // since `KeyedTraversable<mixed, mixed>` assign to `KeyedTraversable<?int, mixed>`
+            // should still report an error here.
+            if ($from_text !== 'mixed' || $to_text !== '?') {
+              return false;
+            }
           }
         }
       }

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.autofix.expect
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.autofix.expect
@@ -33,6 +33,8 @@ final class SomeTest extends HackTest {
   public function test_dynamic_1(dynamic $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_mixed_copy')>> // Special case where `mixed` assigns to `?` and no other type tokens are needed.
   public function test_nullable_t_1<T>(?T $_): void { invariant_violation('no typechecker'); }
+  <<DataProvider('arg_1_mixed_copy')>> // Even though `mixed` can assign to `?`, we look one token ahead and conclude that `mixed` does not assign to `int`.
+  public function test_nullable_int_1(?int $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_string')>> // equal
   public function test_string_1(string $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_string')>> // no subtyping

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.autofix.expect
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.autofix.expect
@@ -7,6 +7,7 @@ use function Facebook\FBExpect\expect;
 
 final class SomeTest extends HackTest {
   public function arg_1_mixed(): vec<(mixed)> { invariant_violation('no typechecker'); }
+  public function arg_1_mixed_copy(): vec<(mixed)> { invariant_violation('no typechecker'); }
   public function arg_1_string(): vec<(string)> { invariant_violation('no typechecker'); }
   public function arg_1_int(): vec<(int)> { invariant_violation('no typechecker'); }
   public function arg_1_arraykey(): vec<(arraykey)> { invariant_violation('no typechecker'); }
@@ -17,6 +18,7 @@ final class SomeTest extends HackTest {
   public function arg_1_generic_t<T>(): vec<(Generic<T>)> { invariant_violation('no typechecker'); }
   public function arg_1_generic_nothing(): vec<(Generic<nothing>)> { invariant_violation('no typechecker'); }
   public function arg_1_generics_mixed_mixed(): vec<(Generics<mixed, mixed>)> { invariant_violation('no typechecker'); }
+  public function arg_1_generics_mixed_string(): vec<(Generics<mixed, string>)> { invariant_violation('no typechecker'); }
   public function arg_1_generics_t1_t2<T1, T2>(): vec<(Generics<T1, T2>)> { invariant_violation('no typechecker'); }
   public function arg_1_empty_shape(): vec<(shape())> { invariant_violation('no typechecker'); }
   public function arg_1_shape_key_herp_value_string(): vec<(shape('herp' => string))> { invariant_violation('no typechecker'); }
@@ -29,6 +31,8 @@ final class SomeTest extends HackTest {
   public function test_mixed_1(mixed $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_mixed')>> // no idea of dynamic
   public function test_dynamic_1(dynamic $_): void { invariant_violation('no typechecker'); }
+  <<DataProvider('arg_1_mixed_copy')>> // Special case where `mixed` assigns to `?` and no other type tokens are needed.
+  public function test_nullable_t_1<T>(?T $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_string')>> // equal
   public function test_string_1(string $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_string')>> // no subtyping
@@ -68,6 +72,8 @@ final class SomeTest extends HackTest {
   public function test_generic_ta_tb_1<Ta, Tb>(Generics<Ta, Tb> $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_generics_mixed_mixed')>> // not a Generics
   public function test_mixed_3<T1, T2>(mixed $_): void { invariant_violation('no typechecker'); }
+  <<DataProvider('arg_1_generics_mixed_string')>> // Even though `mixed` is allowed to match `?`, the compare should continue.
+  public function test_mixed_3<T>(Generics<?T, int> $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_generics_t1_t2')>> // ignored generics
   public function test_generic_t1_t2_2<T1, T2>(Generics<T1, T2> $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_generics_t1_t2')>> // ignored generics

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.expect
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.expect
@@ -5,6 +5,11 @@
         "description": "Potential type error: Parameter 1 on method test_dynamic_1 is of type dynamic, but the DataProvider provides mixed"
     },
     {
+        "blame": "  public function arg_1_mixed_copy(): vec<(mixed)> ",
+        "blame_pretty": "  public function arg_1_mixed_copy(): vec<(mixed)> ",
+        "description": "Potential type error: Parameter 1 on method test_nullable_int_1 is of type ?int, but the DataProvider provides mixed"
+    },
+    {
         "blame": "  public function arg_1_string(): vec<(string)> ",
         "blame_pretty": "  public function arg_1_string(): vec<(string)> ",
         "description": "Potential type error: Parameter 1 on method test_mixed_2 is of type mixed, but the DataProvider provides string"

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.expect
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.expect
@@ -32,7 +32,12 @@
     {
         "blame": "  public function arg_1_generics_mixed_mixed(): vec<(Generics<mixed, mixed>)> ",
         "blame_pretty": "  public function arg_1_generics_mixed_mixed(): vec<(Generics<mixed, mixed>)> ",
-        "description": "Potential type error: Parameter 1 on method test_mixed_3 is of type mixed, but the DataProvider provides Generics<mixed,mixed>"
+        "description": "Potential type error: Parameter 1 on method test_mixed_3 is of type Generics<?T,int>, but the DataProvider provides Generics<mixed,mixed>"
+    },
+    {
+        "blame": "  public function arg_1_generics_mixed_string(): vec<(Generics<mixed, string>)> ",
+        "blame_pretty": "  public function arg_1_generics_mixed_string(): vec<(Generics<mixed, string>)> ",
+        "description": "Potential type error: Parameter 1 on method test_mixed_3 is of type Generics<?T,int>, but the DataProvider provides Generics<mixed,string>"
     },
     {
         "blame": "  public function arg_1_generics_t1_t2<T1, T2>(): vec<(Generics<T1, T2>)> ",

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.in
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.in
@@ -33,6 +33,8 @@ final class SomeTest extends HackTest {
   public function test_dynamic_1(dynamic $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_mixed_copy')>> // Special case where `mixed` assigns to `?` and no other type tokens are needed.
   public function test_nullable_t_1<T>(?T $_): void { invariant_violation('no typechecker'); }
+  <<DataProvider('arg_1_mixed_copy')>> // Even though `mixed` can assign to `?`, we look one token ahead and conclude that `mixed` does not assign to `int`.
+  public function test_nullable_int_1(?int $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_string')>> // equal
   public function test_string_1(string $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_string')>> // no subtyping

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.in
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.in
@@ -7,6 +7,7 @@ use function Facebook\FBExpect\expect;
 
 final class SomeTest extends HackTest {
   public function arg_1_mixed(): vec<(mixed)> { invariant_violation('no typechecker'); }
+  public function arg_1_mixed_copy(): vec<(mixed)> { invariant_violation('no typechecker'); }
   public function arg_1_string(): vec<(string)> { invariant_violation('no typechecker'); }
   public function arg_1_int(): vec<(int)> { invariant_violation('no typechecker'); }
   public function arg_1_arraykey(): vec<(arraykey)> { invariant_violation('no typechecker'); }
@@ -17,6 +18,7 @@ final class SomeTest extends HackTest {
   public function arg_1_generic_t<T>(): vec<(Generic<T>)> { invariant_violation('no typechecker'); }
   public function arg_1_generic_nothing(): vec<(Generic<nothing>)> { invariant_violation('no typechecker'); }
   public function arg_1_generics_mixed_mixed(): vec<(Generics<mixed, mixed>)> { invariant_violation('no typechecker'); }
+  public function arg_1_generics_mixed_string(): vec<(Generics<mixed, string>)> { invariant_violation('no typechecker'); }
   public function arg_1_generics_t1_t2<T1, T2>(): vec<(Generics<T1, T2>)> { invariant_violation('no typechecker'); }
   public function arg_1_empty_shape(): vec<(shape())> { invariant_violation('no typechecker'); }
   public function arg_1_shape_key_herp_value_string(): vec<(shape('herp' => string))> { invariant_violation('no typechecker'); }
@@ -29,6 +31,8 @@ final class SomeTest extends HackTest {
   public function test_mixed_1(mixed $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_mixed')>> // no idea of dynamic
   public function test_dynamic_1(dynamic $_): void { invariant_violation('no typechecker'); }
+  <<DataProvider('arg_1_mixed_copy')>> // Special case where `mixed` assigns to `?` and no other type tokens are needed.
+  public function test_nullable_t_1<T>(?T $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_string')>> // equal
   public function test_string_1(string $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_string')>> // no subtyping
@@ -68,6 +72,8 @@ final class SomeTest extends HackTest {
   public function test_generic_ta_tb_1<Ta, Tb>(Generics<Ta, Tb> $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_generics_mixed_mixed')>> // not a Generics
   public function test_mixed_3<T1, T2>(mixed $_): void { invariant_violation('no typechecker'); }
+  <<DataProvider('arg_1_generics_mixed_string')>> // Even though `mixed` is allowed to match `?`, the compare should continue.
+  public function test_mixed_3<T>(Generics<?T, int> $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_generics_t1_t2')>> // ignored generics
   public function test_generic_t1_t2_2<T1, T2>(Generics<T1, T2> $_): void { invariant_violation('no typechecker'); }
   <<DataProvider('arg_1_generics_t1_t2')>> // ignored generics


### PR DESCRIPTION
https://github.com/hhvm/hsl/pull/132#discussion_r411768035

> I think the right fix here would be to add a special case to the linter so that it understands that mixed can match a nullable type (mixed is the only type that can, so this would be just that one special case).
> 
> The function is typed as generic `?T`, I don't think we want to change that to `mixed`.
>

