### PR TITLE
update docs/ast-lib.md

### DIFF
--- a/docs/ast-lib.md
+++ b/docs/ast-lib.md
@@ -10,22 +10,27 @@ php composer.phar require hhvm/hhast
 
 ## Introduction
 
-[`Facebook\HHAST\from_file()`](../src/entrypoints.php) is the main entry point to the library; it will get you an instance of
-[`Node`](../src/Node.php), most likely a [`Script`](../codegen/syntax/Script.php). The main classes are:
+[`Facebook\HHAST\from_file()`](../src/entrypoints.hack) is the main entry point to the library; it will get you an instance of
+[`Node`](../src/nodes/Node.hack), most likely a [`Script`](../codegen/syntax/Script.hack). The main classes are:
 
- - [`Node`](../src/Node.php): the base class of all AST nodes
- - [`Token`](../src/Token.php): the base class of all nodes that are also tokens; this is a subclass of `Node`
- - [`Trivia`](../src/Trivia.php): the base class of all nodes that do not affect runtime behavior, such as whitespace and comments; this is a subclass of `Node`
- - [`NodeList`](../src/Trivia.php): this node merely contains a vector-like list of child nodes; this is a subclass of `Node`
- - [`Missing`](../src/Missing.php): a singleton; this node is present when an optional node is not present. It is a subclass of `Node`, and instantiated via the function `Missing()`
+ - [`Node`](../src/nodes/Node.hack): the base class of all AST nodes
+ - [`Token`](../src/nodes/Token.hack): the base class of all nodes that are also tokens; this is a subclass of `Node`
+ - [`Trivia`](../src/nodes/Trivia.hack): the base class of all nodes that do not affect runtime behavior, such as whitespace and comments; this is a subclass of `Node`
+ - [`NodeList`](../src/nodes/NodeList.hack): this node merely contains a vector-like list of child nodes; this is a subclass of `Node`
+ - [`ListItem`](../src/nodes/ListItem.hack): most `NodeList`s have these as
+   children, each contains the relevant child node (accessed via `->getItem()`)
+   and the separator that follows it (comma/backslash/...); `ListItem`s are not
+   used by `NodeList`s without separators
 
-For every type of node in the full fidelity AST, there is a generated class extending `Node`, `Token`, or `Trivia`; for example, class declarations are represented by the [`ClassishDeclaration`](../codegen/syntax/ClassishDeclaration.php) class. These define accessors for every field on the node.
+For every type of node in the full fidelity AST, there is a generated class extending `Node`, `Token`, or `Trivia`; for example, class declarations are represented by the [`ClassishDeclaration`](../codegen/syntax/ClassishDeclaration.hack) class. These define accessors for every field on the node.
 
-Additionally, several interfaces are defined for convenience, which are not present in the FFP schema:
+Additionally, several interfaces are defined for convenience, which are not present in the FFP schema; for example:
 
  - `IControlFlowStatement`: implemented by structures like `if` and looping constructs
  - `IFunctionishDeclaration`: implemented by both function and method declarations
  - `ILoopStatement`: sub-interface of `IControlFlowStatement`, specifically for looping constructs
+ - see [`CodegenBase`](../src/__Private/codegen/CodegenBase.hack#L118) for the
+   full list
 
 These are primarily useful for `instanceof` checks, or as a value for `classname<Node>` when calling `get(Children|Descendants)OfType()`.
 
@@ -41,23 +46,49 @@ For the basic API, see below; for usage examples, see:
  - `->getChildrenWhere((function(Node):bool))`: return all direct children of the node where the function returns true
  - `->getChildrenOfType(classname<Node>)`: return all direct children of the specified type
  - `->traverse()`: return the node and all recursive descendants
- - `->traverseWithParents()`: return the node and all recursive descendants, and the stack of the parents
  - `->getDescendantsWhere((function(Node$node, vec<Node> $parents):bool))`: return all recursive children of the node where the function returns true
  - `->getDescendantsOfType(classname<Node>)`: return all recursive children of the specified type
+ - `->getAncestorsOfDescendant(Node $descendant)`: return the sequence of child
+   nodes starting with `$this` and ending with `$descendant` (throws if not a
+   descendant of `$this`); call on `Script` to get all ancestors
+ - `->getParentOfDescendant(Node)`: return only the last node from the above list
  - `->getFirstToken()`: returns the first `Token` that is part of the current node
  - `->getLastToken()`: returns the first `Token` that is part of the current node
+ - `->getChildrenOfItems(): vec<T>`: only available on `NodeList<ListItem<T>>`,
+   returns the output of `getItem()` on each of the child `ListItem`s (for when
+   you don't care about the separators)&mdash;so actually "items of children",
+   despite the name
 
 ## Write Methods
 
 The AST does not support in-place editing; instead, all mutation functions return a new node with the specified mutation applied.
 
- - `->rewrite((function(Node $node, vec<Node> $parents): Node))`: traverses the AST, and applies the specified mapping function to every node. To remove a node, you can specify `Missing()`
+ - `->with...($replacement)` returns a copy of the node with a specific child
+   replaced, e.g. `$class->withName(new NameToken(...))` returns an identical
+   class node except for its name; this is the only type-safe way to mutate an
+   AST, as each of these methods is generated with the correct argument type
+ - `->rewrite((function(Node $node, vec<Node> $parents): Node))`: traverses the AST, and applies the specified mapping function to every node;
+   cannot add or remove nodes (see below)
  - `->rewriteDescendants((function(Node $node, vec<Node> $parents): Node)): this`: traverses the AST, and applies the specified mapping function to every node except itself, so returns a node of the same type.
  - `->replace(Node $old, Node $new)`: return a copy of the node with descendant `$old` replaced with `$new`
- - `->removeWhere((function(Node, vec<Node>)))`: returns a copy of the node without any descendants that pass the predicate
- - `->remove(Node)`: returns a copy of the node without the specified descendant
- - `->insertAfter(Node $target, Node $new)`: returns a copy of the node with the specified `$new` node inserted after the `$target` node
- - `->insertBefore(Node $target, Node $new)`: returns a copy of the node with the specified `$new` node inserted before the `$target` node
+
+### Adding and removing nodes
+
+Arbitrary nodes can't be added or removed, as it could result in an invalid AST.
+Most commonly, nodes are added to or removed from a `NodeList`, which can be
+done by providing a new `NodeList` to `->replace(...)` or to the parent node's
+constructor or `->with...(...)` method. The `NodeList` class provides some
+helper static methods:
+
+- `NodeList::createMaybeEmptyList(vec<T>): NodeList<T>`
+- `NodeList::createNonEmptyListOrNull(vec<T>): ?NodeList<T>`
+- `NodeList::concat(NodeList<T>, NodeList<T>): NodeList<T>`
+
+Other than that, nodes can only be added or removed when the parent node
+declares a specific child as nullable, by passing `null` to the parent node's
+constructor or `->with...(null)` method. For example,
+`$class->withTypeParameters(null)` returns a copy of `$class` but without any
+generic type parameters.
 
 ## Tokens
 
@@ -76,13 +107,14 @@ For every field on AST node, there are at least two accessors; assuming a field 
  - `->getSomeField()`: returns `T` or `?T` where T is either `Node`, or a subclass of it
 
 
-If `Missing` is considered a valid value, additional methods are defined:
+If `null` is considered a valid value, additional methods are defined:
 
  - `->hasSomeField()`: returns true or false
  - `->getSomeFieldx()`: returns `T` or throws an exception if missing
 
 ## Advice
 
- - install `jq` or another JSON prettifier, and examine files containing AST structures you're interested in with `hh_parse --full-fidelity-json $file | jq`
+ - HHAST can generate HTML pages to explore the AST when given a file from disk; you can create such an HTML file by using `bin/hhast-inspect --output="where_do_you_want_it.html" /path/to/hackfile.hack`
+ - alternatively, install `jq` or another JSON prettifier, and examine files containing AST structures you're interested in with `hh_parse --full-fidelity-json $file | jq`
  - use an IDE with autocompletion; there are far too many AST node types for memorizing the APIs to be practical
  - if you are using the write API, write unit tests with various combinations of leading and trailing whitespace and comments


### PR DESCRIPTION
This had a bunch of invalid links and mentioned a lot of methods that no longer exist.

(the rendered markdown mode makes it easier to review, most changed lines in the source code are just fixed URLs)