### PR TITLE
bring back XHP children migrations, revert version bump

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 bin/update-* export-ignore
 src/__Private/codegen/ export-ignore
 src/__Private/CodegenCLI.hack export-ignore
+src/codegen/data/ export-ignore
 tests/ export-ignore
 codegen/**/* linguist-generated
 .hhconfig export-ignore

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         os: [ ubuntu , macos ]
         hhvm:
-          - 4.74
+          - 4.72
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.hhconfig
+++ b/.hhconfig
@@ -12,5 +12,6 @@ disallow_array_literal = true
 disable_lval_as_an_expression = true
 new_inference_lambda = true
 error_php_lambdas = true
+disable_xhp_children_declarations = false
 allowed_decl_fixme_codes=2053,4045,4047
 allowed_fixme_codes_strict=2011,2049,2050,2053,2083,3084,4027,4045,4047,4104,4106,4107,4108,4110,4128,4135,4188,4223,4240,4323

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: generic
 services: docker
 env:
-  - HHVM_VERSION=4.74-latest
+  - HHVM_VERSION=4.72-latest
   - HHVM_VERSION=latest
   - HHVM_VERSION=nightly
 install:

--- a/codegen/inferred_relationships.hack
+++ b/codegen/inferred_relationships.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d72aab49f53a0b80507d89c1beaac25a>>
+ * @generated SignedSource<<73568419576595204a545a143b64317b>>
  */
 namespace Facebook\HHAST\__Private;
 
@@ -2579,11 +2579,14 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'member_selection_expression',
     'scope_resolution_expression',
     'subscript_expression',
+    'token:name',
     'variable',
   ],
   'postfix_unary_expression.postfix_unary_operator' => keyset[
+    'token:*',
     'token:++',
     'token:--',
+    'token:?',
   ],
   'prefix_unary_expression.prefix_unary_operand' => keyset[
     'anonymous_function',
@@ -2810,6 +2813,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<classish_declaration|end_of_file|function_declaration|markup_section|namespace_declaration|namespace_use_declaration>',
     'list<classish_declaration|end_of_file|function_declaration|markup_section|namespace_use_declaration>',
     'list<classish_declaration|end_of_file|markup_section>',
+    'list<classish_declaration|end_of_file|namespace_declaration>',
     'list<classish_declaration|end_of_file|namespace_declaration|namespace_group_use_declaration|namespace_use_declaration>',
     'list<const_declaration|end_of_file|function_declaration|markup_section>',
     'list<const_declaration|end_of_file|function_declaration|markup_section|namespace_declaration>',
@@ -3690,12 +3694,23 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   ],
   'xhp_children_declaration.xhp_children_expression' => keyset[
     'token:empty',
+    'xhp_children_parenthesized_list',
   ],
   'xhp_children_declaration.xhp_children_keyword' => keyset[
     'token:children',
   ],
   'xhp_children_declaration.xhp_children_semicolon' => keyset[
     'token:;',
+  ],
+  'xhp_children_parenthesized_list.xhp_children_list_left_paren' => keyset[
+    'token:(',
+  ],
+  'xhp_children_parenthesized_list.xhp_children_list_right_paren' => keyset[
+    'token:)',
+  ],
+  'xhp_children_parenthesized_list.xhp_children_list_xhp_children' => keyset[
+    'list<list_item<postfix_unary_expression>|list_item<token:name>>',
+    'list<list_item<token:name>>',
   ],
   'xhp_class_attribute.xhp_attribute_decl_initializer' => keyset[
     'missing',

--- a/codegen/syntax/PostfixUnaryExpression.hack
+++ b/codegen/syntax/PostfixUnaryExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<937b00a97de1e8c5d144b9962209982c>>
+ * @generated SignedSource<<a4073bb8c2f541f1e6bcc8d2f04853d5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -110,7 +110,7 @@ final class PostfixUnaryExpression
 
   /**
    * @return MemberSelectionExpression | ScopeResolutionExpression |
-   * SubscriptExpression | VariableExpression
+   * SubscriptExpression | NameToken | VariableExpression
    */
   public function getOperand(): IExpression {
     return TypeAssert\instance_of(IExpression::class, $this->_operand);
@@ -118,7 +118,7 @@ final class PostfixUnaryExpression
 
   /**
    * @return MemberSelectionExpression | ScopeResolutionExpression |
-   * SubscriptExpression | VariableExpression
+   * SubscriptExpression | NameToken | VariableExpression
    */
   public function getOperandx(): IExpression {
     return $this->getOperand();
@@ -140,14 +140,14 @@ final class PostfixUnaryExpression
   }
 
   /**
-   * @return PlusPlusToken | MinusMinusToken
+   * @return StarToken | PlusPlusToken | MinusMinusToken | QuestionToken
    */
   public function getOperator(): Token {
     return TypeAssert\instance_of(Token::class, $this->_operator);
   }
 
   /**
-   * @return PlusPlusToken | MinusMinusToken
+   * @return StarToken | PlusPlusToken | MinusMinusToken | QuestionToken
    */
   public function getOperatorx(): Token {
     return $this->getOperator();

--- a/codegen/syntax/XHPChildrenDeclaration.hack
+++ b/codegen/syntax/XHPChildrenDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d7630eb07b4f7f949fcb59e493eb33ff>>
+ * @generated SignedSource<<7b09c7dcf5ba973ed788ec5469d0b986>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -15,12 +15,12 @@ final class XHPChildrenDeclaration
   const string SYNTAX_KIND = 'xhp_children_declaration';
 
   private ChildrenToken $_keyword;
-  private EmptyToken $_expression;
+  private Node $_expression;
   private SemicolonToken $_semicolon;
 
   public function __construct(
     ChildrenToken $keyword,
-    EmptyToken $expression,
+    Node $expression,
     SemicolonToken $semicolon,
     ?__Private\SourceRef $source_ref = null,
   ) {
@@ -53,7 +53,7 @@ final class XHPChildrenDeclaration
       $file,
       $offset,
       $source,
-      'EmptyToken',
+      'Node',
     );
     $expression = $expression as nonnull;
     $offset += $expression->getWidth();
@@ -146,7 +146,7 @@ final class XHPChildrenDeclaration
     return $this->_expression;
   }
 
-  public function withExpression(EmptyToken $value): this {
+  public function withExpression(Node $value): this {
     if ($value === $this->_expression) {
       return $this;
     }
@@ -158,16 +158,16 @@ final class XHPChildrenDeclaration
   }
 
   /**
-   * @return EmptyToken
+   * @return EmptyToken | XHPChildrenParenthesizedList
    */
-  public function getExpression(): EmptyToken {
-    return TypeAssert\instance_of(EmptyToken::class, $this->_expression);
+  public function getExpression(): Node {
+    return $this->_expression;
   }
 
   /**
-   * @return EmptyToken
+   * @return EmptyToken | XHPChildrenParenthesizedList
    */
-  public function getExpressionx(): EmptyToken {
+  public function getExpressionx(): Node {
     return $this->getExpression();
   }
 

--- a/codegen/syntax/XHPChildrenParenthesizedList.hack
+++ b/codegen/syntax/XHPChildrenParenthesizedList.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<aa03e936634cb1364015b005a062dcf0>>
+ * @generated SignedSource<<3ce7005d5b74500b993f53ec73c54f54>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -14,14 +14,14 @@ final class XHPChildrenParenthesizedList
 
   const string SYNTAX_KIND = 'xhp_children_parenthesized_list';
 
-  private ?Node $_left_paren;
-  private ?Node $_xhp_children;
-  private ?Node $_right_paren;
+  private LeftParenToken $_left_paren;
+  private NodeList<ListItem<IExpression>> $_xhp_children;
+  private RightParenToken $_right_paren;
 
   public function __construct(
-    ?Node $left_paren,
-    ?Node $xhp_children,
-    ?Node $right_paren,
+    LeftParenToken $left_paren,
+    NodeList<ListItem<IExpression>> $xhp_children,
+    RightParenToken $right_paren,
     ?__Private\SourceRef $source_ref = null,
   ) {
     $this->_left_paren = $left_paren;
@@ -40,29 +40,32 @@ final class XHPChildrenParenthesizedList
   ): this {
     $offset = $initial_offset;
     $left_paren = Node::fromJSON(
-      /* HH_FIXME[4110] */ $json['xhp_children_list_left_paren'] ?? dict['kind' => 'missing'],
+      /* HH_FIXME[4110] */ $json['xhp_children_list_left_paren'],
       $file,
       $offset,
       $source,
-      'Node',
+      'LeftParenToken',
     );
-    $offset += $left_paren?->getWidth() ?? 0;
+    $left_paren = $left_paren as nonnull;
+    $offset += $left_paren->getWidth();
     $xhp_children = Node::fromJSON(
-      /* HH_FIXME[4110] */ $json['xhp_children_list_xhp_children'] ?? dict['kind' => 'missing'],
+      /* HH_FIXME[4110] */ $json['xhp_children_list_xhp_children'],
       $file,
       $offset,
       $source,
-      'Node',
+      'NodeList<ListItem<IExpression>>',
     );
-    $offset += $xhp_children?->getWidth() ?? 0;
+    $xhp_children = $xhp_children as nonnull;
+    $offset += $xhp_children->getWidth();
     $right_paren = Node::fromJSON(
-      /* HH_FIXME[4110] */ $json['xhp_children_list_right_paren'] ?? dict['kind' => 'missing'],
+      /* HH_FIXME[4110] */ $json['xhp_children_list_right_paren'],
       $file,
       $offset,
       $source,
-      'Node',
+      'RightParenToken',
     );
-    $offset += $right_paren?->getWidth() ?? 0;
+    $right_paren = $right_paren as nonnull;
+    $offset += $right_paren->getWidth();
     $source_ref = shape(
       'file' => $file,
       'source' => $source,
@@ -93,15 +96,9 @@ final class XHPChildrenParenthesizedList
     vec<Node> $parents = vec[],
   ): this {
     $parents[] = $this;
-    $left_paren = $this->_left_paren === null
-      ? null
-      : $rewriter($this->_left_paren, $parents);
-    $xhp_children = $this->_xhp_children === null
-      ? null
-      : $rewriter($this->_xhp_children, $parents);
-    $right_paren = $this->_right_paren === null
-      ? null
-      : $rewriter($this->_right_paren, $parents);
+    $left_paren = $rewriter($this->_left_paren, $parents);
+    $xhp_children = $rewriter($this->_xhp_children, $parents);
+    $right_paren = $rewriter($this->_right_paren, $parents);
     if (
       $left_paren === $this->_left_paren &&
       $xhp_children === $this->_xhp_children &&
@@ -120,7 +117,7 @@ final class XHPChildrenParenthesizedList
     return $this->_left_paren;
   }
 
-  public function withLeftParen(?Node $value): this {
+  public function withLeftParen(LeftParenToken $value): this {
     if ($value === $this->_left_paren) {
       return $this;
     }
@@ -132,24 +129,26 @@ final class XHPChildrenParenthesizedList
   }
 
   /**
-   * @return unknown
+   * @return LeftParenToken
    */
-  public function getLeftParen(): ?Node {
-    return $this->_left_paren;
+  public function getLeftParen(): LeftParenToken {
+    return TypeAssert\instance_of(LeftParenToken::class, $this->_left_paren);
   }
 
   /**
-   * @return unknown
+   * @return LeftParenToken
    */
-  public function getLeftParenx(): Node {
-    return TypeAssert\not_null($this->getLeftParen());
+  public function getLeftParenx(): LeftParenToken {
+    return $this->getLeftParen();
   }
 
   public function getXhpChildrenUNTYPED(): ?Node {
     return $this->_xhp_children;
   }
 
-  public function withXhpChildren(?Node $value): this {
+  public function withXhpChildren(
+    NodeList<ListItem<IExpression>> $value,
+  ): this {
     if ($value === $this->_xhp_children) {
       return $this;
     }
@@ -161,24 +160,24 @@ final class XHPChildrenParenthesizedList
   }
 
   /**
-   * @return unknown
+   * @return NodeList<ListItem<IExpression>> | NodeList<ListItem<NameToken>>
    */
-  public function getXhpChildren(): ?Node {
-    return $this->_xhp_children;
+  public function getXhpChildren(): NodeList<ListItem<IExpression>> {
+    return TypeAssert\instance_of(NodeList::class, $this->_xhp_children);
   }
 
   /**
-   * @return unknown
+   * @return NodeList<ListItem<IExpression>> | NodeList<ListItem<NameToken>>
    */
-  public function getXhpChildrenx(): Node {
-    return TypeAssert\not_null($this->getXhpChildren());
+  public function getXhpChildrenx(): NodeList<ListItem<IExpression>> {
+    return $this->getXhpChildren();
   }
 
   public function getRightParenUNTYPED(): ?Node {
     return $this->_right_paren;
   }
 
-  public function withRightParen(?Node $value): this {
+  public function withRightParen(RightParenToken $value): this {
     if ($value === $this->_right_paren) {
       return $this;
     }
@@ -190,16 +189,16 @@ final class XHPChildrenParenthesizedList
   }
 
   /**
-   * @return unknown
+   * @return RightParenToken
    */
-  public function getRightParen(): ?Node {
-    return $this->_right_paren;
+  public function getRightParen(): RightParenToken {
+    return TypeAssert\instance_of(RightParenToken::class, $this->_right_paren);
   }
 
   /**
-   * @return unknown
+   * @return RightParenToken
    */
-  public function getRightParenx(): Node {
-    return TypeAssert\not_null($this->getRightParen());
+  public function getRightParenx(): RightParenToken {
+    return $this->getRightParen();
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "hhvm/hacktest": "^2.2.0"
     },
     "require": {
-        "hhvm": "^4.74",
+        "hhvm": "^4.72",
         "hhvm/hsl": "^4.25",
         "hhvm/hsl-experimental": "^4.58.0rc1",
         "hhvm/hsl-io": "^0.2.0",

--- a/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
@@ -1,0 +1,443 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{C, Str, Vec};
+
+final class AddXHPChildrenDeclarationMethodMigration
+  extends StepBasedMigration {
+  private static function scopeNeedsUseNamespace(NodeList<Node> $in): bool {
+    if (
+      Str\contains(
+        $in->getCode(),
+        'use namespace Facebook\\XHP\\ChildValidation as XHPChild;',
+      )
+    ) {
+      return false;
+    }
+    $classes = $in->getChildrenOfType(ClassishDeclaration::class);
+    return C\any(
+      $classes,
+      $class ==> !C\is_empty(
+        $class->getBody()
+          ->getElements()
+          ?->getChildrenOfType(XHPChildrenDeclaration::class) ??
+          vec[],
+      ),
+    );
+  }
+
+  private static function addUseNamespaceToScript(Script $in): Script {
+    $decls = $in->getDeclarations();
+    if (!self::scopeNeedsUseNamespace($decls)) {
+      return $in;
+    }
+
+    $before = C\firstx($decls->getChildrenOfType(IDeclaration::class));
+    $t = $before->getFirstTokenx();
+    $use = self::getUseNamespace();
+    if ($t->getLeading() !== $t->getLeadingWhitespace()) {
+      $ut = $use->getFirstTokenx();
+      return $in->withDeclarations(
+        $in->getDeclarations()->insertBefore(
+          $before,
+          $use->replace($ut, $ut->withLeading($t->getLeading())),
+        ),
+      )
+        ->replace($t, $t->withLeading(null));
+    }
+    return $in->withDeclarations(
+      $decls->insertBefore($before, self::getUseNamespace()),
+    );
+  }
+
+  private static function addUseNamespaceToNamespaceBlock(
+    NamespaceDeclaration $in,
+  ): NamespaceDeclaration {
+    // Can't use XHP in namespaces, so if we're not in the root namespace,
+    // we have nothing to do.
+    if ($in->hasName()) {
+      return $in;
+    }
+
+    // Don't have to worry about empty bodies as `namespace;` is invalid,
+    // and `namespace foo;` is caught above.
+
+    $body = $in->getBody() as NamespaceBody;
+    $decls = $body->getDeclarationsx();
+    if (!self::scopeNeedsUseNamespace($decls)) {
+      return $in;
+    }
+
+    $use = self::getUseNamespace();
+    $ws = $decls->getFirstTokenx()->getLeadingWhitespace();
+    if ($ws !== null) {
+      $t = $use->getFirstTokenx();
+      $use = $use->replace($t, $t->withLeading(new NodeList(vec[$ws])));
+    }
+
+    return $in->withBody(
+      $body->withDeclarations(
+        $decls->insertBefore(
+          C\firstx($decls->getChildrenOfType(IDeclaration::class)),
+          $use,
+        ),
+      ),
+    );
+  }
+
+  <<__Memoize>>
+  private static function getUseNamespace(): NamespaceUseDeclaration {
+    $s = new NodeList(vec[new WhiteSpace(' ')]);
+    return new NamespaceUseDeclaration(
+      new UseToken(null, $s),
+      new NamespaceToken(null, $s),
+      new NodeList(vec[new ListItem(
+        new NamespaceUseClause(
+          null,
+          new QualifiedName(
+            new NodeList(vec[
+              new ListItem(
+                new NameToken(null, null, 'Facebook'),
+                new BackslashToken(null, null),
+              ),
+              new ListItem(
+                new NameToken(null, null, 'XHP'),
+                new BackslashToken(null, null),
+              ),
+              new ListItem(new NameToken(null, $s, 'ChildValidation'), null),
+            ]),
+          ),
+          new AsToken(null, $s, 'as'),
+          new NameToken(null, null, 'XHPChild'),
+        ),
+        null,
+      )]),
+      new SemicolonToken(
+        null,
+        new NodeList(vec[new EndOfLine("\n"), new EndOfLine("\n")]),
+      ),
+    );
+  }
+
+  private static function alreadyUsesTrait(ClassishBody $in): bool {
+    $uses = $in->getElementsx()->getChildrenOfType(TraitUse::class)
+      |> Vec\map($$, $use ==> $use->getNames()->getChildrenOfItems())
+      |> Vec\flatten($$);
+    foreach ($uses as $use) {
+      $name = $use ?as SimpleTypeSpecifier
+        |> $$?->getSpecifier() ?as NameToken
+        |> $$?->getText();
+      if (
+        $name === 'XHPChildValidation' ||
+        $name === 'XHPChildDeclarationConsistencyValidation'
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static function addTrait(ClassishBody $in): ClassishBody {
+    $decl = $in->getElements()
+      ?->getChildrenOfType(XHPChildrenDeclaration::class) ??
+      vec[];
+    if (C\is_empty($decl)) {
+      return $in;
+    }
+    if (self::alreadyUsesTrait($in)) {
+      return $in;
+    }
+
+    $decl = C\firstx($decl);
+
+    $indent = $decl->getFirstTokenx()->getLeadingWhitespace()?->getText() ?? '';
+    $use = new TraitUse(
+      new UseToken(
+        new NodeList(vec[new WhiteSpace($indent)]),
+        new NodeList(vec[new WhiteSpace(' ')]),
+      ),
+      new NodeList(vec[
+        new ListItem(
+          new SimpleTypeSpecifier(
+            new NameToken(
+              null,
+              null,
+              'XHPChildDeclarationConsistencyValidation',
+            ),
+          ),
+          null,
+        ),
+      ]),
+      new SemicolonToken(null, new NodeList(vec[new EndOfLine("\n")])),
+    );
+
+    return $in->withElements(
+      $in->getElementsx()
+        ->insertBefore(C\firstx($in->getElementsx()->toVec()), $use),
+    );
+  }
+
+  private static function addChildrenDeclarationMethod(
+    ClassishBody $in,
+  ): ClassishBody {
+    $decl = $in->getElements()
+      ?->getChildrenOfType(XHPChildrenDeclaration::class) ??
+      vec[];
+    if (C\is_empty($decl)) {
+      return $in;
+    }
+    foreach (
+      $in->getElementsx()->getChildrenOfType(MethodishDeclaration::class) as
+        $method
+    ) {
+      if (
+        $method->getFunctionDeclHeader()->getName()->getText() ===
+          'getChildrenDeclaration'
+      ) {
+        return $in;
+      }
+    }
+    $decl = C\firstx($decl);
+
+    $indent = $decl->getFirstTokenx()->getLeadingWhitespace()?->getText() ?? '';
+    $s = new NodeList(vec[new WhiteSpace(' ')]);
+    $meth = new MethodishDeclaration(
+      null,
+      self::getFunctionDeclarationHeader($indent),
+      new CompoundStatement(
+        new LeftBraceToken(null, new NodeList(vec[new EndOfLine("\n")])),
+        new NodeList(vec[
+          new ReturnStatement(
+            new ReturnToken(
+              new NodeList(vec[new WhiteSpace($indent.$indent)]),
+              $s,
+            ),
+            self::convertChildrenExpression($decl->getExpression()),
+            new SemicolonToken(null, new NodeList(vec[new EndOfLine("\n")])),
+          ),
+        ]),
+        new RightBraceToken(
+          new NodeList(vec[new WhiteSpace($indent)]),
+          new NodeList(vec[
+            new EndOfLine("\n"),
+            new EndOfLine("\n"),
+          ]),
+        ),
+      ),
+      /* semicolon = */ null,
+    );
+    return $in->withElements($in->getElementsx()->insertAfter($decl, $meth));
+  }
+
+  <<__Memoize>>
+  private static function getFunctionDeclarationHeader(
+    string $leading_whitespace,
+  ): FunctionDeclarationHeader {
+    $s = new NodeList(vec[new WhiteSpace(' ')]);
+    return new FunctionDeclarationHeader(
+      new NodeList(vec[
+        new ProtectedToken(
+          new NodeList(
+            vec[new EndOfLine("\n"), new WhiteSpace($leading_whitespace)],
+          ),
+          $s,
+        ),
+        new StaticToken(null, $s),
+      ]),
+      new FunctionToken(null, $s),
+      new NameToken(null, null, 'getChildrenDeclaration'),
+      null,
+      new LeftParenToken(null, null),
+      null,
+      new RightParenToken(null, null),
+      new ColonToken(null, $s),
+      null,
+      new SimpleTypeSpecifier(
+        new QualifiedName(
+          new NodeList(vec[
+            new ListItem(
+              new NameToken(null, null, 'XHPChild'),
+              new BackslashToken(null, null),
+            ),
+            new ListItem(new NameToken(null, $s, 'Constraint'), null),
+          ]),
+        ),
+      ),
+      null,
+    );
+  }
+
+  private static function convertChildrenExpression(
+    Node $in,
+  ): FunctionCallExpression {
+    if ($in is XHPChildrenParenthesizedList) {
+      $count = $in->getXhpChildren()->getCount();
+      invariant($count >= 1, 'Got empty XHP children parenthesized list');
+      if ($count === 1) {
+        return self::convertChildrenExpression(
+          C\onlyx($in->getXhpChildren()->getChildrenOfItems()),
+        );
+      }
+      $children = Vec\map(
+        $in->getXhpChildren()->getChildrenOfItems(),
+        $node ==> self::convertChildrenExpression($node),
+      );
+      return self::makeCall('sequence', null, $children);
+    }
+
+    if ($in is PostfixUnaryExpression) {
+      $op = $in->getOperator();
+      if ($op is PlusToken) {
+        $fun = 'atLeastOneOf';
+      } else if ($op is QuestionToken) {
+        $fun = 'optional';
+      } else if ($op is StarToken) {
+        $fun = 'anyNumberOf';
+      } else {
+        invariant_violation(
+          "Got an XHP postfix unary expression with unexpected operator '%s'",
+          $in->getOperator()->getText(),
+        );
+      }
+      return self::makeCall(
+        $fun,
+        null,
+        vec[self::convertChildrenExpression($in->getOperand())],
+      );
+    }
+
+    if ($in is BinaryExpression) {
+      // foo | bar | baz
+      invariant(
+        $in->getOperator() is BarToken,
+        "Got an XHP child binary expression with unexpected operator '%s'",
+        $in->getOperator()->getText(),
+      );
+      // `foo | bar | baz` is `((foo | bar) | baz)` in the AST; flatten them out
+      // for readability
+      $next = $in;
+      $parts = vec[];
+      while ($next is BinaryExpression && $next->getOperator() is BarToken) {
+        $parts[] = $next->getRightOperand();
+        $next = $next->getLeftOperand();
+      }
+      $parts[] = $next;
+      $parts = Vec\reverse($parts)
+        |> Vec\map($$, $part ==> self::convertChildrenExpression($part));
+      return self::makeCall('anyOf', null, $parts);
+    }
+
+    if ($in is NameExpression || $in is EmptyToken || $in is NameToken) {
+      $name = $in is NameExpression ? $in->getWrappedNode() : $in;
+      if (
+        $name is NameToken || $name is EmptyToken || $name is XHPClassNameToken
+      ) {
+        $name = $name->getText();
+        if ($name === 'pcdata' || $name === 'empty' || $name === 'any') {
+          return self::makeCall($name);
+        }
+
+        // Class name
+        return self::makeCall(
+          'ofType',
+          new TypeArguments(
+            new LessThanToken(null, null),
+            new NodeList(vec[
+              new ListItem(
+                new SimpleTypeSpecifier(new NameToken(null, null, $name)),
+                null,
+              ),
+            ]),
+            new GreaterThanToken(null, null),
+          ),
+        );
+      }
+
+      if ($name is XHPCategoryNameToken) {
+        return self::makeCall('category', null, vec[new LiteralExpression(
+          new SingleQuotedStringLiteralToken(
+            null,
+            null,
+            "'".$name->getText()."'",
+          ),
+        )]);
+      }
+
+      invariant_violation(
+        'Unhandled XHP child name type: %s',
+        \get_class($name),
+      );
+    }
+
+    invariant_violation(
+      'Unhandled XHP children expression: %s (%s)',
+      \get_class($in),
+      $in->getCode(),
+    );
+  }
+
+  private static function makeCall(
+    string $name,
+    ?TypeArguments $generics = null,
+    vec<IExpression> $arguments = vec[],
+  ): FunctionCallExpression {
+    $sep = C\count($arguments) > 1
+      ? new CommaToken(null, new NodeList(vec[new WhiteSpace(' ')]))
+      : null;
+    return new FunctionCallExpression(
+      new QualifiedName(
+        new NodeList(vec[
+          new ListItem(
+            new NameToken(null, null, 'XHPChild'),
+            new BackslashToken(null, null),
+          ),
+          new ListItem(new NameToken(null, null, $name), null),
+        ]),
+      ),
+      $generics,
+      new LeftParenToken(null, null),
+      C\is_empty($arguments)
+        ? null
+        : new NodeList(Vec\map($arguments, $arg ==> new ListItem($arg, $sep))),
+      new RightParenToken(null, null),
+    );
+  }
+
+  <<__Override>>
+  public function getSteps(): Traversable<IMigrationStep> {
+    return vec[
+      new TypedMigrationStep(
+        'Add `use` statement to top level of file if needed',
+        Script::class,
+        Script::class,
+        $node ==> self::addUseNamespaceToScript($node),
+      ),
+      new TypedMigrationStep(
+        'Add `use` statement to namespace blocks as needed',
+        NamespaceDeclaration::class,
+        NamespaceDeclaration::class,
+        $node ==> self::addUseNamespaceToNamespaceBlock($node),
+      ),
+      new TypedMigrationStep(
+        'Add `getChildrenDeclaration()` method',
+        ClassishBody::class,
+        ClassishBody::class,
+        $node ==> self::addChildrenDeclarationMethod($node),
+      ),
+      new TypedMigrationStep(
+        'Add `XHPChildDeclarationConsistencyValidation` trait',
+        ClassishBody::class,
+        ClassishBody::class,
+        $node ==> self::addTrait($node),
+      ),
+    ];
+  }
+}

--- a/src/Migrations/RemoveXHPChildDeclarationsMigration.hack
+++ b/src/Migrations/RemoveXHPChildDeclarationsMigration.hack
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{C, Vec};
+
+final class RemoveXHPChildDeclarationsMigration extends StepBasedMigration {
+  private static function replaceTrait(ClassishBody $in): ClassishBody {
+    $uses = $in->getElements()?->getChildrenOfType(TraitUse::class) ?? vec[]
+      |> Vec\map($$, $use ==> $use->getNames()->getChildrenOfItems())
+      |> Vec\flatten($$);
+    foreach ($uses as $use) {
+      $name = $use ?as SimpleTypeSpecifier
+        |> $$?->getSpecifier() ?as NameToken
+        |> $$?->getText();
+      if ($name === 'XHPChildDeclarationConsistencyValidation') {
+        return $in->replace(
+          $use,
+          ($use as SimpleTypeSpecifier)->withSpecifier(
+            new NameToken(null, null, 'XHPChildValidation'),
+          ),
+        );
+      }
+    }
+    return $in;
+  }
+
+  private static function removeChildrenDeclaration(
+    ClassishBody $in,
+  ): ClassishBody {
+    $decls = $in->getElements()
+      ?->getChildrenOfType(XHPChildrenDeclaration::class) ??
+      vec[];
+    if (C\is_empty($decls)) {
+      return $in;
+    }
+
+    $decls = vec($decls);
+    $elems = $in->getElementsx()->toVec();
+    foreach ($decls as $decl) {
+      $idx = C\find_key($elems, $elem ==> $elem === $decl) as nonnull;
+      $next = $elems[$idx + 1] ?? null;
+      if ($next !== null) {
+        $trivia = $decl->getFirstTokenx()->getLeading()->toVec();
+        $to_trim = C\find_key(
+          Vec\reverse($trivia),
+          $node ==> !($node is WhiteSpace || $node is EndOfLine),
+        );
+        $keep = $to_trim === null
+          ? vec[]
+          : Vec\slice($trivia, 0, C\count($trivia) - $to_trim);
+        $t = $next->getFirstTokenx();
+        $elems[$idx + 1] = $next->replace(
+          $t,
+          $t->withLeading(
+            new NodeList(Vec\concat($keep, $t->getLeading()->toVec())),
+          ),
+        );
+      }
+      $elems = Vec\concat(Vec\take($elems, $idx), Vec\drop($elems, $idx + 1));
+    }
+
+    return $in->withElements(new NodeList($elems));
+  }
+
+  <<__Override>>
+  public function getSteps(): Traversable<IMigrationStep> {
+    return vec[
+      new TypedMigrationStep(
+        'Replace consistency trait with validation trait',
+        ClassishBody::class,
+        ClassishBody::class,
+        $node ==> self::replaceTrait($node),
+      ),
+      new TypedMigrationStep(
+        'Remove `children` declarations',
+        ClassishBody::class,
+        ClassishBody::class,
+        $node ==> self::removeChildrenDeclaration($node),
+      ),
+    ];
+  }
+}

--- a/src/__Private/MigrationCLI.hack
+++ b/src/__Private/MigrationCLI.hack
@@ -13,6 +13,7 @@ use namespace Facebook\{HHAST, TypeAssert};
 use namespace HH\Lib\{C, Dict, Str, Vec};
 use type Facebook\HHAST\{
   AddFixmesMigration,
+  AddXHPChildrenDeclarationMethodMigration,
   BaseMigration,
   DemangleXHPMigration,
   DollarBraceEmbeddedVariableMigration,
@@ -23,6 +24,7 @@ use type Facebook\HHAST\{
   ImplicitShapeSubtypesMigration,
   IsRefinementMigration,
   OptionalShapeFieldsMigration,
+  RemoveXHPChildDeclarationsMigration,
   TopLevelRequiresMigration,
   XHPClassModifierMigration,
 };
@@ -168,7 +170,13 @@ class MigrationCLI extends CLIWithRequiredArguments {
         '--harden-varray-or-darray-typehints',
       ),
       self::removed('--php-array-typehints-best-guess', '4.64.4 to 4.64.6'),
-      self::removed('--add-xhp-children-declaration-method', '4.33.7 to 4.72'),
+      CLIOptions\flag(
+        () ==> {
+          $this->migrations[] = AddXHPChildrenDeclarationMethodMigration::class;
+        },
+        'Add getChildrenDeclaration() method to XHP classes with a children declaration',
+        '--add-xhp-children-declaration-method',
+      ),
       CLIOptions\flag(
         () ==> {
           $this->migrations[] = DemangleXHPMigration::class;
@@ -176,7 +184,13 @@ class MigrationCLI extends CLIWithRequiredArguments {
         'Replace "-" in XHP class names with "_"',
         '--demangle-xhp-class-names',
       ),
-      self::removed('--remove-xhp-child-declarations', '4.33.7 to 4.72'),
+      CLIOptions\flag(
+        () ==> {
+          $this->migrations[] = RemoveXHPChildDeclarationsMigration::class;
+        },
+        'Remove `children` declarations from XHP classes, and update validation traits',
+        '--remove-xhp-child-declarations',
+      ),
       CLIOptions\flag(
         () ==> {
           $this->migrations[] = XHPClassModifierMigration::class;

--- a/src/__Private/codegen/data/XHPChildrenSyntaxExample.hack
+++ b/src/__Private/codegen/data/XHPChildrenSyntaxExample.hack
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+namespace Facebook\HHAST\__Private\SyntaxExamples;
+
+class :xhpchildren1 {
+  children (pcdata);
+}
+
+class :xhpchildren2 {
+  children (pcdata?, pcdata*, pcdata);
+}
+class :xhpchildren3 {
+  children empty;
+}

--- a/tests/AddXHPChildrenDeclarationMethodMigrationTest.hack
+++ b/tests/AddXHPChildrenDeclarationMethodMigrationTest.hack
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{Str, Vec};
+
+final class AddXHPChildrenDeclarationMethodMigrationTest
+  extends StepBasedMigrationTest {
+  const type TMigration = AddXHPChildrenDeclarationMethodMigration;
+
+  <<__Override>>
+  public function getExamples(): vec<(string)> {
+    return \glob(
+      __DIR__.'/examples/migrations/AddXHPChildrenDeclarationMethod/*.hack.in',
+    )
+      |> Vec\map(
+        $$,
+        $file ==> tuple(
+          Str\strip_suffix($file, '.in')
+            |> Str\strip_prefix($$, __DIR__.'/examples/'),
+        ),
+      );
+  }
+}

--- a/tests/NodeTypesTest.hack
+++ b/tests/NodeTypesTest.hack
@@ -123,8 +123,48 @@ final class NodeTypesTest extends TestCase {
     )->toBeSame('SOME\\NAMESPACED\\CONST');
   }
 
-  public async function testFullyQualifiedXHPClassNodes(): Awaitable<void> {
-    $code = '<?hh class :foo { attribute enum {yes, no} bar @required; }';
+  public async function testXHPClassNameAsNameExpression(): Awaitable<void> {
+    $code = '<?hh class :foo { children (pcdata | :bar+); }';
+    $ast = await from_file_async(File::fromPathAndContents('/dev/null', $code));
+    list($_markup, $x) = $ast->getDeclarations()->getChildren();
+    $class = expect($x)->toBeInstanceOf(ClassishDeclaration::class);
+    $decl = $class->getBody()
+      ->getElementsx()
+      ->getChildrenOfType(XHPChildrenDeclaration::class)
+      |> C\onlyx($$);
+
+    // :bar+
+    $bin_expr = $decl->getDescendantsOfType(PostfixUnaryExpression::class)
+      |> C\onlyx($$);
+    $lhs = $bin_expr->getOperand();
+    $lhs = expect($lhs)->toBeInstanceOf(NameExpression::class);
+    expect($lhs->getCode())->toBeSame(':bar');
+    expect($lhs->getWrappedNode())->toBeInstanceOf(XHPClassNameToken::class);
+    $rhs = $bin_expr->getOperator();
+    expect($rhs)->toBeInstanceOf(PlusToken::class);
+  }
+
+  public async function testXHPChildListAsExpression(): Awaitable<void> {
+    $code = '<?hh class :foo { children (pcdata)*; }';
+    $ast = await from_file_async(File::fromPathAndContents('/dev/null', $code));
+    list($_markup, $x) = $ast->getDeclarations()->getChildren();
+    $class = expect($x)->toBeInstanceOf(ClassishDeclaration::class);
+    $decl = $class->getBody()
+      ->getElementsx()
+      ->getChildrenOfType(XHPChildrenDeclaration::class)
+      |> C\onlyx($$);
+
+    $bin_expr = $decl->getDescendantsOfType(PostfixUnaryExpression::class)
+      |> C\onlyx($$);
+    $lhs = $bin_expr->getOperand();
+    $lhs = expect($lhs)->toBeInstanceOf(XHPChildrenParenthesizedList::class);
+    expect($lhs->getCode())->toBeSame('(pcdata)');
+    $rhs = $bin_expr->getOperator();
+    expect($rhs)->toBeInstanceOf(StarToken::class);
+  }
+
+  public async function testOldStyleXHPClassNodes(): Awaitable<void> {
+    $code = '<?hh class :foo { children (pcdata)*; }';
     $ast = await from_file_async(File::fromPathAndContents('/dev/null', $code));
     list($_markup, $x) = $ast->getDeclarations()->getChildren();
     $class = expect($x)->toBeInstanceOf(ClassishDeclaration::class);
@@ -132,7 +172,7 @@ final class NodeTypesTest extends TestCase {
   }
 
   public async function testNewStyleXHPClassNodes(): Awaitable<void> {
-    $code = '<?hh xhp class foo { attribute enum {yes, no} bar @required; };';
+    $code = '<?hh xhp class foo { };';
     $ast = await from_file_async(File::fromPathAndContents('/dev/null', $code));
     list($_markup, $x) = $ast->getDeclarations()->getChildren();
     $class = expect($x)->toBeInstanceOf(ClassishDeclaration::class);

--- a/tests/RemoveXHPChildDeclarationsMigrationTest.hack
+++ b/tests/RemoveXHPChildDeclarationsMigrationTest.hack
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+
+final class RemoveXHPChildDeclarationsMigrationTest
+  extends StepBasedMigrationTest {
+  const type TMigration = RemoveXHPChildDeclarationsMigration;
+
+  <<__Override>>
+  public function getExamples(): vec<(string)> {
+    return vec[tuple('migrations/remove_xhp_child_declarations.hack')];
+  }
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/basic_behavior.hack.expect
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/basic_behavior.hack.expect
@@ -1,0 +1,37 @@
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+class :empty-children {
+  use XHPChildDeclarationConsistencyValidation;
+  children empty;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\empty();
+  }
+
+}
+
+class :any-children {
+  use XHPChildDeclarationConsistencyValidation;
+  children any;
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\any();
+  }
+
+}
+
+class :has-children {
+  use XHPChildDeclarationConsistencyValidation;
+  children (
+    pcdata,
+    (pcdata+, %flow)*,
+    :any_children?,
+    SomeOtherType,
+    (a | b | c)
+  );
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(XHPChild\pcdata(), XHPChild\anyNumberOf(XHPChild\sequence(XHPChild\atLeastOneOf(XHPChild\pcdata()), XHPChild\category('%flow'), )), XHPChild\optional(XHPChild\ofType<:any_children>()), XHPChild\ofType<SomeOtherType>(), XHPChild\anyOf(XHPChild\ofType<a>(), XHPChild\ofType<b>(), XHPChild\ofType<c>(), ), );
+  }
+
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/basic_behavior.hack.in
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/basic_behavior.hack.in
@@ -1,0 +1,17 @@
+class :empty-children {
+  children empty;
+}
+
+class :any-children {
+  children any;
+}
+
+class :has-children {
+  children (
+    pcdata,
+    (pcdata+, %flow)*,
+    :any_children?,
+    SomeOtherType,
+    (a | b | c)
+  );
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/leading_trivia.hack.expect
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/leading_trivia.hack.expect
@@ -1,0 +1,13 @@
+/** Foo bar baz */
+
+use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+class :has-children {
+  use XHPChildDeclarationConsistencyValidation;
+  children (foo, bar);
+
+  protected static function getChildrenDeclaration(): XHPChild\Constraint {
+    return XHPChild\sequence(XHPChild\ofType<foo>(), XHPChild\ofType<bar>(), );
+  }
+
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/leading_trivia.hack.in
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/leading_trivia.hack.in
@@ -1,0 +1,5 @@
+/** Foo bar baz */
+
+class :has-children {
+  children (foo, bar);
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/namespace_blocks.hack.expect
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/namespace_blocks.hack.expect
@@ -1,0 +1,26 @@
+namespace Foo {
+  // XHP not currently supported here
+}
+
+namespace { 
+  class :herp {
+  }
+}
+
+namespace Bar {
+  // XHP not currently supported here
+}
+
+namespace { 
+  use namespace Facebook\XHP\ChildValidation as XHPChild;
+
+  class :derp {
+    use XHPChildDeclarationConsistencyValidation;
+    children (foo);
+
+    protected static function getChildrenDeclaration(): XHPChild\Constraint {
+        return XHPChild\ofType<foo>();
+    }
+
+  }
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/namespace_blocks.hack.in
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/namespace_blocks.hack.in
@@ -1,0 +1,18 @@
+namespace Foo {
+  // XHP not currently supported here
+}
+
+namespace { 
+  class :herp {
+  }
+}
+
+namespace Bar {
+  // XHP not currently supported here
+}
+
+namespace { 
+  class :derp {
+    children (foo);
+  }
+}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/no_children.hack.expect
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/no_children.hack.expect
@@ -1,0 +1,5 @@
+// Foo
+
+class bar {}
+
+class :baz {}

--- a/tests/examples/migrations/AddXHPChildrenDeclarationMethod/no_children.hack.in
+++ b/tests/examples/migrations/AddXHPChildrenDeclarationMethod/no_children.hack.in
@@ -1,0 +1,5 @@
+// Foo
+
+class bar {}
+
+class :baz {}

--- a/tests/examples/migrations/remove_xhp_child_declarations.hack.expect
+++ b/tests/examples/migrations/remove_xhp_child_declarations.hack.expect
@@ -1,0 +1,23 @@
+class :no:children {
+}
+
+class :no-replacement {
+}
+
+class :with-validation-trait{
+  use XHPChildValidation;
+
+  protected function getChildrenDeclaration(): XHPChild\Constraint {}
+}
+
+class :without-trait{
+
+  // This is /probably/ nonsense, but can't be sure
+  protected function getChildrenDeclaration(): XHPChild\Constraint {}
+}
+
+class :with-comment {
+  // Blah blah
+  // This is /probably/ nonsense, but can't be sure
+  protected function getChildrenDeclaration(): XHPChild\Constraint {}
+}

--- a/tests/examples/migrations/remove_xhp_child_declarations.hack.in
+++ b/tests/examples/migrations/remove_xhp_child_declarations.hack.in
@@ -1,0 +1,28 @@
+class :no:children {
+}
+
+class :no-replacement {
+  children (pcdata);
+}
+
+class :with-validation-trait{
+  use XHPChildDeclarationConsistencyValidation;
+  children (pcdata);
+
+  protected function getChildrenDeclaration(): XHPChild\Constraint {}
+}
+
+class :without-trait{
+  children (pcdata);
+
+  // This is /probably/ nonsense, but can't be sure
+  protected function getChildrenDeclaration(): XHPChild\Constraint {}
+}
+
+class :with-comment {
+  // Blah blah
+  children (pcdata);
+
+  // This is /probably/ nonsense, but can't be sure
+  protected function getChildrenDeclaration(): XHPChild\Constraint {}
+}


### PR DESCRIPTION
- adds back `codegen/data/XHPChildrenSyntaxExample.hack` and regenerates the codegen files (this makes it possible for HHAST to parse XHP children declarations again)
- adds back the 2 removed XHP children migrations (turns out they actually work fine in latest HHVM with the regenerated codegen, doesn't matter that the typechecker complains about any children declarations)
- adds `disable_xhp_children_declarations=false` to `.hhconfig` so that the XHP children example file doesn't cause Hack errors (they are not FIXMEable)
- adds `src/codegen/data/ export-ignore` so that any projects depending on HHAST don't need `.hhconfig` changes
- minimum HHVM version back to 4.72, since the XHP children change was the only non-trivial incompatibility from #321