### PR TITLE
hhast-migrate --xhp-lib-v3-to-v4

### DIFF
--- a/src/Migrations/XHPLibV3ToV4Migration.hack
+++ b/src/Migrations/XHPLibV3ToV4Migration.hack
@@ -1,0 +1,548 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{C, Dict, Str, Vec};
+
+final class XHPLibV3ToV4Migration extends BaseMigration {
+
+  const dict<string, string> DEFAULT_NS_ALIASES = dict[
+    'Facebook\\XHP\\ChildValidation' => 'XHPChild',
+    'Facebook\\XHP\\Core' => 'x',
+  ];
+
+  const dict<string, string> RENAMED_TYPES = dict[
+    'XHPRoot' => 'Facebook\\XHP\\Core\\node',
+    ':x:element' => 'Facebook\\XHP\\Core\\element',
+    ':x:primitive' => 'Facebook\\XHP\\Core\\primitive',
+    'XHPUnsafeRenderable' => 'Facebook\\XHP\\UnsafeRenderable',
+    'XHPAlwaysValidChild' => 'Facebook\\XHP\\AlwaysValidChild',
+    'XHPChildValidation' => 'Facebook\\XHP\\ChildValidation\\Validation',
+  ];
+
+  const dict<string, string> RENAMED_FUNCTIONS = dict[
+    'Facebook\\XHP\\ChildValidation\\anyNumberOf' =>
+      'Facebook\\XHP\\ChildValidation\\any_number_of',
+    'Facebook\\XHP\\ChildValidation\\anyOf' =>
+      'Facebook\\XHP\\ChildValidation\\any_of',
+    'Facebook\\XHP\\ChildValidation\\atLeastOneOf' =>
+      'Facebook\\XHP\\ChildValidation\\at_least_one_of',
+    'Facebook\\XHP\\ChildValidation\\ofType' =>
+      'Facebook\\XHP\\ChildValidation\\of_type',
+  ];
+
+  const dict<string, string> ASYNCIFY_METHODS = dict[
+    // base class => method name
+    'Facebook\\XHP\\Core\\element' => 'render',
+    'Facebook\\XHP\\Core\\primitive' => 'stringify',
+    'Facebook\\XHP\\UnsafeRenderable' => 'toHTMLString',
+  ];
+  const ASYNC_METHOD_SUFFIX = 'Async';
+
+  // grep -Phor "(?<=xhp class )[a-zA-Z0-9_]+" xhp-lib/src/html/tags \
+  //   | sort | tr "\n" , | sed "s/,/', '/g" | fold -w 76 -s
+  // @hackfmt-ignore
+  const keyset<string> HTML_TAGS = keyset[
+    'a', 'abbr', 'address', 'area', 'article', 'aside', 'audio', 'b', 'base',
+    'bdi', 'bdo', 'blockquote', 'body', 'br', 'button', 'canvas', 'caption',
+    'cite', 'code', 'col', 'colgroup', 'conditional_comment', 'data',
+    'datalist', 'dd', 'del', 'details', 'dfn', 'dialog', 'div', 'dl',
+    'doctype', 'dt', 'em', 'embed', 'fieldset', 'figcaption', 'figure',
+    'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'head', 'header',
+    'hgroup', 'hr', 'html', 'i', 'iframe', 'img', 'input', 'ins', 'kbd',
+    'keygen', 'label', 'legend', 'li', 'link', 'main', 'map', 'mark', 'menu',
+    'menuitem', 'meta', 'meter', 'nav', 'noscript', 'object', 'ol', 'optgroup',
+    'option', 'output', 'p', 'param', 'picture', 'pre', 'progress', 'q', 'rb',
+    'rp', 'rt', 'rtc', 'ruby', 's', 'samp', 'script', 'section', 'select',
+    'slot', 'small', 'source', 'span', 'strong', 'style', 'sub', 'summary',
+    'sup', 'table', 'tbody', 'td', 'template', 'textarea', 'tfoot', 'th',
+    'thead', 'time', 'title', 'tr', 'track', 'tt', 'u', 'ul', 'var', 'video',
+    'wbr',
+  ];
+  const HTML_NS = 'Facebook\\XHP\\HTML';
+
+  // Keep track of `use` clauses to be added to this file. If there are multiple
+  // namespaces in the file (this should be rare), we add the `use`s globally.
+  private dict<string, string> $newNamespaces = dict[];
+  private dict<string, string> $newTypes = dict[];
+
+  <<__Override>>
+  public function migrateFile(string $_path, Script $ast): Script {
+    $this->newNamespaces = dict[];
+    $this->newTypes = dict[];
+
+    foreach ($ast->getNamespaces() as $ns) {
+      foreach ($ns['children']->getChildren() as $child) {
+        $ast = $ast->replace(
+          $child,
+          $child->rewrite(
+            ($node, $_) ==> $this->migrateNode($ast, $ns, $node),
+            vec[],
+          ),
+        );
+      }
+    }
+
+    return $this->addUseDeclarations($ast);
+  }
+
+  /**
+   * - migrate type specifiers according to RENAMED_TYPES + HTML_TAGS
+   * - migrate function calls according to RENAMED_FUNCTIONS
+   * - add `use type` for any XHP open/close tags that are HTML_TAGS
+   * - asyncify methods if extending a base class from ASYNCIFY_METHODS
+   */
+  private function migrateNode(
+    Script $ast,
+    Script::TNamespace $ns,
+    Node $node,
+  ): Node {
+    if ($node is SimpleTypeSpecifier && $node->getSpecifier() is INameishNode) {
+      return $node->withSpecifier(
+        $this->migrateName(
+          $ns,
+          $node->getSpecifier() as INameishNode,
+          self::allRenamedTypes(),
+          ($name, $node) ==> resolve_type($name, $ast, $node)['name'],
+        ),
+      );
+    } else if (
+      $node is ScopeResolutionExpression &&
+      $node->getQualifier() is INameishNode
+    ) {
+      return $node->withQualifier(
+        $this->migrateName(
+          $ns,
+          $node->getQualifier() as INameishNode,
+          self::allRenamedTypes(),
+          ($name, $node) ==> resolve_type($name, $ast, $node)['name'],
+        ),
+      );
+    } else if (
+      $node is FunctionCallExpression && $node->getReceiver() is INameishNode
+    ) {
+      return $node->withReceiver(
+        $this->migrateName(
+          $ns,
+          $node->getReceiver() as INameishNode,
+          self::RENAMED_FUNCTIONS,
+          ($name, $node) ==> resolve_function($name, $ast, $node),
+        ),
+      );
+    } else if ($node is XHPOpen || $node is XHPClose) {
+      $this->useHTMLTag($ns, $node->getName());
+      return $node;
+    } else if ($node is ClassishDeclaration) {
+      return $this->migrateClass(
+        $node,
+        ($name, $node) ==> __Private\Resolution\resolve_name(
+          $name,
+          $ast,
+          $node,
+          Dict\merge(
+            $ns['uses']['namespaces'],
+            Dict\flip($this->newNamespaces),
+          ),
+        ),
+      );
+    } else {
+      return $node;
+    }
+  }
+
+  <<__Memoize>>
+  private static function allRenamedTypes(): dict<string, string> {
+    return Dict\merge(
+      self::RENAMED_TYPES,
+      Dict\pull(
+        self::HTML_TAGS,
+        $tag ==> self::HTML_NS.'\\'.$tag,
+        $tag ==> ':'.$tag,
+      ),
+    );
+  }
+
+  /**
+   * If the new name's namespace is already `use`d, respect its current alias.
+   * Otherwise, add a `use` clause according to self::DEFAULT_NS_ALIASES.
+   */
+  private function migrateName(
+    Script::TNamespace $ns,
+    INameishNode $old_name_node,
+    dict<string, string> $old_to_new,
+    (function(string, Node): string) $resolver,
+  ): INameishNode {
+    $old_name = $resolver(self::withoutTrivia($old_name_node), $old_name_node);
+    $new_name = idx($old_to_new, $old_name);
+    if ($new_name is null) {
+      return $old_name_node;
+    }
+
+    list($new_ns, $new_name) = self::split($new_name);
+    $new_ns as nonnull;
+
+    $alias = C\find_key($ns['uses']['namespaces'], $val ==> $val === $new_ns);
+    if ($alias is null) {
+      $alias = idx(self::DEFAULT_NS_ALIASES, $new_ns) ??
+        self::split($new_ns)[1];
+      $this->newNamespaces[$new_ns] = $alias;
+    }
+
+    return self::getNameNode($alias.'\\'.$new_name, $old_name_node);
+  }
+
+  /**
+   * HTML tags don't need to be migrated, just add the necessary `use type`
+   * clauses.
+   */
+  private function useHTMLTag(
+    Script::TNamespace $ns,
+    XHPElementNameToken $name_node,
+  ): void {
+    $name = self::withoutTrivia($name_node);
+    if (!C\contains_key(self::HTML_TAGS, $name)) {
+      return;
+    }
+
+    $qualified = self::HTML_NS.'\\'.$name;
+    if (C\contains($ns['uses']['types'], $qualified)) {
+      // Nothing to do if the type is already `use`d. We ignore the case when
+      // it's `use`d with an alias, since something unexpected is happening that
+      // likely needs manual migration.
+      return;
+    }
+
+    $this->newTypes[$qualified] = $name;
+  }
+
+  /**
+   * If the class extends one of the core XHP base classes, asyncify the
+   * relevant method. We don't handle classes that don't extend the base class
+   * directly or other special cases -- those are better migrated manually.
+   */
+  private function migrateClass(
+    ClassishDeclaration $class,
+    (function(string, Node): string) $type_resolver,
+  ): ClassishDeclaration {
+    if (
+      !$class->getKeyword() is ClassToken ||
+      $class->getExtendsList() is null ||
+      $class->getBody()->getElements() is null
+    ) {
+      return $class;
+    }
+
+    $method_name = idx(
+      self::ASYNCIFY_METHODS,
+      $type_resolver(
+        self::withoutTrivia($class->getExtendsListx()),
+        $class->getExtendsListx(),
+      ),
+    );
+    if ($method_name is null) {
+      return $class;
+    }
+
+    foreach ($class->getBody()->getElementsx()->getChildren() as $decl) {
+      if (!$decl is MethodishDeclaration) {
+        continue;
+      }
+      $new_header = $decl->getFunctionDeclHeader();
+      if (self::withoutTrivia($new_header->getName()) !== $method_name) {
+        continue;
+      }
+      // asyncify return type
+      if ($new_header->hasType()) {
+        $new_header = $new_header->withType(
+          self::asyncifyType($new_header->getTypex()),
+        );
+      }
+      // add `async` keyword
+      if (
+        $new_header->hasModifiers() && !$new_header->getModifiersx()->isEmpty()
+      ) {
+        $new_header = $new_header->withModifiers(NodeList::createMaybeEmptyList(
+          Vec\concat(
+            $new_header->getModifiersx()->getChildren(),
+            vec[new AsyncToken(null, self::space())],
+          ),
+        ));
+      } else {
+        // If there are no existing modifiers, also move leading Trivia from
+        // the `function` token to the new `async` token.
+        $new_header = $new_header
+          ->withModifiers(NodeList::createMaybeEmptyList(vec[
+            new AsyncToken(
+              $new_header->getKeyword()->getLeading(),
+              self::space(),
+            ),
+          ]))
+          ->withKeyword($new_header->getKeyword()->withLeading(null));
+      }
+      return $class->replaceDescendant(
+        $decl->getFunctionDeclHeader(),
+        // append `Async` to method name
+        $new_header->withName(
+          new NameToken(
+            $new_header->getName()->getFirstTokenx()->getLeading(),
+            $new_header->getName()->getLastTokenx()->getTrailing(),
+            $method_name.self::ASYNC_METHOD_SUFFIX,
+          ),
+        ),
+      );
+    }
+
+    return $class;
+  }
+
+  private static function asyncifyType(ITypeSpecifier $type): ITypeSpecifier {
+    if ($type is AttributizedSpecifier) {
+      // Try saying 10 times very quickly:
+      return $type->withType(self::asyncifyType($type->getType()));
+    }
+    return new GenericTypeSpecifier(
+      new NameToken($type->getFirstTokenx()->getLeading(), null, 'Awaitable'),
+      new TypeArguments(
+        new LessThanToken(null, null),
+        NodeList::createMaybeEmptyList(vec[
+          new ListItem(
+            $type->withFirstTokenLeading(null)->withLastTokenTrailing(null),
+            null,
+          ),
+        ]),
+        new GreaterThanToken(null, $type->getLastTokenx()->getTrailing()),
+      ),
+    );
+  }
+
+  /**
+   * Add all `use` declarations that have been aggregated in $this->newTypes and
+   * $this->newNamespaces to the correct place in $ast.
+   */
+  private function addUseDeclarations(Script $ast): Script {
+    if (C\is_empty($this->newNamespaces) && C\is_empty($this->newTypes)) {
+      return $ast;
+    }
+
+    // Figure out where to put the new `use` declarations.
+    $insert_into = $ast->getDeclarations();
+    $insert_at = 0;
+
+    // If there is exactly one namespace in the file (common case), we want to
+    // put the `use`s inside it. Otherwise (should be rare), they'll be global.
+    if (C\count($ast->getNamespaces()) === 1) {
+      foreach ($insert_into->getChildren() as $idx => $decl) {
+        if ($decl is NamespaceDeclaration) {
+          $body = $decl->getBody();
+          if ($body is NamespaceBody) {
+            // Put the `use`s inside the `namespace Foo { ... }` body.
+            $insert_into = $body->getDeclarations() as nonnull;
+            break;
+          } else {
+            $body as NamespaceEmptyBody;
+            // Put the `use`s after the `namespace Foo;` line.
+            $insert_at = $idx + 1;
+            break;
+          }
+        }
+      }
+    }
+
+    // If there are any existing `use` declarations in the scope we've chosen
+    // above, put the new ones after the last existing one.
+    for ($idx = $insert_at; $idx < $insert_into->getCount(); ++$idx) {
+      $decl = $insert_into->getChildren()[$idx];
+      if ($decl is NamespaceDeclaration) {
+        // We've reached the next (possibly first) namespace.
+        break;
+      } else if ($decl is NamespaceUseDeclaration) {
+        $insert_at = $idx + 1;
+      }
+    }
+
+    return $ast->replace(
+      $insert_into,
+      NodeList::createMaybeEmptyList(Vec\concat(
+        Vec\take($insert_into->getChildren(), $insert_at),
+        self::getUseDeclarations(
+          new NamespaceToken(null, null),
+          $this->newNamespaces,
+        ),
+        self::getUseDeclarations(new TypeToken(null, null), $this->newTypes),
+        Vec\drop($insert_into->getChildren(), $insert_at),
+      )),
+    );
+  }
+
+  /**
+   * All `use` declarations of one kind (namespace/type).
+   */
+  private static function getUseDeclarations(
+    Token $kind,
+    dict<string, string> $names,
+  ): vec<INamespaceUseDeclaration> {
+    // Group together names that only differ in their last part.
+    $grouped = dict[];
+    foreach ($names as $name => $alias) {
+      list($ns, $name) = self::split($name);
+      $ns as nonnull;
+      $grouped[$ns] ??= dict[];
+      $grouped[$ns][$name] = $alias;
+    }
+
+    return Dict\map($grouped, $names ==> Dict\sort_by_key($names))
+      |> Dict\sort_by_key($$)
+      |> Vec\map_with_key(
+        $$,
+        ($ns, $names) ==> C\count($names) === 1
+          ? self::getUseDeclaration(
+              $kind,
+              $ns.'\\'.C\first_keyx($names),
+              C\onlyx($names),
+            )
+          : self::getGroupUseDeclaration($kind, $ns, $names),
+      );
+  }
+
+  /**
+   * e.g. `use Foo\Bar;` or `use Foo\Bar as Baz;`
+   */
+  private static function getUseDeclaration(
+    Token $kind,
+    string $name,
+    string $alias,
+  ): NamespaceUseDeclaration {
+    return new NamespaceUseDeclaration(
+      new UseToken(null, self::space()),
+      $kind->withTrailing(self::space()),
+      NodeList::createMaybeEmptyList(vec[
+        new ListItem(self::getUseClause($name, $alias), null),
+      ]),
+      new SemicolonToken(null, self::endl()),
+    );
+  }
+
+  /**
+   * e.g. `use Foo\Bar\{Baz, Herp as Derp};`
+   */
+  private static function getGroupUseDeclaration(
+    Token $kind,
+    string $prefix,
+    dict<string, string> $names,
+  ): NamespaceGroupUseDeclaration {
+    return new NamespaceGroupUseDeclaration(
+      new UseToken(null, self::space()),
+      $kind->withTrailing(self::space()),
+      Str\split($prefix, '\\')
+        |> Vec\map(
+          $$,
+          $part ==> new ListItem(
+            new NameToken(null, null, $part),
+            new BackslashToken(null, null),
+          ),
+        )
+        |> NodeList::createMaybeEmptyList($$)
+        |> new QualifiedName($$),
+      new LeftBraceToken(null, null),
+      Vec\map_with_key(
+        $names,
+        ($name, $alias) ==> new ListItem(
+          self::getUseClause($name, $alias),
+          $name === C\last_keyx($names)
+            ? null
+            : new CommaToken(null, self::space()),
+        ),
+      )
+        |> NodeList::createMaybeEmptyList($$),
+      new RightBraceToken(null, null),
+      new SemicolonToken(null, self::endl()),
+    );
+  }
+
+  /**
+   * e.g. `Foo\Bar` or `Foo\Bar as Baz`
+   */
+  private static function getUseClause(
+    string $name,
+    string $alias,
+  ): NamespaceUseClause {
+    list($_, $last_part) = self::split($name);
+    return new NamespaceUseClause(
+      null,
+      self::getNameNode($name),
+      $last_part === $alias ? null : new AsToken(self::space(), null),
+      $last_part === $alias ? null : new NameToken(self::space(), null, $alias),
+    );
+  }
+
+  /**
+   * Create a NameToken or QualifiedName based on whether $name contains any
+   * backslashes. Optionally copy over whitespace/comments from $old_name_node.
+   */
+  private static function getNameNode(
+    string $name,
+    ?INameishNode $old_name_node = null,
+  ): INameishNode {
+    $parts = Str\split($name, '\\');
+
+    if (C\count($parts) === 1) {
+      $ret = new NameToken(null, null, $name);
+    } else {
+      $ret = Vec\map_with_key(
+        $parts,
+        ($idx, $part) ==> new ListItem(
+          new NameToken(null, null, $part),
+          $idx === C\last_keyx($parts) ? null : new BackslashToken(null, null),
+        ),
+      )
+        |> NodeList::createMaybeEmptyList($$)
+        |> new QualifiedName($$);
+    }
+
+    // Copy over Trivia from $old_name_node.
+    if ($old_name_node is null) {
+      return $ret;
+    }
+
+    return $ret
+      ->withFirstTokenLeading($old_name_node->getFirstTokenx()->getLeading())
+      ->withLastTokenTrailing($old_name_node->getLastTokenx()->getTrailing());
+  }
+
+  /**
+   * 'Foo\Bar\Baz' -> tuple('Foo\Bar', 'Baz')
+   */
+  private static function split(string $qualified_name): (?string, string) {
+    $pos = Str\search_last($qualified_name, '\\');
+    return $pos is null
+      ? tuple(null, $qualified_name)
+      : tuple(
+          Str\slice($qualified_name, 0, $pos),
+          Str\slice($qualified_name, $pos + 1),
+        );
+  }
+
+  /**
+   * `Foo \ Bar \ Baz // comment` -> `Foo\Bar\Baz`
+   */
+  private static function withoutTrivia(Node $node): string {
+    return $node->getDescendantsOfType(Token::class)
+      |> Vec\map($$, $token ==> $token->getText())
+      |> Str\join($$, '');
+  }
+
+  private static function space(): NodeList<WhiteSpace> {
+    return NodeList::createMaybeEmptyList(vec[new WhiteSpace(' ')]);
+  }
+
+  private static function endl(): NodeList<EndOfLine> {
+    return NodeList::createMaybeEmptyList(vec[new EndOfLine("\n")]);
+  }
+}

--- a/src/__Private/MigrationCLI.hack
+++ b/src/__Private/MigrationCLI.hack
@@ -344,6 +344,14 @@ class MigrationCLI extends CLIWithRequiredArguments {
       ),
       CLIOptions\flag(
         () ==> {
+          $this->migrations[] = HHAST\XHPLibV3ToV4Migration::class;
+        },
+        'Migrate class/function names changed in xhp-lib v4, add necessary '.
+        '`use` clauses (incl. HTML tags)',
+        '--xhp-lib-v3-to-v4',
+      ),
+      CLIOptions\flag(
+        () ==> {
           $this->migrations[] = Fixme4110Migration::class;
         },
         'Migrate /* HH_FIXME[4110] */ to the equivalent new error codes',

--- a/src/nodes/Node.hack
+++ b/src/nodes/Node.hack
@@ -209,10 +209,29 @@ abstract class Node implements IMemoizeParam {
   }
 
   public function getLastToken(): ?Token {
-    foreach (Vec\reverse($this->getChildren()) as $child) {
-      return $child->getLastToken();
-    }
-    return null;
+    return C\last($this->getChildren())?->getLastToken();
+  }
+
+  final public function withFirstTokenLeading(
+    ?NodeList<Trivia> $leading,
+  ): this {
+    return $this is Token
+      ? $this->withLeading($leading)
+      : $this->replaceDescendant(
+          $this->getFirstTokenx(),
+          $this->getFirstTokenx()->withLeading($leading),
+        );
+  }
+
+  final public function withLastTokenTrailing(
+    ?NodeList<Trivia> $trailing,
+  ): this {
+    return $this is Token
+      ? $this->withTrailing($trailing)
+      : $this->replaceDescendant(
+          $this->getLastTokenx(),
+          $this->getLastTokenx()->withTrailing($trailing),
+        );
   }
 
   final public function rewriteDescendants<Tret as ?Node>(

--- a/src/nodes/Script.hack
+++ b/src/nodes/Script.hack
@@ -66,7 +66,9 @@ final class Script extends ScriptGeneratedBase {
       $namespace = $all_declarations[$idx];
       $idx++;
       if (!$namespace is NamespaceDeclaration) {
-        $global_declarations[] = $namespace;
+        if (!$namespace is EndOfFile) {
+          $global_declarations[] = $namespace;
+        }
         continue;
       }
 
@@ -100,10 +102,12 @@ final class Script extends ScriptGeneratedBase {
     $global_nodelist = NodeList::createMaybeEmptyList($global_declarations);
 
     // Add-in the global namespace.
-    $namespaces[] = shape(
-      'name' => null,
-      'children' => $global_nodelist,
-    );
+    if (!$global_nodelist->isEmpty()) {
+      $namespaces[] = shape(
+        'name' => null,
+        'children' => $global_nodelist,
+      );
+    }
 
     // Normalize name and calculate `use`s for each namespace.
 

--- a/src/nodes/Token.hack
+++ b/src/nodes/Token.hack
@@ -106,9 +106,9 @@ abstract class Token extends Node {
       $this->getTrailing()->getCode();
   }
 
-  public abstract function withLeading(?NodeList<Trivia> $leading): Token;
+  public abstract function withLeading(?NodeList<Trivia> $leading): this;
 
-  public abstract function withTrailing(?NodeList<Trivia> $trailing): Token;
+  public abstract function withTrailing(?NodeList<Trivia> $trailing): this;
 
   <<__Override>>
   final public static function fromJSON(

--- a/tests/XHPLibV3ToV4MigrationTest.hack
+++ b/tests/XHPLibV3ToV4MigrationTest.hack
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{Str, Vec};
+
+final class XHPLibV3ToV4MigrationTest extends MigrationTest {
+  const type TMigration = XHPLibV3ToV4Migration;
+
+  <<__Override>>
+  public function getExamples(): vec<(string)> {
+    return Vec\map(
+      \glob(__DIR__.'/examples/migrations/XHPLibV3ToV4/*.hack.in'),
+      $file ==> tuple(
+        Str\strip_suffix($file, '.in')
+          |> Str\strip_prefix($$, __DIR__.'/examples/'),
+      ),
+    );
+  }
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/basic.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/basic.hack.expect
@@ -1,0 +1,61 @@
+/* file docblock */
+
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP;
+use namespace Facebook\XHP\{Core as x, HTML};
+use type Facebook\XHP\HTML\{br, p};
+
+/** function docblock */
+function foo(
+  x\node $node,
+  // 1
+  x\element $element,
+  /* 2 */ x\primitive $primitive,
+  XHP\UnsafeRenderable $ur,
+  XHP\AlwaysValidChild $awc,  // 3
+  <<__Soft>> HTML\br $br,
+  vec<HTML\h1> $h1,
+): <<__Soft>> dict<string, (?x\node, x\element)> {
+  $classname = x\node::class;
+  $children = HTML\form::__xhpReflectionChildrenDeclaration();
+  return dict[
+    'foo' => tuple(
+      null,
+      <p>
+        Hello<br/>
+        world!
+      </p>,
+    ),
+  ];
+}
+
+class :my_element extends x\element {
+  use XHPChild\Validation;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(
+      /* 1 */ XHPChild\any_number_of /* 2 */ (XHPChild\of_type<HTML\div>()),
+      XHPChild\any_of(
+        XHPChild\of_type<:my_primitive>(),
+        XHPChild\at_least_one_of(XHPChild\of_type<HTML\p>()),
+      ),
+    );
+  }
+
+  /* 1 */ protected /* 2 */ async function /* 3 */ renderAsync /* 4 */ (
+  ): /* 5 */ Awaitable<x\element> /* 6 */ {
+    return <p>hi</p>;
+  }
+}
+
+class :my_primitive extends x\primitive {
+  protected async function stringifyAsync() /* missing return type */ {
+    return 'hi';
+  }
+}
+
+class MyUnsafeRenderable extends XHP\UnsafeRenderable {
+  /* no modifiers */ async function toHTMLStringAsync(): <<__Soft>> Awaitable<string> {
+    return '<p>hi</p>';
+  }
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/basic.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/basic.hack.in
@@ -1,0 +1,58 @@
+/* file docblock */
+
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+/** function docblock */
+function foo(
+  XHPRoot $node,
+  // 1
+  :x:element $element,
+  /* 2 */ :x:primitive $primitive,
+  XHPUnsafeRenderable $ur,
+  XHPAlwaysValidChild $awc,  // 3
+  <<__Soft>> :br $br,
+  vec<:h1> $h1,
+): <<__Soft>> dict<string, (?XHPRoot, :x:element)> {
+  $classname = XHPRoot::class;
+  $children = :form::__xhpReflectionChildrenDeclaration();
+  return dict[
+    'foo' => tuple(
+      null,
+      <p>
+        Hello<br/>
+        world!
+      </p>,
+    ),
+  ];
+}
+
+class :my_element extends :x:element {
+  use XHPChildValidation;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(
+      /* 1 */ XHPChild\anyNumberOf /* 2 */ (XHPChild\ofType<:div>()),
+      XHPChild /* these comments */ \ /* will be lost */ anyOf(
+        XHPChild\ofType<:my_primitive>(),
+        XHPChild\atLeastOneOf(XHPChild\ofType<:p>()),
+      ),
+    );
+  }
+
+  /* 1 */ protected /* 2 */ function /* 3 */ render /* 4 */ (
+  ): /* 5 */ :x:element /* 6 */ {
+    return <p>hi</p>;
+  }
+}
+
+class :my_primitive extends :x:primitive {
+  protected function stringify() /* missing return type */ {
+    return 'hi';
+  }
+}
+
+class MyUnsafeRenderable extends XHPUnsafeRenderable {
+  /* no modifiers */ function toHTMLString(): <<__Soft>> string {
+    return '<p>hi</p>';
+  }
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/existing_uses.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/existing_uses.hack.expect
@@ -1,0 +1,36 @@
+use namespace Facebook\XHP\{Core, HTML as h};
+use namespace Facebook\XHP\ChildValidation as not;
+
+// These are actually ignored, we always migrate to NS\Name:
+use type Facebook\XHP\{ChildValidation\Validation, UnsafeRenderable as Safe};
+use type Facebook\XHP\HTML\div as script;  // XSS protection
+
+// We'll add a conflicting `use type`, which will need to be resolved manually.
+use type Blue\Red as br;
+use namespace Facebook\XHP;
+use type Facebook\XHP\HTML\br;
+
+function foo(
+  Core\node $node,
+  Core\element $element,
+  XHP\UnsafeRenderable $ur,
+  XHP\AlwaysValidChild $awc,
+  h\br $br,
+  h\div $div,
+): void {
+  $classname = Core\node::class;
+  $children = h\div::__xhpReflectionChildrenDeclaration();
+  $xhp = <div>Hello<br />world!</div>;
+}
+
+class :my_element extends Core\element {
+  use not\Validation;
+
+  protected static function getChildrenDeclaration(): not\Constraint {
+    return not\of_type<h\div>();
+  }
+
+  protected async function renderAsync(): Awaitable<h\div> {
+    return <div>hi</div>;
+  }
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/existing_uses.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/existing_uses.hack.in
@@ -1,0 +1,34 @@
+use namespace Facebook\XHP\{Core, HTML as h};
+use namespace Facebook\XHP\ChildValidation as not;
+
+// These are actually ignored, we always migrate to NS\Name:
+use type Facebook\XHP\{ChildValidation\Validation, UnsafeRenderable as Safe};
+use type Facebook\XHP\HTML\div as script;  // XSS protection
+
+// We'll add a conflicting `use type`, which will need to be resolved manually.
+use type Blue\Red as br;
+
+function foo(
+  XHPRoot $node,
+  :x:element $element,
+  XHPUnsafeRenderable $ur,
+  XHPAlwaysValidChild $awc,
+  :br $br,
+  :div $div,
+): void {
+  $classname = XHPRoot::class;
+  $children = :div::__xhpReflectionChildrenDeclaration();
+  $xhp = <div>Hello<br />world!</div>;
+}
+
+class :my_element extends :x:element {
+  use XHPChildValidation;
+
+  protected static function getChildrenDeclaration(): not\Constraint {
+    return not\ofType<:div>();
+  }
+
+  protected function render(): :div {
+    return <div>hi</div>;
+  }
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_body_n.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_body_n.hack.expect
@@ -1,0 +1,4 @@
+namespace Foo {
+use namespace Facebook\XHP\Core as x;
+  function foo(x\node $node): void {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_body_n.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_body_n.hack.in
@@ -1,0 +1,3 @@
+namespace Foo {
+  function foo(\XHPRoot $node): void {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_body_nu.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_body_nu.hack.expect
@@ -1,0 +1,11 @@
+namespace Foo {
+  use namespace Facebook\XHP;
+  use namespace Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP\Core as x;
+
+  function foo(
+    x\node $node,
+    XHPChild\Constraint $c,
+    XHP\UnsafeRenderable $ur,
+  ): void {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_body_nu.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_body_nu.hack.in
@@ -1,0 +1,10 @@
+namespace Foo {
+  use namespace Facebook\XHP;
+  use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+  function foo(
+    \XHPRoot $node,
+    XHPChild\Constraint $c,
+    XHP\UnsafeRenderable $ur,
+  ): void {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_body_un.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_body_un.hack.expect
@@ -1,0 +1,11 @@
+use namespace Facebook\XHP;
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP\Core as x;
+
+namespace Foo {
+  function foo(
+    x\node $node,
+    XHPChild\Constraint $c,
+    XHP\UnsafeRenderable $ur,
+  ): void {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_body_un.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_body_un.hack.in
@@ -1,0 +1,10 @@
+use namespace Facebook\XHP;
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+namespace Foo {
+  function foo(
+    \XHPRoot $node,
+    XHPChild\Constraint $c,
+    XHP\UnsafeRenderable $ur,
+  ): void {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_body_unu.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_body_unu.hack.expect
@@ -1,0 +1,12 @@
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP\Core as x;
+
+namespace Foo {
+  use namespace Facebook\XHP;
+
+  function foo(
+    x\node $node,
+    XHPChild\Constraint $c,
+    XHP\UnsafeRenderable $ur,
+  ): void {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_body_unu.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_body_unu.hack.in
@@ -1,0 +1,11 @@
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+namespace Foo {
+  use namespace Facebook\XHP;
+
+  function foo(
+    \XHPRoot $node,
+    XHPChild\Constraint $c,
+    XHP\UnsafeRenderable $ur,
+  ): void {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_n.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_n.hack.expect
@@ -1,0 +1,4 @@
+namespace Foo;
+use namespace Facebook\XHP\Core as x;
+
+function foo(x\node $node): void {}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_n.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_n.hack.in
@@ -1,0 +1,3 @@
+namespace Foo;
+
+function foo(\XHPRoot $node): void {}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_nu.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_nu.hack.expect
@@ -1,0 +1,11 @@
+namespace Foo;
+
+use namespace Facebook\XHP;
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP\Core as x;
+
+function foo(
+  x\node $node,
+  XHPChild\Constraint $c,
+  XHP\UnsafeRenderable $ur,
+): void {}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_nu.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_nu.hack.in
@@ -1,0 +1,10 @@
+namespace Foo;
+
+use namespace Facebook\XHP;
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+function foo(
+  \XHPRoot $node,
+  XHPChild\Constraint $c,
+  XHP\UnsafeRenderable $ur,
+): void {}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_un.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_un.hack.expect
@@ -1,0 +1,11 @@
+use namespace Facebook\XHP;
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP\Core as x;
+
+namespace Foo;
+
+function foo(
+  x\node $node,
+  XHPChild\Constraint $c,
+  XHP\UnsafeRenderable $ur,
+): void {}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_un.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_un.hack.in
@@ -1,0 +1,10 @@
+use namespace Facebook\XHP;
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+namespace Foo;
+
+function foo(
+  \XHPRoot $node,
+  XHPChild\Constraint $c,
+  XHP\UnsafeRenderable $ur,
+): void {}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_unu.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_unu.hack.expect
@@ -1,0 +1,12 @@
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP\Core as x;
+
+namespace Foo;
+
+use namespace Facebook\XHP;
+
+function foo(
+  x\node $node,
+  XHPChild\Constraint $c,
+  XHP\UnsafeRenderable $ur,
+): void {}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_unu.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns1_nobody_unu.hack.in
@@ -1,0 +1,11 @@
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+namespace Foo;
+
+use namespace Facebook\XHP;
+
+function foo(
+  \XHPRoot $node,
+  XHPChild\Constraint $c,
+  XHP\UnsafeRenderable $ur,
+): void {}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns2_body_nn.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns2_body_nn.hack.expect
@@ -1,0 +1,9 @@
+use namespace Facebook\XHP;
+use namespace Facebook\XHP\Core as x;
+namespace Foo {
+  function foo(x\node $node): void {}
+}
+
+namespace Bar {
+  function foo(XHP\UnsafeRenderable $ur) {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns2_body_nn.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns2_body_nn.hack.in
@@ -1,0 +1,7 @@
+namespace Foo {
+  function foo(\XHPRoot $node): void {}
+}
+
+namespace Bar {
+  function foo(\XHPUnsafeRenderable $ur) {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns2_body_unn.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns2_body_unn.hack.expect
@@ -1,0 +1,15 @@
+use namespace Facebook\XHP;
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP\Core as x;
+
+namespace Foo {
+  function foo(
+    x\node $node,
+    XHPChild\Constraint $c,
+    XHP\UnsafeRenderable $ur,
+  ): void {}
+}
+
+namespace Bar {
+  function foo(XHP\UnsafeRenderable $ur) {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns2_body_unn.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns2_body_unn.hack.in
@@ -1,0 +1,14 @@
+use namespace Facebook\XHP;
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+namespace Foo {
+  function foo(
+    \XHPRoot $node,
+    XHPChild\Constraint $c,
+    XHP\UnsafeRenderable $ur,
+  ): void {}
+}
+
+namespace Bar {
+  function foo(\XHPUnsafeRenderable $ur) {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns2_body_unun.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns2_body_unun.hack.expect
@@ -1,0 +1,16 @@
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP;
+
+namespace Foo {
+  use namespace Facebook\XHP\Core;
+
+  function foo(
+    Core\node $node,
+    XHPChild\Constraint $c,
+    XHP\UnsafeRenderable $ur,
+  ): void {}
+}
+
+namespace Bar {
+  function foo(XHP\UnsafeRenderable $ur) {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns2_body_unun.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns2_body_unun.hack.in
@@ -1,0 +1,15 @@
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+namespace Foo {
+  use namespace Facebook\XHP\Core;
+
+  function foo(
+    \XHPRoot $node,
+    XHPChild\Constraint $c,
+    \XHPUnsafeRenderable $ur,
+  ): void {}
+}
+
+namespace Bar {
+  function foo(\XHPUnsafeRenderable $ur) {}
+}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns2_nobody_nn.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns2_nobody_nn.hack.expect
@@ -1,0 +1,7 @@
+use namespace Facebook\XHP;
+use namespace Facebook\XHP\Core as x;
+namespace Foo;
+function foo(x\node $node): void {}
+
+namespace Bar;
+function foo(XHP\UnsafeRenderable $ur) {}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns2_nobody_nn.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns2_nobody_nn.hack.in
@@ -1,0 +1,5 @@
+namespace Foo;
+function foo(\XHPRoot $node): void {}
+
+namespace Bar;
+function foo(\XHPUnsafeRenderable $ur) {}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns2_nobody_unn.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns2_nobody_unn.hack.expect
@@ -1,0 +1,15 @@
+use namespace Facebook\XHP;
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP\Core as x;
+
+namespace Foo;
+
+function foo(
+  x\node $node,
+  XHPChild\Constraint $c,
+  XHP\UnsafeRenderable $ur,
+): void {}
+
+namespace Bar;
+
+function foo(XHP\UnsafeRenderable $ur) {}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns2_nobody_unn.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns2_nobody_unn.hack.in
@@ -1,0 +1,14 @@
+use namespace Facebook\XHP;
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+namespace Foo;
+
+function foo(
+  \XHPRoot $node,
+  XHPChild\Constraint $c,
+  XHP\UnsafeRenderable $ur,
+): void {}
+
+namespace Bar;
+
+function foo(\XHPUnsafeRenderable $ur) {}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns2_nobody_unun.hack.expect
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns2_nobody_unun.hack.expect
@@ -1,0 +1,13 @@
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+use namespace Facebook\XHP;
+
+namespace Foo;
+use namespace Facebook\XHP\Core;
+function foo(
+  Core\node $node,
+  XHPChild\Constraint $c,
+  XHP\UnsafeRenderable $ur,
+): void {}
+
+namespace Bar;
+function foo(XHP\UnsafeRenderable $ur) {}

--- a/tests/examples/migrations/XHPLibV3ToV4/ns2_nobody_unun.hack.in
+++ b/tests/examples/migrations/XHPLibV3ToV4/ns2_nobody_unun.hack.in
@@ -1,0 +1,12 @@
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+namespace Foo;
+use namespace Facebook\XHP\Core;
+function foo(
+  \XHPRoot $node,
+  XHPChild\Constraint $c,
+  \XHPUnsafeRenderable $ur,
+): void {}
+
+namespace Bar;
+function foo(\XHPUnsafeRenderable $ur) {}


### PR DESCRIPTION
I put it all in a single migration since there's no point in running any subset of this (all of this is needed iff migrating to xhp-lib v4):

- renamed types
- renamed functions in XHPChild
- add `use type` for any XHP open/close tags that are HTML tags
- asyncify methods if extending one of the relevant base classes

(see consts in the migration class for the exact lists)

There's a lot of test files because there are different combinations of namespaces which are impossible to test in a single file. Even though XHP classes can't be used from namespaced files, all the non-XHP classes (e.g. XHPRoot) can.