### PR TITLE
require HHVM 4.91 ?

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "hhvm/hacktest": "^2.2.0"
     },
     "require": {
-        "hhvm": "^4.89",
+        "hhvm": "^4.91",
         "hhvm/hsl": "^4.25",
         "hhvm/hsl-experimental": "^4.58.0rc1",
         "hhvm/hsl-io": "^0.2.0|0.3.0",


### PR DESCRIPTION
4.89 and 4.90 was skipped, we probably want to require an existing HHVM version here?

On the other hand, there were several nightly releases tagged 4.89-dev which would also satisfy the original requirement -- maybe we want to preserve that? I'm not sure what's preferable.

Either way the release should probably be tagged as HHAST 4.91.0