### PR TITLE
Clean up hhconfig, it is used in user-documentation

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -1,16 +1,4 @@
 ignored_paths = [ "tests/examples/NonHackFileTest/php_files/*" ]
-assume_php=false
-enable_experimental_tc_features = no_fallback_in_namespaces, unpacking_check_arity, disallow_refs_in_array, disallow_untyped_lambda_as_non_function_type
-safe_array = true
-safe_vector_array = true
-disable_instanceof_refinement = true
-disallow_destruct = true
-user_attributes=
-disable_static_local_variables = true
-disable_instanceof_refinement = true
-disallow_array_literal = true
-disable_lval_as_an_expression = true
-new_inference_lambda = true
 error_php_lambdas = true
 disable_xhp_children_declarations = false
 allowed_decl_fixme_codes=2053,4045,4047


### PR DESCRIPTION
Removed options which have been dead for some time.
Usage: https://github.com/hhvm/user-documentation/pull/923/commits/2590eb0eb84290f0690d7040622bcdfdcaf1a2c6