### PR TITLE
use XHP for hhast-inspect

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -14,4 +14,4 @@ new_inference_lambda = true
 error_php_lambdas = true
 disable_xhp_children_declarations = false
 allowed_decl_fixme_codes=2053,4045,4047
-allowed_fixme_codes_strict=2011,2049,2050,2053,2083,3084,4027,4045,4047,4104,4106,4107,4108,4110,4128,4135,4188,4223,4240,4323
+allowed_fixme_codes_strict=2011,2049,2050,2053,2083,3084,4027,4045,4047,4104,4106,4107,4108,4110,4128,4135,4188,4223,4240,4281,4323

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "hhvm/hhvm-autoload": "^2.0.4|^3.0",
         "hhvm/type-assert": "^3.0|^4.0",
         "facebook/hh-clilib": "^2.5.0rc1",
-        "facebook/difflib": "^1.0.0"
+        "facebook/difflib": "^1.0.0",
+        "facebook/xhp-lib": "^4.0"
     }
 }


### PR DESCRIPTION
This is mostly trivial, with a tiny bit of refactoring. Found a small
bug - pre/code open and close order were mismatched.

This should probably be split out to a separate repo; having HHAST
depend on xhp-lib isn't really acceptable, but neither is using HTML
strings when there's a better alternative.

fixes #323