### PR TITLE
Add some blame information to namespace resolution/info

### DIFF
--- a/src/Linters/DontUseAsioJoinLinter.hack
+++ b/src/Linters/DontUseAsioJoinLinter.hack
@@ -38,7 +38,7 @@ final class DontUseAsioJoinLinter extends AutoFixingASTLinter {
 
     // Performance won't suffer from resolving a fully qualified name.
     // This is handled very efficiently in resolve_function().
-    $resolved_name = resolve_function($string_name, $context, $node);
+    $resolved_name = resolve_function($string_name, $context, $node)['name'];
 
     if ($resolved_name !== self::F_JOIN) {
       return null;

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -92,8 +92,7 @@ final class LintRunConfig {
     HHAST\StrictModeOnlyLinter::class,
     HHAST\UseStatementWithAsLinter::class,
     HHAST\NoFinalMethodInFinalClassLinter::class,
-    // Experimental: error message needs to blame correct node
-    //HHAST\NamespacePrivateLinter::class,
+    HHAST\NamespacePrivateLinter::class,
   ];
 
   private static function getNamedLinterGroup(

--- a/src/__Private/Resolution/get_current_uses.hack
+++ b/src/__Private/Resolution/get_current_uses.hack
@@ -15,9 +15,9 @@ function get_current_uses(
   Script $root,
   Node $node,
 ): shape(
-  'namespaces' => dict<string, string>,
-  'types' => dict<string, string>,
-  'functions' => dict<string, string>,
+  'namespaces' => dict<string, Script::TAliasedNamespace>,
+  'types' => dict<string, Script::TAliasedNamespace>,
+  'functions' => dict<string, Script::TAliasedNamespace>,
 ) {
   foreach ($root->getNamespaces() as $ns) {
     if ($ns['children']->isAncestorOf($node)) {

--- a/src/__Private/Resolution/resolve_name.hack
+++ b/src/__Private/Resolution/resolve_name.hack
@@ -10,16 +10,16 @@
 namespace Facebook\HHAST\__Private\Resolution;
 
 use namespace HH\Lib\{C, Str, Vec};
-use type Facebook\HHAST\{Node, Script};
+use type Facebook\HHAST\{NamespaceUseClause, Node, Script};
 
 function resolve_name(
   string $name,
   Script $root,
   Node $node,
-  dict<string, string> $used_namespaces,
-): string {
+  dict<string, shape('name' => string, 'use_clause' => ?NamespaceUseClause)> $used_namespaces,
+): shape('name' => string, 'use_clause' => ?NamespaceUseClause) {
   if (Str\starts_with($name, '\\')) {
-    return Str\strip_prefix($name, '\\');
+    return shape('name' => Str\strip_prefix($name, '\\'), 'use_clause' => null);
   }
   invariant(
     !Str\contains($name, '<'),
@@ -33,22 +33,24 @@ function resolve_name(
       |> Str\split($$, '\\')
       |> C\firstx($$);
     if (C\contains_key($used_namespaces, $maybe_aliased)) {
+      $ns = $used_namespaces[$maybe_aliased];
       return $name
         |> Str\split($$, '\\')
         |> Vec\drop($$, 1)
         |> Str\join($$, '\\')
-        |> $used_namespaces[$maybe_aliased].'\\'.$$;
+        |> $ns['name'].'\\'.$$
+        |> shape('name' => $$, 'use_clause' => $ns['use_clause']);
     }
 
     if ($ns !== null) {
-      return $ns.'\\'.$name;
+      return shape('name' => $ns.'\\'.$name, 'use_clause' => null);
     }
-    return $name;
+    return shape('name' => $name, 'use_clause' => null);
   }
 
   if ($ns !== null) {
-    return $ns.'\\'.$name;
+    return shape('name' => $ns.'\\'.$name, 'use_clause' => null);
   }
 
-  return $name;
+  return shape('name' => $name, 'use_clause' => null);
 }

--- a/src/nodes/Script.hack
+++ b/src/nodes/Script.hack
@@ -39,13 +39,18 @@ final class Script extends ScriptGeneratedBase {
     return $this->getTokens()[$idx + 1] ?? null;
   }
 
-  const type TNamespace = shape(
+  const type TAliasedNamespace = shape(
+    'name' => string,
+    'use_clause' => NamespaceUseClause,
+  );
+
+  const type TNamespaceScope = shape(
     'name' => ?string,
     'children' => NodeList<Node>,
     'uses' => shape(
-      'namespaces' => dict<string, string>,
-      'types' => dict<string, string>,
-      'functions' => dict<string, string>,
+      'namespaces' => dict<string, self::TAliasedNamespace>,
+      'types' => dict<string, self::TAliasedNamespace>,
+      'functions' => dict<string, self::TAliasedNamespace>,
     ),
   );
 
@@ -56,7 +61,7 @@ final class Script extends ScriptGeneratedBase {
    * with and without a body.
    */
   <<__Memoize>>
-  public function getNamespaces(): vec<this::TNamespace> {
+  public function getNamespaces(): vec<this::TNamespaceScope> {
     $all_declarations = $this->getDeclarationsx()->getChildren();
     $global_declarations = vec[];
     $namespaces = vec[];

--- a/src/resolve_function.hack
+++ b/src/resolve_function.hack
@@ -28,14 +28,19 @@ use namespace Facebook\HHAST\__Private\Resolution;
  *              This will be a NameToken or QualifiedName in the common case.
  *
  * @return      The returned string is the fully qualified name of the given $node
- *              without the leading `\`.
+ *              without the leading `\`. If a `use` clause affected the resolution,
+ *              it is also returned.
  *
  * @example     $name_token of the name `join`.
  *              $my_script as a `use function HH\Asio\join` at the top.
  *              `resolve_function($name_token->getText(), $my_script, $name_token);`
  *              Expected return "HH\Asio\join".
  */
-function resolve_function(string $name, Script $root, Node $node): string {
+function resolve_function(
+  string $name,
+  Script $root,
+  Node $node,
+): shape('name' => string, 'use_clause' => ?NamespaceUseClause) {
   $uses = Resolution\get_current_uses($root, $node);
 
   if (C\contains_key($uses['functions'], $name)) {

--- a/tests/ResolutionTest.hack
+++ b/tests/ResolutionTest.hack
@@ -13,7 +13,7 @@ namespace Facebook\HHAST;
 use function Facebook\FBExpect\expect;
 use namespace Facebook\HHAST\__Private\Resolution;
 use type Facebook\HackTest\DataProvider;
-use namespace HH\Lib\{C, Vec};
+use namespace HH\Lib\{C, Dict, Vec};
 
 final class ResolutionTest extends TestCase {
   private static async function getRootAndNodeAsync(
@@ -160,7 +160,14 @@ final class ResolutionTest extends TestCase {
     ) $expected,
   ): Awaitable<void> {
     list($root, $node) = await self::getRootAndNodeAsync($code);
-    expect(Resolution\get_current_uses($root, $node))->toBeSame(
+    $uses = Resolution\get_current_uses($root, $node);
+    // Discard blame node for comparison
+    $actual = shape(
+      'namespaces' => Dict\map($uses['namespaces'], $v ==> $v['name']),
+      'types' => Dict\map($uses['types'], $v ==> $v['name']),
+      'functions' => Dict\map($uses['functions'], $v ==> $v['name']),
+    );
+    expect($actual)->toBeSame(
       $expected,
       'Source: %s',
       $code,

--- a/tests/examples/NamespacePrivateLinter/namespace_private_only_ns_banned.php.expect
+++ b/tests/examples/NamespacePrivateLinter/namespace_private_only_ns_banned.php.expect
@@ -1,7 +1,7 @@
 [
     {
-        "blame": "<?hh \/\/ strict\n\/*\n *  Copyright (c) 2017-present, Facebook, Inc.\n *  All rights reserved.\n *\n *  This source code is licensed under the MIT license found in the\n *  LICENSE file in the root directory of this source tree.\n *\n *\/\nnamespace Blergh;\nuse type \\Something\\__Private\\TestingWithPrivateNamespace;\nuse type TeamJoins\\__Private;\n",
-        "blame_pretty": "<?hh \/\/ strict\n\/*\n *  Copyright (c) 2017-present, Facebook, Inc.\n *  All rights reserved.\n *\n *  This source code is licensed under the MIT license found in the\n *  LICENSE file in the root directory of this source tree.\n *\n *\/\nnamespace Blergh;\nuse type \\Something\\__Private\\TestingWithPrivateNamespace;\nuse type TeamJoins\\__Private;\n",
+        "blame": "\\Something\\__Private\\TestingWithPrivateNamespace",
+        "blame_pretty": "\\Something\\__Private\\TestingWithPrivateNamespace",
         "description": "Artifacts belonging to a namespace are private to the parent namespace"
     }
 ]


### PR DESCRIPTION
- adds relevant `use` clauses to return values of resolution functions
- uses this to improve the `NamespacePrivateLinter` error message

Prior versions would blame the entire file in the error message; now:

```
Artifacts belonging to a namespace are private to the parent namespace
  Linter: Facebook\HHAST\NamespacePrivateLinter
  Location: /Users/fredemmott/code/hhast-inspect/src/InspectorCLI.hack:15:9
  Code:
  >HH\Lib\_Private\PHPWarningSuppressor
```