### PR TITLE
migrations for array typehints

### DIFF
--- a/src/Migrations/HardenVarrayOrDarrayTypehintsMigration.hack
+++ b/src/Migrations/HardenVarrayOrDarrayTypehintsMigration.hack
@@ -17,16 +17,22 @@ final class HardenVarrayOrDarrayTypehintsMigration extends StepBasedMigration {
   public function getSteps(): Traversable<IMigrationStep> {
     return vec[
       new TypedMigrationStep(
-        'Migrate varray_or_array parameters',
+        'Migrate varray_or_darray parameters',
         ParameterDeclaration::class,
         ParameterDeclaration::class,
         $node ==> self::migrateParameter($node),
       ),
       new TypedMigrationStep(
-        'Migrate varray_or_array return types',
+        'Migrate varray_or_darray return types',
         FunctionDeclarationHeader::class,
         FunctionDeclarationHeader::class,
         $node ==> $node->withType(self::migrateReturnType($node->getType())),
+      ),
+      new TypedMigrationStep(
+        'Migrate varray_or_darray return types in lambda functions',
+        LambdaSignature::class,
+        LambdaSignature::class,
+        $node ==> $node->withType(static::migrateReturnType($node->getType())),
       ),
     ];
   }

--- a/src/Migrations/HardenVarrayOrDarrayTypehintsMigration.hack
+++ b/src/Migrations/HardenVarrayOrDarrayTypehintsMigration.hack
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\C;
+
+final class HardenVarrayOrDarrayTypehintsMigration extends StepBasedMigration {
+
+  <<__Override>>
+  public function getSteps(): Traversable<IMigrationStep> {
+    return vec[
+      new TypedMigrationStep(
+        'Migrate varray_or_array parameters',
+        ParameterDeclaration::class,
+        ParameterDeclaration::class,
+        $node ==> self::migrateParameter($node),
+      ),
+      new TypedMigrationStep(
+        'Migrate varray_or_array return types',
+        FunctionDeclarationHeader::class,
+        FunctionDeclarationHeader::class,
+        $node ==> $node->withType(self::migrateReturnType($node->getType())),
+      ),
+    ];
+  }
+
+  private static function migrateParameter(
+    ParameterDeclaration $param,
+  ): ParameterDeclaration {
+    list($attr, $type) = static::migrate(
+      $param->getAttribute(),
+      $param->getType(),
+    );
+    return $param->withAttribute($attr)->withType($type);
+  }
+
+  private static function migrateReturnType(
+    ?ITypeSpecifier $type,
+  ): ?ITypeSpecifier {
+    $wrapper = null;
+    if ($type is AttributizedSpecifier) {
+      $wrapper = $type;
+      $type = $type->getType();
+    }
+    list($attr, $type) = static::migrate($wrapper?->getAttributeSpec(), $type);
+    return $wrapper is null || $attr is null || $type is null
+      ? $type
+      : $wrapper->withAttributeSpec($attr)->withType($type);
+  }
+
+  /**
+   * Shared part of migrateParameter() and migrateReturnType().
+   */
+  private static function migrate(
+    ?OldAttributeSpecification $old_attr_spec,
+    ?ITypeSpecifier $type,
+  ): (?OldAttributeSpecification, ?ITypeSpecifier) {
+    if ($type is GenericTypeSpecifier) {
+      $name = $type->getClassType();
+      if ($name is NameToken && $name->getText() === 'varray_or_darray') {
+        $new_attr_spec = self::removeSoft($old_attr_spec);
+        if ($old_attr_spec is nonnull && $new_attr_spec is null) {
+          // The whole attribute spec is being removed. Preserve whitespace and
+          // comments by concatenating trivia from before $old_attr_spec, after
+          // $old_attr_spec, and before $type.
+          $between = NodeList::concat(
+            $old_attr_spec->getLastTokenx()->getTrailing(),
+            $type->getFirstTokenx()->getLeading(),
+          );
+          // Common edge case: Single space between <<__Soft>> varray_or_darray
+          // should be removed.
+          if (
+            $between->getCount() === 1 &&
+            C\onlyx($between->getChildren())->getText() === ' '
+          ) {
+            $between = NodeList::createMaybeEmptyList(vec[]);
+          }
+          $type = $type->replaceDescendant(
+            $type->getFirstTokenx(),
+            $type->getFirstTokenx()->withLeading(
+              NodeList::concat(
+                $old_attr_spec->getFirstTokenx()->getLeading(),
+                $between,
+              ),
+            ),
+          );
+        }
+        return tuple($new_attr_spec, $type);
+      }
+    }
+    return tuple($old_attr_spec, $type);
+  }
+
+  private static function removeSoft(
+    ?OldAttributeSpecification $attr_spec,
+  ): ?OldAttributeSpecification {
+    if ($attr_spec is null) {
+      return null;
+    }
+    $attrs = $attr_spec->getAttributes()->filterChildren(
+      $item ==> {
+        $name = $item->getItem()->getType();
+        if ($name is NameToken && $name->getText() === '__Soft') {
+          return false;
+        }
+        return true;
+      },
+    );
+    if ($attrs->isEmpty()) {
+      return null;
+    }
+    return $attr_spec->withAttributes($attrs);
+  }
+}

--- a/src/Migrations/PHPArrayTypehintsMigrationBase.hack
+++ b/src/Migrations/PHPArrayTypehintsMigrationBase.hack
@@ -26,6 +26,12 @@ abstract class PHPArrayTypehintsMigrationBase extends StepBasedMigration {
         FunctionDeclarationHeader::class,
         $node ==> $node->withType(static::migrateReturnType($node->getType())),
       ),
+      new TypedMigrationStep(
+        'Migrate array return types in lambda functions',
+        LambdaSignature::class,
+        LambdaSignature::class,
+        $node ==> $node->withType(static::migrateReturnType($node->getType())),
+      ),
     ];
   }
 

--- a/src/Migrations/PHPArrayTypehintsMigrationBase.hack
+++ b/src/Migrations/PHPArrayTypehintsMigrationBase.hack
@@ -1,0 +1,179 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+abstract class PHPArrayTypehintsMigrationBase extends StepBasedMigration {
+
+  <<__Override>>
+  public function getSteps(): Traversable<IMigrationStep> {
+    return vec[
+      new TypedMigrationStep(
+        'Migrate array parameters',
+        ParameterDeclaration::class,
+        ParameterDeclaration::class,
+        $node ==> static::migrateParameter($node),
+      ),
+      new TypedMigrationStep(
+        'Migrate array return types',
+        FunctionDeclarationHeader::class,
+        FunctionDeclarationHeader::class,
+        $node ==> $node->withType(static::migrateReturnType($node->getType())),
+      ),
+    ];
+  }
+
+  final protected static function migrateParameter(
+    ParameterDeclaration $param,
+  ): ParameterDeclaration {
+    if (!$param->hasType()) {
+      return $param;
+    }
+    list($attr, $type) =
+      static::migrate($param->getAttribute(), $param->getTypex());
+    return $param->withAttribute($attr)->withType($type);
+  }
+
+  final protected static function migrateReturnType(
+    ?ITypeSpecifier $type,
+  ): ?ITypeSpecifier {
+    if ($type is null) {
+      return null;
+    }
+    $wrapper = null;
+    if ($type is AttributizedSpecifier) {
+      $wrapper = $type;
+      $type = $type->getType();
+    }
+    list($attr, $type) = static::migrate($wrapper?->getAttributeSpec(), $type);
+    if ($attr is nonnull && $wrapper is null) {
+      return new AttributizedSpecifier($attr, $type);
+    }
+    return $wrapper is nonnull
+      ? $wrapper->withAttributeSpec($attr as nonnull)->withType($type)
+      : $type;
+  }
+
+  /**
+   * Shared part of migrateParameter() and migrateReturnType().
+   */
+  final protected static function migrate(
+    ?OldAttributeSpecification $attr_spec,
+    ITypeSpecifier $type,
+  ): (?OldAttributeSpecification, ITypeSpecifier) {
+    if ($type is null) {
+      return tuple($attr_spec, $type);
+    }
+
+    if (
+      ($type is VectorArrayTypeSpecifier || $type is MapArrayTypeSpecifier) &&
+      static::shouldAddSoft()
+    ) {
+      if ($attr_spec is null) {
+        // move trivia from the old first token to the new first token
+        $ft = $type->getFirstTokenx();
+        $type = $type->replaceDescendant($ft, $ft->withLeading(null));
+        $attr_spec = new OldAttributeSpecification(
+          new LessThanLessThanToken($ft->getLeading(), null),
+          NodeList::createMaybeEmptyList(vec[]),
+          new GreaterThanGreaterThanToken(
+            null,
+            NodeList::createMaybeEmptyList(vec[new WhiteSpace(' ')]),
+          ),
+        );
+      }
+      $attr_spec = static::addSoft($attr_spec);
+    }
+
+    $type = $type->rewrite(
+      ($node, $_) ==> {
+        if ($node is VectorArrayTypeSpecifier) {
+          return static::migrateVectorArray($node);
+        } else if ($node is MapArrayTypeSpecifier) {
+          return static::migrateMapArray($node);
+        } else {
+          return $node;
+        }
+      },
+      vec[],
+    ) as ITypeSpecifier;
+
+    return tuple($attr_spec, $type);
+  }
+
+  final protected static function addSoft(
+    OldAttributeSpecification $attr_spec,
+  ): OldAttributeSpecification {
+    foreach ($attr_spec->getAttributes()->getChildrenOfItems() as $attr) {
+      $name = $attr->getType();
+      if ($name is NameToken && $name->getText() === '__Soft') {
+        return $attr_spec; // already has __Soft, nothing to do here
+      }
+    }
+    return $attr_spec->withAttributes(
+      $attr_spec->getAttributes()
+        |> append_to_nodelist(
+          $$,
+          vec[
+            new ConstructorCall(
+              new NameToken(null, null, '__Soft'),
+              null,
+              null,
+              null,
+            ),
+          ],
+          CommaToken::class,
+        ),
+    );
+  }
+
+  /**
+   * Not final, some subclasses override these.
+   */
+  protected static function migrateVectorArray(
+    VectorArrayTypeSpecifier $node,
+  ): ITypeSpecifier {
+    return new GenericTypeSpecifier(
+      new NameToken(
+        $node->getKeyword()->getFirstTokenx()->getLeading(),
+        $node->getKeyword()->getLastTokenx()->getTrailing(),
+        'varray_or_darray',
+      ),
+      new TypeArguments(
+        $node->getLeftAngle(),
+        NodeList::createMaybeEmptyList(vec[
+          new ListItem($node->getType(), null),
+        ]),
+        $node->getRightAngle(),
+      ),
+    );
+  }
+
+  protected static function migrateMapArray(
+    MapArrayTypeSpecifier $node,
+  ): ITypeSpecifier {
+    return new GenericTypeSpecifier(
+      new NameToken(
+        $node->getKeyword()->getFirstTokenx()->getLeading(),
+        $node->getKeyword()->getLastTokenx()->getTrailing(),
+        'varray_or_darray',
+      ),
+      new TypeArguments(
+        $node->getLeftAngle(),
+        NodeList::createMaybeEmptyList(vec[
+          new ListItem($node->getKey(), $node->getComma()),
+          new ListItem($node->getValue(), null),
+        ]),
+        $node->getRightAngle(),
+      ),
+    );
+  }
+
+  abstract protected static function shouldAddSoft(): bool;
+}

--- a/src/Migrations/PHPArrayTypehintsMigrationBestGuess.hack
+++ b/src/Migrations/PHPArrayTypehintsMigrationBestGuess.hack
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class PHPArrayTypehintsMigrationBestGuess
+  extends PHPArrayTypehintsMigrationBase {
+
+  <<__Override>>
+  protected static function migrateVectorArray(
+    VectorArrayTypeSpecifier $node,
+  ): ITypeSpecifier {
+    return new VarrayTypeSpecifier(
+      new VarrayToken(
+        $node->getKeyword()->getFirstTokenx()->getLeading(),
+        $node->getKeyword()->getLastTokenx()->getTrailing(),
+      ),
+      $node->getLeftAngle(),
+      $node->getType(),
+      null,
+      $node->getRightAngle(),
+    );
+  }
+
+  <<__Override>>
+  protected static function migrateMapArray(
+    MapArrayTypeSpecifier $node,
+  ): ITypeSpecifier {
+    return new DarrayTypeSpecifier(
+      new DarrayToken(
+        $node->getKeyword()->getFirstTokenx()->getLeading(),
+        $node->getKeyword()->getLastTokenx()->getTrailing(),
+      ),
+      $node->getLeftAngle(),
+      $node->getKey(),
+      $node->getComma(),
+      $node->getValue(),
+      null,
+      $node->getRightAngle(),
+    );
+  }
+
+  <<__Override>>
+  protected static function shouldAddSoft(): bool {
+    return true;
+  }
+}

--- a/src/Migrations/PHPArrayTypehintsMigrationHard.hack
+++ b/src/Migrations/PHPArrayTypehintsMigrationHard.hack
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class PHPArrayTypehintsMigrationHard
+  extends PHPArrayTypehintsMigrationBase {
+
+  <<__Override>>
+  protected static function shouldAddSoft(): bool {
+    return false;
+  }
+}

--- a/src/Migrations/PHPArrayTypehintsMigrationSoft.hack
+++ b/src/Migrations/PHPArrayTypehintsMigrationSoft.hack
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class PHPArrayTypehintsMigrationSoft
+  extends PHPArrayTypehintsMigrationBase {
+
+  <<__Override>>
+  protected static function shouldAddSoft(): bool {
+    return true;
+  }
+}

--- a/src/__Private/MigrationCLI.hack
+++ b/src/__Private/MigrationCLI.hack
@@ -284,6 +284,38 @@ class MigrationCLI extends CLIWithRequiredArguments {
       ),
       CLIOptions\flag(
         () ==> {
+          $this->migrations[] = HHAST\PHPArrayTypehintsMigrationSoft::class;
+        },
+        'Migrate array typehints to <<__Soft>> varray_or_darray (safe)',
+        '--php-array-typehints-soft',
+      ),
+      CLIOptions\flag(
+        () ==> {
+          $this->migrations[] = HHAST\PHPArrayTypehintsMigrationHard::class;
+        },
+        'Migrate array typehints to varray_or_darray (safe only in HHVM 4.68+)',
+        '--php-array-typehints-hard',
+      ),
+      CLIOptions\flag(
+        () ==> {
+          $this->migrations[] =
+            HHAST\HardenVarrayOrDarrayTypehintsMigration::class;
+        },
+        'Remove <<__Soft>> from varray_or_darray typehints (recommended after '.
+        'migrating to HHVM 4.68+)',
+        '--harden-varray-or-darray-typehints',
+      ),
+      CLIOptions\flag(
+        () ==> {
+          $this->migrations[] =
+            HHAST\PHPArrayTypehintsMigrationBestGuess::class;
+        },
+        'Migrate array typehints to <<__Soft>> varray or <<__Soft>> darray '.
+        '(likely to cause runtime warnings)',
+        '--php-array-typehints-best-guess',
+      ),
+      CLIOptions\flag(
+        () ==> {
           $this->migrations[] = AddXHPChildrenDeclarationMethodMigration::class;
         },
         'Add getChildrenDeclaration() method to XHP classes with a children declaration',

--- a/tests/HardenVarrayOrDarrayTypehintsMigrationTest.hack
+++ b/tests/HardenVarrayOrDarrayTypehintsMigrationTest.hack
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class HardenVarrayOrDarrayTypehintsMigrationTest
+  extends StepBasedMigrationTest {
+
+  const type TMigration = HardenVarrayOrDarrayTypehintsMigration;
+}

--- a/tests/PHPArrayTypehintsMigrationBestGuessTest.hack
+++ b/tests/PHPArrayTypehintsMigrationBestGuessTest.hack
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class PHPArrayTypehintsMigrationBestGuessTest
+  extends StepBasedMigrationTest {
+
+  const type TMigration = PHPArrayTypehintsMigrationBestGuess;
+}

--- a/tests/PHPArrayTypehintsMigrationHardTest.hack
+++ b/tests/PHPArrayTypehintsMigrationHardTest.hack
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class PHPArrayTypehintsMigrationHardTest
+  extends StepBasedMigrationTest {
+
+  const type TMigration = PHPArrayTypehintsMigrationHard;
+}

--- a/tests/PHPArrayTypehintsMigrationSoftTest.hack
+++ b/tests/PHPArrayTypehintsMigrationSoftTest.hack
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class PHPArrayTypehintsMigrationSoftTest
+  extends StepBasedMigrationTest {
+
+  const type TMigration = PHPArrayTypehintsMigrationSoft;
+}

--- a/tests/examples/migrations/harden_varray_or_darray_typehints.hack.expect
+++ b/tests/examples/migrations/harden_varray_or_darray_typehints.hack.expect
@@ -33,6 +33,13 @@ function foo(
   /* 7 */ >> // 8
   /* 9 */ varray_or_darray<int, varray_or_darray<varray_or_darray<string, bool>>> /* 10 */ $analbumcover, // 11
 ): varray_or_darray<string, varray_or_darray<bool>> {
+  $lambda =
+    (varray_or_darray<int> $a, varray_or_darray<string, bool> $b): varray_or_darray<float> ==>
+    varray[42.0];
+  $soft_lambda = (): varray_or_darray<int> ==> {
+    echo 'hi';
+    return varray[1, 1, 2, 3, 5, 8, 14];
+  };
   return darray[];
 }
 

--- a/tests/examples/migrations/harden_varray_or_darray_typehints.hack.expect
+++ b/tests/examples/migrations/harden_varray_or_darray_typehints.hack.expect
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+function foo(
+  varray_or_darray<int> $a,
+  varray_or_darray<string, bool> $b,
+  varray_or_darray<float> $already_soft,
+  <<Foo, >> varray_or_darray<int> $foo,
+  <<Foo, Bar, >> varray_or_darray<int> $foo_bar,
+  <<
+    Foo,
+  >> varray_or_darray<int> $foo2,
+  <<
+    Foo,
+    Bar,
+  >> varray_or_darray<int> $foo_bar2,
+  <<
+    Foo,
+    Bar,
+  >> varray_or_darray<int> $foo_bar3,
+  /* 1 */ varray_or_darray<bool> /* 2 */ $x, // 3
+  /* 1 */  /* 2 */ varray_or_darray<bool> /* 3 */ $y, // 4
+  /* 1 */ << /* 2 */ Foo, /* 3 */ Bar, /* 4 */ >> /* 5 */ varray_or_darray<int> $z, // 5
+  /* 1 */ << // 2
+    /* 3 */ Foo, // 4
+    /* 5 */ Bar, // 6
+  /* 7 */ >> // 8
+  /* 9 */ varray_or_darray<int, varray_or_darray<varray_or_darray<string, bool>>> /* 10 */ $analbumcover, // 11
+): varray_or_darray<string, varray_or_darray<bool>> {
+  return darray[];
+}
+
+function untyped($foo) {}

--- a/tests/examples/migrations/harden_varray_or_darray_typehints.hack.in
+++ b/tests/examples/migrations/harden_varray_or_darray_typehints.hack.in
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+function foo(
+  <<__Soft>> varray_or_darray<int> $a,
+  <<__Soft>> varray_or_darray<string, bool> $b,
+  <<__Soft>> varray_or_darray<float> $already_soft,
+  <<Foo, __Soft>> varray_or_darray<int> $foo,
+  <<Foo, Bar, __Soft>> varray_or_darray<int> $foo_bar,
+  <<
+    Foo,
+    __Soft
+  >> varray_or_darray<int> $foo2,
+  <<
+    Foo,
+    Bar,
+    __Soft
+  >> varray_or_darray<int> $foo_bar2,
+  <<
+    Foo,
+    Bar,
+    __Soft,
+  >> varray_or_darray<int> $foo_bar3,
+  /* 1 */ <<__Soft>> varray_or_darray<bool> /* 2 */ $x, // 3
+  /* 1 */ <<__Soft>> /* 2 */ varray_or_darray<bool> /* 3 */ $y, // 4
+  /* 1 */ << /* 2 */ Foo, /* 3 */ Bar, /* 4 */ __Soft >> /* 5 */ varray_or_darray<int> $z, // 5
+  /* 1 */ << // 2
+    /* 3 */ Foo, // 4
+    /* 5 */ Bar, // 6
+    __Soft,
+  /* 7 */ >> // 8
+  /* 9 */ varray_or_darray<int, varray_or_darray<varray_or_darray<string, bool>>> /* 10 */ $analbumcover, // 11
+): <<__Soft>> varray_or_darray<string, varray_or_darray<bool>> {
+  return darray[];
+}
+
+function untyped($foo) {}

--- a/tests/examples/migrations/harden_varray_or_darray_typehints.hack.in
+++ b/tests/examples/migrations/harden_varray_or_darray_typehints.hack.in
@@ -37,6 +37,13 @@ function foo(
   /* 7 */ >> // 8
   /* 9 */ varray_or_darray<int, varray_or_darray<varray_or_darray<string, bool>>> /* 10 */ $analbumcover, // 11
 ): <<__Soft>> varray_or_darray<string, varray_or_darray<bool>> {
+  $lambda =
+    (<<__Soft>> varray_or_darray<int> $a, <<__Soft>> varray_or_darray<string, bool> $b): <<__Soft>> varray_or_darray<float> ==>
+    varray[42.0];
+  $soft_lambda = (): <<__Soft>> varray_or_darray<int> ==> {
+    echo 'hi';
+    return varray[1, 1, 2, 3, 5, 8, 14];
+  };
   return darray[];
 }
 

--- a/tests/examples/migrations/php_array_typehints_migration_best_guess.hack.expect
+++ b/tests/examples/migrations/php_array_typehints_migration_best_guess.hack.expect
@@ -41,6 +41,13 @@ function foo(
   /* 7 */ >> // 8
   /* 9 */ darray<int, varray<darray<string, bool>>> /* 10 */ $analbumcover, // 11
 ): <<__Soft>> darray<string, varray<bool>> {
+  $lambda =
+    (<<__Soft>> varray<int> $a, <<__Soft>> darray<string, bool> $b): <<__Soft>> varray<float> ==>
+    varray[42.0];
+  $soft_lambda = (): <<__Soft>> varray<int> ==> {
+    echo 'hi';
+    return varray[1, 1, 2, 3, 5, 8, 14];
+  };
   return darray[];
 }
 

--- a/tests/examples/migrations/php_array_typehints_migration_best_guess.hack.expect
+++ b/tests/examples/migrations/php_array_typehints_migration_best_guess.hack.expect
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// anything except params and return types is ignored
+type V = array<int>;
+type D = array<string, bool>;
+
+function foo(
+  <<__Soft>> varray<int> $a,
+  <<__Soft>> darray<string, bool> $b,
+  <<__Soft>> varray<float> $already_soft,
+  <<Foo, __Soft>> varray<int> $foo,
+  <<Foo, Bar, __Soft>> varray<int> $foo_bar,
+  <<
+    Foo,
+    __Soft
+  >> varray<int> $foo2,
+  <<
+    Foo,
+    Bar,
+    __Soft
+  >> varray<int> $foo_bar2,
+  <<
+    Foo,
+    Bar,
+    __Soft,
+  >> varray<int> $foo_bar3,
+  /* 1 */ <<__Soft>> varray<bool> /* 2 */ $x, // 3
+  /* 1 */ <<__Soft>> /* 2 */ varray<bool> /* 3 */ $y, // 4
+  /* 1 */ << /* 2 */ Foo, /* 3 */ Bar, /* 4 */ __Soft >> /* 5 */ varray<int> $z, // 5
+  /* 1 */ << // 2
+    /* 3 */ Foo, // 4
+    /* 5 */ Bar, // 6
+    __Soft,
+  /* 7 */ >> // 8
+  /* 9 */ darray<int, varray<darray<string, bool>>> /* 10 */ $analbumcover, // 11
+): <<__Soft>> darray<string, varray<bool>> {
+  return darray[];
+}
+
+function already_soft(): <<__Soft>> varray<int> {
+  return varray[];
+}
+
+function untyped($foo) {}
+
+final class Foo implements HH\ParameterAttribute {};
+final class Bar implements HH\ParameterAttribute {};

--- a/tests/examples/migrations/php_array_typehints_migration_best_guess.hack.in
+++ b/tests/examples/migrations/php_array_typehints_migration_best_guess.hack.in
@@ -37,6 +37,13 @@ function foo(
   /* 7 */ >> // 8
   /* 9 */ array<int, array<array<string, bool>>> /* 10 */ $analbumcover, // 11
 ): array<string, array<bool>> {
+  $lambda =
+    (array<int> $a, <<__Soft>> array<string, bool> $b): array<float> ==>
+    varray[42.0];
+  $soft_lambda = (): <<__Soft>> array<int> ==> {
+    echo 'hi';
+    return varray[1, 1, 2, 3, 5, 8, 14];
+  };
   return darray[];
 }
 

--- a/tests/examples/migrations/php_array_typehints_migration_best_guess.hack.in
+++ b/tests/examples/migrations/php_array_typehints_migration_best_guess.hack.in
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// anything except params and return types is ignored
+type V = array<int>;
+type D = array<string, bool>;
+
+function foo(
+  array<int> $a,
+  array<string, bool> $b,
+  <<__Soft>> array<float> $already_soft,
+  <<Foo>> array<int> $foo,
+  <<Foo, Bar>> array<int> $foo_bar,
+  <<
+    Foo
+  >> array<int> $foo2,
+  <<
+    Foo,
+    Bar
+  >> array<int> $foo_bar2,
+  <<
+    Foo,
+    Bar,
+  >> array<int> $foo_bar3,
+  /* 1 */ array<bool> /* 2 */ $x, // 3
+  /* 1 */ <<__Soft>> /* 2 */ array<bool> /* 3 */ $y, // 4
+  /* 1 */ << /* 2 */ Foo, /* 3 */ Bar /* 4 */ >> /* 5 */ array<int> $z, // 5
+  /* 1 */ << // 2
+    /* 3 */ Foo, // 4
+    /* 5 */ Bar, // 6
+  /* 7 */ >> // 8
+  /* 9 */ array<int, array<array<string, bool>>> /* 10 */ $analbumcover, // 11
+): array<string, array<bool>> {
+  return darray[];
+}
+
+function already_soft(): <<__Soft>> array<int> {
+  return varray[];
+}
+
+function untyped($foo) {}
+
+final class Foo implements HH\ParameterAttribute {};
+final class Bar implements HH\ParameterAttribute {};

--- a/tests/examples/migrations/php_array_typehints_migration_hard.hack.expect
+++ b/tests/examples/migrations/php_array_typehints_migration_hard.hack.expect
@@ -38,6 +38,13 @@ function foo(
   /* 7 */ >> // 8
   /* 9 */ varray_or_darray<int, varray_or_darray<varray_or_darray<string, bool>>> /* 10 */ $analbumcover, // 11
 ): varray_or_darray<string, varray_or_darray<bool>> {
+  $lambda =
+    (varray_or_darray<int> $a, <<__Soft>> varray_or_darray<string, bool> $b): varray_or_darray<float> ==>
+    varray[42.0];
+  $soft_lambda = (): <<__Soft>> varray_or_darray<int> ==> {
+    echo 'hi';
+    return varray[1, 1, 2, 3, 5, 8, 14];
+  };
   return darray[];
 }
 

--- a/tests/examples/migrations/php_array_typehints_migration_hard.hack.expect
+++ b/tests/examples/migrations/php_array_typehints_migration_hard.hack.expect
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// anything except params and return types is ignored
+type V = array<int>;
+type D = array<string, bool>;
+
+function foo(
+  varray_or_darray<int> $a,
+  varray_or_darray<string, bool> $b,
+  // should not remove existing <<__Soft>>
+  <<__Soft>> varray_or_darray<float> $already_soft,
+  <<Foo>> varray_or_darray<int> $foo,
+  <<Foo, Bar>> varray_or_darray<int> $foo_bar,
+  <<
+    Foo
+  >> varray_or_darray<int> $foo2,
+  <<
+    Foo,
+    Bar
+  >> varray_or_darray<int> $foo_bar2,
+  <<
+    Foo,
+    Bar,
+  >> varray_or_darray<int> $foo_bar3,
+  /* 1 */ varray_or_darray<bool> /* 2 */ $x, // 3
+  /* 1 */ <<__Soft>> /* 2 */ varray_or_darray<bool> /* 3 */ $y, // 4
+  /* 1 */ << /* 2 */ Foo, /* 3 */ Bar /* 4 */ >> /* 5 */ varray_or_darray<int> $z, // 5
+  /* 1 */ << // 2
+    /* 3 */ Foo, // 4
+    /* 5 */ Bar, // 6
+  /* 7 */ >> // 8
+  /* 9 */ varray_or_darray<int, varray_or_darray<varray_or_darray<string, bool>>> /* 10 */ $analbumcover, // 11
+): varray_or_darray<string, varray_or_darray<bool>> {
+  return darray[];
+}
+
+function already_soft(): <<__Soft>> varray_or_darray<int> {
+  return varray[];
+}
+
+function untyped($foo) {}
+
+final class Foo implements HH\ParameterAttribute {};
+final class Bar implements HH\ParameterAttribute {};

--- a/tests/examples/migrations/php_array_typehints_migration_hard.hack.in
+++ b/tests/examples/migrations/php_array_typehints_migration_hard.hack.in
@@ -38,6 +38,13 @@ function foo(
   /* 7 */ >> // 8
   /* 9 */ array<int, array<array<string, bool>>> /* 10 */ $analbumcover, // 11
 ): array<string, array<bool>> {
+  $lambda =
+    (array<int> $a, <<__Soft>> array<string, bool> $b): array<float> ==>
+    varray[42.0];
+  $soft_lambda = (): <<__Soft>> array<int> ==> {
+    echo 'hi';
+    return varray[1, 1, 2, 3, 5, 8, 14];
+  };
   return darray[];
 }
 

--- a/tests/examples/migrations/php_array_typehints_migration_hard.hack.in
+++ b/tests/examples/migrations/php_array_typehints_migration_hard.hack.in
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// anything except params and return types is ignored
+type V = array<int>;
+type D = array<string, bool>;
+
+function foo(
+  array<int> $a,
+  array<string, bool> $b,
+  // should not remove existing <<__Soft>>
+  <<__Soft>> array<float> $already_soft,
+  <<Foo>> array<int> $foo,
+  <<Foo, Bar>> array<int> $foo_bar,
+  <<
+    Foo
+  >> array<int> $foo2,
+  <<
+    Foo,
+    Bar
+  >> array<int> $foo_bar2,
+  <<
+    Foo,
+    Bar,
+  >> array<int> $foo_bar3,
+  /* 1 */ array<bool> /* 2 */ $x, // 3
+  /* 1 */ <<__Soft>> /* 2 */ array<bool> /* 3 */ $y, // 4
+  /* 1 */ << /* 2 */ Foo, /* 3 */ Bar /* 4 */ >> /* 5 */ array<int> $z, // 5
+  /* 1 */ << // 2
+    /* 3 */ Foo, // 4
+    /* 5 */ Bar, // 6
+  /* 7 */ >> // 8
+  /* 9 */ array<int, array<array<string, bool>>> /* 10 */ $analbumcover, // 11
+): array<string, array<bool>> {
+  return darray[];
+}
+
+function already_soft(): <<__Soft>> array<int> {
+  return varray[];
+}
+
+function untyped($foo) {}
+
+final class Foo implements HH\ParameterAttribute {};
+final class Bar implements HH\ParameterAttribute {};

--- a/tests/examples/migrations/php_array_typehints_migration_soft.hack.expect
+++ b/tests/examples/migrations/php_array_typehints_migration_soft.hack.expect
@@ -41,6 +41,13 @@ function foo(
   /* 7 */ >> // 8
   /* 9 */ varray_or_darray<int, varray_or_darray<varray_or_darray<string, bool>>> /* 10 */ $analbumcover, // 11
 ): <<__Soft>> varray_or_darray<string, varray_or_darray<bool>> {
+  $lambda =
+    (<<__Soft>> varray_or_darray<int> $a, <<__Soft>> varray_or_darray<string, bool> $b): <<__Soft>> varray_or_darray<float> ==>
+    varray[42.0];
+  $soft_lambda = (): <<__Soft>> varray_or_darray<int> ==> {
+    echo 'hi';
+    return varray[1, 1, 2, 3, 5, 8, 14];
+  };
   return darray[];
 }
 

--- a/tests/examples/migrations/php_array_typehints_migration_soft.hack.expect
+++ b/tests/examples/migrations/php_array_typehints_migration_soft.hack.expect
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// anything except params and return types is ignored
+type V = array<int>;
+type D = array<string, bool>;
+
+function foo(
+  <<__Soft>> varray_or_darray<int> $a,
+  <<__Soft>> varray_or_darray<string, bool> $b,
+  <<__Soft>> varray_or_darray<float> $already_soft,
+  <<Foo, __Soft>> varray_or_darray<int> $foo,
+  <<Foo, Bar, __Soft>> varray_or_darray<int> $foo_bar,
+  <<
+    Foo,
+    __Soft
+  >> varray_or_darray<int> $foo2,
+  <<
+    Foo,
+    Bar,
+    __Soft
+  >> varray_or_darray<int> $foo_bar2,
+  <<
+    Foo,
+    Bar,
+    __Soft,
+  >> varray_or_darray<int> $foo_bar3,
+  /* 1 */ <<__Soft>> varray_or_darray<bool> /* 2 */ $x, // 3
+  /* 1 */ <<__Soft>> /* 2 */ varray_or_darray<bool> /* 3 */ $y, // 4
+  /* 1 */ << /* 2 */ Foo, /* 3 */ Bar, /* 4 */ __Soft >> /* 5 */ varray_or_darray<int> $z, // 5
+  /* 1 */ << // 2
+    /* 3 */ Foo, // 4
+    /* 5 */ Bar, // 6
+    __Soft,
+  /* 7 */ >> // 8
+  /* 9 */ varray_or_darray<int, varray_or_darray<varray_or_darray<string, bool>>> /* 10 */ $analbumcover, // 11
+): <<__Soft>> varray_or_darray<string, varray_or_darray<bool>> {
+  return darray[];
+}
+
+function already_soft(): <<__Soft>> varray_or_darray<int> {
+  return varray[];
+}
+
+function untyped($foo) {}
+
+final class Foo implements HH\ParameterAttribute {};
+final class Bar implements HH\ParameterAttribute {};

--- a/tests/examples/migrations/php_array_typehints_migration_soft.hack.in
+++ b/tests/examples/migrations/php_array_typehints_migration_soft.hack.in
@@ -37,6 +37,13 @@ function foo(
   /* 7 */ >> // 8
   /* 9 */ array<int, array<array<string, bool>>> /* 10 */ $analbumcover, // 11
 ): array<string, array<bool>> {
+  $lambda =
+    (array<int> $a, <<__Soft>> array<string, bool> $b): array<float> ==>
+    varray[42.0];
+  $soft_lambda = (): <<__Soft>> array<int> ==> {
+    echo 'hi';
+    return varray[1, 1, 2, 3, 5, 8, 14];
+  };
   return darray[];
 }
 

--- a/tests/examples/migrations/php_array_typehints_migration_soft.hack.in
+++ b/tests/examples/migrations/php_array_typehints_migration_soft.hack.in
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+// anything except params and return types is ignored
+type V = array<int>;
+type D = array<string, bool>;
+
+function foo(
+  array<int> $a,
+  array<string, bool> $b,
+  <<__Soft>> array<float> $already_soft,
+  <<Foo>> array<int> $foo,
+  <<Foo, Bar>> array<int> $foo_bar,
+  <<
+    Foo
+  >> array<int> $foo2,
+  <<
+    Foo,
+    Bar
+  >> array<int> $foo_bar2,
+  <<
+    Foo,
+    Bar,
+  >> array<int> $foo_bar3,
+  /* 1 */ array<bool> /* 2 */ $x, // 3
+  /* 1 */ <<__Soft>> /* 2 */ array<bool> /* 3 */ $y, // 4
+  /* 1 */ << /* 2 */ Foo, /* 3 */ Bar /* 4 */ >> /* 5 */ array<int> $z, // 5
+  /* 1 */ << // 2
+    /* 3 */ Foo, // 4
+    /* 5 */ Bar, // 6
+  /* 7 */ >> // 8
+  /* 9 */ array<int, array<array<string, bool>>> /* 10 */ $analbumcover, // 11
+): array<string, array<bool>> {
+  return darray[];
+}
+
+function already_soft(): <<__Soft>> array<int> {
+  return varray[];
+}
+
+function untyped($foo) {}
+
+final class Foo implements HH\ParameterAttribute {};
+final class Bar implements HH\ParameterAttribute {};


### PR DESCRIPTION
```
  --php-array-typehints-soft
	Migrate array typehints to <<__Soft>> varray_or_darray (safe)
  --php-array-typehints-hard
	Migrate array typehints to varray_or_darray (safe only in HHVM 4.68+)
  --harden-varray-or-darray-typehints
	Remove <<__Soft>> from varray_or_darray typehints (recommended after migrating to HHVM 4.68+)
  --php-array-typehints-best-guess
	Migrate array typehints to <<__Soft>> varray or <<__Soft>> darray (likely to cause runtime warnings)
```

Review only last commit, the rest is #310 

The `--php-array-*` migrations share most of the code in a common base class.