### PR TITLE
Audit uses of writeAsync()

### DIFF
--- a/src/__Private/CodegenCLI.hack
+++ b/src/__Private/CodegenCLI.hack
@@ -55,7 +55,7 @@ final class CodegenCLI extends CLIBase {
     if ($rebuild_relationships) {
       $hhvm = $this->hhvmPath;
       if ($hhvm === null) {
-        await $this->getStderr()->writeAsync(
+        await $this->getStderr()->writeAllAsync(
           "--hhvm-path is required when rebuilding relationships.\n",
         );
         return 1;

--- a/src/__Private/Inspector/InspectorCLI.hack
+++ b/src/__Private/Inspector/InspectorCLI.hack
@@ -49,13 +49,13 @@ final class InspectorCLI extends CLIWithRequiredArguments {
   public async function mainAsync(): Awaitable<int> {
     $err = $this->getStderr();
     if (C\count($this->getArguments()) !== 1) {
-      await $err->writeAsync("Provide exactly one file name\n");
+      await $err->writeAllAsync("Provide exactly one file name\n");
       return 1;
     }
 
     $input = C\onlyx($this->getArguments());
     if (!\is_file($input)) {
-      await $err->writeAsync("Provided path is not a file.\n");
+      await $err->writeAllAsync("Provided path is not a file.\n");
       return 1;
     }
 
@@ -78,7 +78,7 @@ final class InspectorCLI extends CLIWithRequiredArguments {
 
     if ($this->open) {
       if (!self::openFileInBrowser($output)) {
-        await $err->writeAsync("We failed to open your browser.\n");
+        await $err->writeAllAsync("We failed to open your browser.\n");
       }
     }
 

--- a/src/__Private/LSPImpl/Client.hack
+++ b/src/__Private/LSPImpl/Client.hack
@@ -29,7 +29,7 @@ final class Client extends LSPLib\Client {
       await $tail;
       await $this->terminal
         ->getStdout()
-        ->writeAsync(
+        ->writeAllAsync(
           Str\format("Content-Length: %d\r\n\r\n%s", Str\length($json), $json),
         );
     };

--- a/src/__Private/LSPImpl/Server.hack
+++ b/src/__Private/LSPImpl/Server.hack
@@ -93,7 +93,7 @@ final class Server extends LSPLib\Server<ServerState> {
       }
       await $this->terminal
         ->getStderr()
-        ->writeAsync($message);
+        ->writeAllAsync($message);
       throw $e;
     }
     return 0;
@@ -108,15 +108,15 @@ final class Server extends LSPLib\Server<ServerState> {
       async {
         while (!$this->input->isEndOfFile()) {
           /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
-          await $verbose?->writeAsync("< [waiting]\n");
+          await $verbose?->writeAllAsync("< [waiting]\n");
           /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
           $body = await $this->readMessageAsync();
           /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
-          await $verbose?->writeAsync("> [dispatch]\n");
+          await $verbose?->writeAllAsync("> [dispatch]\n");
           $poll->add(async {
-            await $verbose?->writeAsync("> [start]\n");
+            await $verbose?->writeAllAsync("> [start]\n");
             await $this->handleMessageAsync($body);
-            await $verbose?->writeAsync("> [done]\n");
+            await $verbose?->writeAllAsync("> [done]\n");
           });
         }
       },

--- a/src/__Private/LintRunCLIEventHandler.hack
+++ b/src/__Private/LintRunCLIEventHandler.hack
@@ -64,7 +64,7 @@ final class LintRunCLIEventHandler implements LintRunEventHandler {
       /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
       await $this->terminal
         ->getStdout()
-        ->writeAsync(Str\format(
+        ->writeAllAsync(Str\format(
           "%s%s%s\n"."  %sLinter: %s%s\n"."  Location: %s\n",
           $colors ? "\e[1;31m" : '',
           $error->getDescription(),
@@ -119,7 +119,7 @@ final class LintRunCLIEventHandler implements LintRunEventHandler {
     LintRunResult $result,
   ): Awaitable<void> {
     if ($result === LintRunResult::NO_ERRORS) {
-      await $this->terminal->getStdout()->writeAsync("No errors.\n");
+      await $this->terminal->getStdout()->writeAllAsync("No errors.\n");
     }
   }
 
@@ -153,11 +153,11 @@ final class LintRunCLIEventHandler implements LintRunEventHandler {
     if ($this->terminal->supportsColors()) {
       await $this->terminal
         ->getStdout()
-        ->writeAsync(CLIColoredUnifiedDiff::create($old, $new));
+        ->writeAllAsync(CLIColoredUnifiedDiff::create($old, $new));
     } else {
       await $this->terminal
         ->getStdout()
-        ->writeAsync(StringDiff::lines($old, $new)->getUnifiedDiff());
+        ->writeAllAsync(StringDiff::lines($old, $new)->getUnifiedDiff());
     }
 
     if (!$this->terminal->isInteractive()) {
@@ -169,7 +169,7 @@ final class LintRunCLIEventHandler implements LintRunEventHandler {
       $should_fix = $this->userResponseCache[$cache_key];
       await $this->terminal
         ->getStdout()
-        ->writeAsync(Str\format(
+        ->writeAllAsync(Str\format(
           "Would you like to apply this fix?\n  <%s to all>\n",
           $should_fix ? 'yes' : 'no',
         ));
@@ -181,7 +181,7 @@ final class LintRunCLIEventHandler implements LintRunEventHandler {
       /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
       await $this->terminal
         ->getStdout()
-        ->writeAsync(
+        ->writeAllAsync(
           "\e[94mWould you like to apply this fix?\e[0m\n".
           "  \e[37m[y]es/[n]o/yes to [a]ll/n[o] to all:\e[0m ",
         );
@@ -204,7 +204,7 @@ final class LintRunCLIEventHandler implements LintRunEventHandler {
           /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
           await $this->terminal
             ->getStderr()
-            ->writeAsync(
+            ->writeAllAsync(
               Str\format("'%s' is not a valid response.\n", $response),
             );
           $response = null;
@@ -224,7 +224,7 @@ final class LintRunCLIEventHandler implements LintRunEventHandler {
     $colors = $this->terminal->supportsColors();
     await $this->terminal
       ->getStdout()
-      ->writeAsync(Str\format(
+      ->writeAllAsync(Str\format(
         "  Code:\n%s%s%s\n",
         $colors ? "\e[33m" : '',
         Str\split($blame, "\n")

--- a/src/__Private/LintRunJSONEventHandler.hack
+++ b/src/__Private/LintRunJSONEventHandler.hack
@@ -61,7 +61,7 @@ final class LintRunJSONEventHandler implements LintRunEventHandler {
   public async function finishedRunAsync(LintRunResult $_): Awaitable<void> {
     await $this->terminal
       ->getStdout()
-      ->writeAsync(\json_encode($this->getOutput()));
+      ->writeAllAsync(\json_encode($this->getOutput()));
   }
 
   private function getOutput(): self::TOutput {

--- a/src/__Private/LinterCLI.hack
+++ b/src/__Private/LinterCLI.hack
@@ -82,10 +82,10 @@ final class LinterCLI extends CLIWithArguments {
           $dotfile,
           \HH\Lib\File\WriteMode::TRUNCATE,
         );
-        await $file->writeAsync($dot);
+        await $file->writeAllAsync($dot);
         $file->close();
         await $this->getStderr()
-          ->writeAsync(Str\format("Wrote XHProf data to %s\n", $dotfile));
+          ->writeAllAsync(Str\format("Wrote XHProf data to %s\n", $dotfile));
       }
     }
 
@@ -105,7 +105,7 @@ final class LinterCLI extends CLIWithArguments {
       $config = LintRunConfig::getForPath(\getcwd());
       $roots = $config->getRoots();
       if (C\is_empty($roots)) {
-        await $err->writeAsync(
+        await $err->writeAllAsync(
           'You must either specify PATH arguments, or provide a configuration'.
           "file.\n",
         );
@@ -118,7 +118,7 @@ final class LinterCLI extends CLIWithArguments {
           $config_file = $path.'/hhast-lint.json';
           if (\file_exists($config_file)) {
             /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
-            await $err->writeAsync(
+            await $err->writeAllAsync(
               'Warning: PATH arguments contain a hhast-lint.json, '.
               'which modifies the linters used and customizes behavior. '.
               "Consider 'cd ".
@@ -150,7 +150,7 @@ final class LinterCLI extends CLIWithArguments {
       $orig = $e->getPrevious() ?? $e;
       $err = $terminal->getStderr();
       $pos = $e->getPosition();
-      await $err->writeAsync(Str\format(
+      await $err->writeAllAsync(Str\format(
         "A linter threw an exception:\n  Linter: %s\n  File: %s%s\n",
         $e->getLinterClass(),
         \realpath($e->getFileBeingLinted()),
@@ -166,15 +166,15 @@ final class LinterCLI extends CLIWithArguments {
           |> Vec\map($$, $line ==> '    > '.$line)
           |> Str\join($$, "\n")
           |> Str\format("%s\n      %s^ HERE\n", $$, Str\repeat(' ', $column))
-          |> $err->writeAsync($$)
+          |> $err->writeAllAsync($$)
         );
       }
-      await $err->writeAsync(Str\format(
+      await $err->writeAllAsync(Str\format(
         "  Exception: %s\n"."  Message: %s\n",
         \get_class($orig),
         $orig->getMessage(),
       ));
-      await $err->writeAsync(
+      await $err->writeAllAsync(
         $orig->getTraceAsString()
           |> Str\split($$, "\n")
           |> Vec\map($$, $line ==> '    '.$line)

--- a/src/__Private/MigrationCLI.hack
+++ b/src/__Private/MigrationCLI.hack
@@ -368,7 +368,7 @@ class MigrationCLI extends CLIWithRequiredArguments {
       $ast = \HH\Asio\join(HHAST\from_file_async(HHAST\File::fromPath($file)));
     } catch (\Facebook\HHAST\ASTError $e) {
       /*HHAST_FIXME[DontUseAsioJoin]*/
-      \HH\Asio\join($this->getStderr()->writeAsync($e->getMessage()));
+      \HH\Asio\join($this->getStderr()->writeAllAsync($e->getMessage()));
       return;
     }
     foreach ($migrations as $migration) {
@@ -468,14 +468,14 @@ class MigrationCLI extends CLIWithRequiredArguments {
   private async function mainImplAsync(): Awaitable<int> {
     $err = $this->getStderr();
     if (C\is_empty($this->migrations)) {
-      await $err->writeAsync("You must specify at least one migration!\n\n");
+      await $err->writeAllAsync("You must specify at least one migration!\n\n");
       $this->displayHelp($err);
       return 1;
     }
 
     $args = $this->getArguments();
     if (C\is_empty($args)) {
-      await $err->writeAsync("You must specify at least one path!\n\n");
+      await $err->writeAllAsync("You must specify at least one path!\n\n");
       $this->displayHelp($err);
       return 1;
     }
@@ -488,7 +488,7 @@ class MigrationCLI extends CLIWithRequiredArguments {
         \version_compare(\HHVM_VERSION, $min_version, '<')
       ) {
         /* HHAST_IGNORE_ERROR[DontAwaitInALoop] we quit after doing this once */
-        await $err->writeAsync(Str\format(
+        await $err->writeAllAsync(Str\format(
           "Migration %s requires HHVM version %s or newer.\n",
           $migration,
           $min_version,
@@ -501,7 +501,7 @@ class MigrationCLI extends CLIWithRequiredArguments {
       foreach ($config_options as $option => $value) {
         if ($all_config_options[$option] !== $value) {
           /* HHAST_IGNORE_ERROR[DontAwaitInALoop] same as above */
-          await $err->writeAsync(Str\format(
+          await $err->writeAllAsync(Str\format(
             'Migration %s requires .hhconfig option %s=%s which conflicts '.
             "with another migration.\n",
             $migration,
@@ -544,7 +544,7 @@ class MigrationCLI extends CLIWithRequiredArguments {
         }
 
         /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
-        await $err->writeAsync(
+        await $err->writeAllAsync(
           Str\format("Don't know how to process path: %s\n", $path),
         );
         return 1;

--- a/tests/LSPServerTest.hack
+++ b/tests/LSPServerTest.hack
@@ -130,7 +130,7 @@ final class LSPServerTest extends TestCase {
             \fprintf(\STDERR, "< %s\n", $message);
           }
           /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
-          await $inw->writeAsync(
+          await $inw->writeAllAsync(
             'Content-Length: '.Str\length($message)."\r\n\r\n".$message,
           );
           switch ($behavior) {


### PR DESCRIPTION
closes #305
fixes #305

I have ctrl+f'ed the codebase and replaced writeAsync() with writeAllAsync() if at least one criterion is met:
 - This is output intended for the programmer in the CLI (messages should be completed).
 - This is clearly English text (sentences should be completed).
 - This is sent in a context where the byte count matters (lsp has a concept of content length, missing bytes could end up garbling the communication)
 - This is JSON (incomplete JSON is not parse-able).

I was left with one use that I can't audit with my current knowledge.
https://github.com/hhvm/hhast/pull/309/files#diff-02a3273e73a8a328d589c683a48465b6R85