### PR TITLE
update schema (2021-01-22-0001)

### DIFF
--- a/codegen/inferred_relationships.hack
+++ b/codegen/inferred_relationships.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4a1d222459067c2cf86706fd92475c44>>
+ * @generated SignedSource<<47eadaa50ec56f929e2a3f8f2f9f06ca>>
  */
 namespace Facebook\HHAST\__Private;
 
@@ -70,6 +70,9 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   ],
   'anonymous_function.anonymous_parameters' => keyset[
     'list<list_item<parameter_declaration>>',
+    'missing',
+  ],
+  'anonymous_function.anonymous_readonly_return' => keyset[
     'missing',
   ],
   'anonymous_function.anonymous_right_paren' => keyset[
@@ -641,6 +644,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<echo_statement|foreach_statement>',
     'list<echo_statement|if_statement>',
     'list<echo_statement|if_statement|return_statement>',
+    'list<echo_statement|if_statement|try_statement>',
     'list<echo_statement|return_statement>',
     'list<echo_statement|return_statement|try_statement>',
     'list<echo_statement|switch_statement>',
@@ -1337,7 +1341,17 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'type_constraint',
   ],
   'enum_declaration.enum_use_clauses' => keyset[
+    'list<enum_use>',
     'missing',
+  ],
+  'enum_use.enum_use_keyword' => keyset[
+    'token:use',
+  ],
+  'enum_use.enum_use_names' => keyset[
+    'list<list_item<simple_type_specifier>>',
+  ],
+  'enum_use.enum_use_semicolon' => keyset[
+    'token:;',
   ],
   'enumerator.enumerator_equal' => keyset[
     'token:=',
@@ -1584,7 +1598,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<anonymous_function>|list_item<token:name>|list_item<variable>>',
     'list<list_item<anonymous_function>|list_item<variable>>',
     'list<list_item<anonymous_function>|list_item<varray_intrinsic_expression>>',
-    'list<list_item<anonymous_function>|list_item<vector_intrinsic_expression>>',
     'list<list_item<as_expression>>',
     'list<list_item<awaitable_creation_expression>>',
     'list<list_item<awaitable_creation_expression>|list_item<function_call_expression>>',
@@ -2036,6 +2049,9 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<parameter_declaration>|list_item<variadic_parameter>>',
     'missing',
   ],
+  'function_declaration_header.function_readonly_return' => keyset[
+    'missing',
+  ],
   'function_declaration_header.function_right_paren' => keyset[
     'token:)',
   ],
@@ -2284,6 +2300,9 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   'lambda_signature.lambda_parameters' => keyset[
     'list<list_item<parameter_declaration>>',
     'list<list_item<variadic_parameter>>',
+    'missing',
+  ],
+  'lambda_signature.lambda_readonly_return' => keyset[
     'missing',
   ],
   'lambda_signature.lambda_right_paren' => keyset[
@@ -2625,6 +2644,9 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   'parameter_declaration.parameter_name' => keyset[
     'decorated_expression',
     'token:variable',
+  ],
+  'parameter_declaration.parameter_readonly' => keyset[
+    'missing',
   ],
   'parameter_declaration.parameter_type' => keyset[
     'classname_type_specifier',

--- a/codegen/schema.json
+++ b/codegen/schema.json
@@ -1,6 +1,6 @@
 { "description" :
   "@generated JSON schema of the Hack Full Fidelity Parser AST",
-  "version" : "2021-01-21-0001",
+  "version" : "2021-01-22-0001",
   "trivia" : [
     { "trivia_kind_name" : "WhiteSpace",
       "trivia_type_name" : "whitespace" },
@@ -379,6 +379,8 @@
       "token_text" : "xhp" },
     { "token_kind" : "Hash",
       "token_text" : "#" },
+    { "token_kind" : "Readonly",
+      "token_text" : "readonly" },
 
     { "token_kind" : "ErrorToken",
       "token_text" : null },
@@ -721,6 +723,7 @@
         { "field_name" : "right_paren" },
         { "field_name" : "contexts" },
         { "field_name" : "colon" },
+        { "field_name" : "readonly_return" },
         { "field_name" : "type" },
         { "field_name" : "where_clause" }
       ] },
@@ -913,6 +916,7 @@
         { "field_name" : "attribute" },
         { "field_name" : "visibility" },
         { "field_name" : "call_convention" },
+        { "field_name" : "readonly" },
         { "field_name" : "type" },
         { "field_name" : "name" },
         { "field_name" : "default_value" }
@@ -1293,6 +1297,7 @@
         { "field_name" : "right_paren" },
         { "field_name" : "ctx_list" },
         { "field_name" : "colon" },
+        { "field_name" : "readonly_return" },
         { "field_name" : "type" },
         { "field_name" : "use" },
         { "field_name" : "body" }
@@ -1328,6 +1333,7 @@
         { "field_name" : "right_paren" },
         { "field_name" : "contexts" },
         { "field_name" : "colon" },
+        { "field_name" : "readonly_return" },
         { "field_name" : "type" }
       ] },
     { "kind_name" : "CastExpression",

--- a/codegen/syntax/AnonymousFunction.hack
+++ b/codegen/syntax/AnonymousFunction.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<924a9dc48ac06e43499b44c68a1cbd15>>
+ * @generated SignedSource<<c5ce08f4005ce0d33a0d402db8f55981>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -23,6 +23,7 @@ final class AnonymousFunction
   private RightParenToken $_right_paren;
   private ?Node $_ctx_list;
   private ?ColonToken $_colon;
+  private ?Node $_readonly_return;
   private ?ITypeSpecifier $_type;
   private ?AnonymousFunctionUseClause $_use;
   private CompoundStatement $_body;
@@ -37,6 +38,7 @@ final class AnonymousFunction
     RightParenToken $right_paren,
     ?Node $ctx_list,
     ?ColonToken $colon,
+    ?Node $readonly_return,
     ?ITypeSpecifier $type,
     ?AnonymousFunctionUseClause $use,
     CompoundStatement $body,
@@ -51,6 +53,7 @@ final class AnonymousFunction
     $this->_right_paren = $right_paren;
     $this->_ctx_list = $ctx_list;
     $this->_colon = $colon;
+    $this->_readonly_return = $readonly_return;
     $this->_type = $type;
     $this->_use = $use;
     $this->_body = $body;
@@ -141,6 +144,14 @@ final class AnonymousFunction
       'ColonToken',
     );
     $offset += $colon?->getWidth() ?? 0;
+    $readonly_return = Node::fromJSON(
+      /* HH_FIXME[4110] */ $json['anonymous_readonly_return'] ?? dict['kind' => 'missing'],
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $readonly_return?->getWidth() ?? 0;
     $type = Node::fromJSON(
       /* HH_FIXME[4110] */ $json['anonymous_type'] ?? dict['kind' => 'missing'],
       $file,
@@ -182,6 +193,7 @@ final class AnonymousFunction
       /* HH_IGNORE_ERROR[4110] */ $right_paren,
       /* HH_IGNORE_ERROR[4110] */ $ctx_list,
       /* HH_IGNORE_ERROR[4110] */ $colon,
+      /* HH_IGNORE_ERROR[4110] */ $readonly_return,
       /* HH_IGNORE_ERROR[4110] */ $type,
       /* HH_IGNORE_ERROR[4110] */ $use,
       /* HH_IGNORE_ERROR[4110] */ $body,
@@ -201,6 +213,7 @@ final class AnonymousFunction
       'right_paren' => $this->_right_paren,
       'ctx_list' => $this->_ctx_list,
       'colon' => $this->_colon,
+      'readonly_return' => $this->_readonly_return,
       'type' => $this->_type,
       'use' => $this->_use,
       'body' => $this->_body,
@@ -233,6 +246,9 @@ final class AnonymousFunction
       ? null
       : $rewriter($this->_ctx_list, $parents);
     $colon = $this->_colon === null ? null : $rewriter($this->_colon, $parents);
+    $readonly_return = $this->_readonly_return === null
+      ? null
+      : $rewriter($this->_readonly_return, $parents);
     $type = $this->_type === null ? null : $rewriter($this->_type, $parents);
     $use = $this->_use === null ? null : $rewriter($this->_use, $parents);
     $body = $rewriter($this->_body, $parents);
@@ -246,6 +262,7 @@ final class AnonymousFunction
       $right_paren === $this->_right_paren &&
       $ctx_list === $this->_ctx_list &&
       $colon === $this->_colon &&
+      $readonly_return === $this->_readonly_return &&
       $type === $this->_type &&
       $use === $this->_use &&
       $body === $this->_body
@@ -262,6 +279,7 @@ final class AnonymousFunction
       /* HH_FIXME[4110] use `as` */ $right_paren,
       /* HH_FIXME[4110] use `as` */ $ctx_list,
       /* HH_FIXME[4110] use `as` */ $colon,
+      /* HH_FIXME[4110] use `as` */ $readonly_return,
       /* HH_FIXME[4110] use `as` */ $type,
       /* HH_FIXME[4110] use `as` */ $use,
       /* HH_FIXME[4110] use `as` */ $body,
@@ -286,6 +304,7 @@ final class AnonymousFunction
       $this->_right_paren,
       $this->_ctx_list,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_use,
       $this->_body,
@@ -328,6 +347,7 @@ final class AnonymousFunction
       $this->_right_paren,
       $this->_ctx_list,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_use,
       $this->_body,
@@ -370,6 +390,7 @@ final class AnonymousFunction
       $this->_right_paren,
       $this->_ctx_list,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_use,
       $this->_body,
@@ -412,6 +433,7 @@ final class AnonymousFunction
       $this->_right_paren,
       $this->_ctx_list,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_use,
       $this->_body,
@@ -457,6 +479,7 @@ final class AnonymousFunction
       $this->_right_paren,
       $this->_ctx_list,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_use,
       $this->_body,
@@ -501,6 +524,7 @@ final class AnonymousFunction
       $this->_right_paren,
       $this->_ctx_list,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_use,
       $this->_body,
@@ -543,6 +567,7 @@ final class AnonymousFunction
       $value,
       $this->_ctx_list,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_use,
       $this->_body,
@@ -585,6 +610,7 @@ final class AnonymousFunction
       $this->_right_paren,
       $value,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_use,
       $this->_body,
@@ -627,6 +653,7 @@ final class AnonymousFunction
       $this->_right_paren,
       $this->_ctx_list,
       $value,
+      $this->_readonly_return,
       $this->_type,
       $this->_use,
       $this->_body,
@@ -651,6 +678,49 @@ final class AnonymousFunction
     return TypeAssert\not_null($this->getColon());
   }
 
+  public function getReadonlyReturnUNTYPED(): ?Node {
+    return $this->_readonly_return;
+  }
+
+  public function withReadonlyReturn(?Node $value): this {
+    if ($value === $this->_readonly_return) {
+      return $this;
+    }
+    return new static(
+      $this->_attribute_spec,
+      $this->_static_keyword,
+      $this->_async_keyword,
+      $this->_function_keyword,
+      $this->_left_paren,
+      $this->_parameters,
+      $this->_right_paren,
+      $this->_ctx_list,
+      $this->_colon,
+      $value,
+      $this->_type,
+      $this->_use,
+      $this->_body,
+    );
+  }
+
+  public function hasReadonlyReturn(): bool {
+    return $this->_readonly_return !== null;
+  }
+
+  /**
+   * @return null
+   */
+  public function getReadonlyReturn(): ?Node {
+    return $this->_readonly_return;
+  }
+
+  /**
+   * @return
+   */
+  public function getReadonlyReturnx(): Node {
+    return TypeAssert\not_null($this->getReadonlyReturn());
+  }
+
   public function getTypeUNTYPED(): ?Node {
     return $this->_type;
   }
@@ -669,6 +739,7 @@ final class AnonymousFunction
       $this->_right_paren,
       $this->_ctx_list,
       $this->_colon,
+      $this->_readonly_return,
       $value,
       $this->_use,
       $this->_body,
@@ -715,6 +786,7 @@ final class AnonymousFunction
       $this->_right_paren,
       $this->_ctx_list,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $value,
       $this->_body,
@@ -757,6 +829,7 @@ final class AnonymousFunction
       $this->_right_paren,
       $this->_ctx_list,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_use,
       $value,

--- a/codegen/syntax/EnumDeclaration.hack
+++ b/codegen/syntax/EnumDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<db4c27fbd99820a397ca61e352cb7b4a>>
+ * @generated SignedSource<<968bb272c6522ea7c1a049ad226dbd38>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -19,7 +19,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
   private ITypeSpecifier $_base;
   private ?TypeConstraint $_type;
   private LeftBraceToken $_left_brace;
-  private ?Node $_use_clauses;
+  private ?NodeList<EnumUse> $_use_clauses;
   private ?NodeList<Enumerator> $_enumerators;
   private RightBraceToken $_right_brace;
 
@@ -31,7 +31,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
     ITypeSpecifier $base,
     ?TypeConstraint $type,
     LeftBraceToken $left_brace,
-    ?Node $use_clauses,
+    ?NodeList<EnumUse> $use_clauses,
     ?NodeList<Enumerator> $enumerators,
     RightBraceToken $right_brace,
     ?__Private\SourceRef $source_ref = null,
@@ -124,7 +124,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
-      'Node',
+      'NodeList<EnumUse>',
     );
     $offset += $use_clauses?->getWidth() ?? 0;
     $enumerators = Node::fromJSON(
@@ -516,7 +516,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
     return $this->_use_clauses;
   }
 
-  public function withUseClauses(?Node $value): this {
+  public function withUseClauses(?NodeList<EnumUse> $value): this {
     if ($value === $this->_use_clauses) {
       return $this;
     }
@@ -539,16 +539,16 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
   }
 
   /**
-   * @return null
+   * @return NodeList<EnumUse> | null
    */
-  public function getUseClauses(): ?Node {
+  public function getUseClauses(): ?NodeList<EnumUse> {
     return $this->_use_clauses;
   }
 
   /**
-   * @return
+   * @return NodeList<EnumUse>
    */
-  public function getUseClausesx(): Node {
+  public function getUseClausesx(): NodeList<EnumUse> {
     return TypeAssert\not_null($this->getUseClauses());
   }
 

--- a/codegen/syntax/EnumUse.hack
+++ b/codegen/syntax/EnumUse.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<38cc0dedd81c26fe0d5a4a3976de25f1>>
+ * @generated SignedSource<<715078d94815b872208a79d1cf638217>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -12,14 +12,14 @@ final class EnumUse extends Node {
 
   const string SYNTAX_KIND = 'enum_use';
 
-  private ?Node $_keyword;
-  private ?Node $_names;
-  private ?Node $_semicolon;
+  private UseToken $_keyword;
+  private NodeList<ListItem<SimpleTypeSpecifier>> $_names;
+  private SemicolonToken $_semicolon;
 
   public function __construct(
-    ?Node $keyword,
-    ?Node $names,
-    ?Node $semicolon,
+    UseToken $keyword,
+    NodeList<ListItem<SimpleTypeSpecifier>> $names,
+    SemicolonToken $semicolon,
     ?__Private\SourceRef $source_ref = null,
   ) {
     $this->_keyword = $keyword;
@@ -38,29 +38,32 @@ final class EnumUse extends Node {
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
-      /* HH_FIXME[4110] */ $json['enum_use_keyword'] ?? dict['kind' => 'missing'],
+      /* HH_FIXME[4110] */ $json['enum_use_keyword'],
       $file,
       $offset,
       $source,
-      'Node',
+      'UseToken',
     );
-    $offset += $keyword?->getWidth() ?? 0;
+    $keyword = $keyword as nonnull;
+    $offset += $keyword->getWidth();
     $names = Node::fromJSON(
-      /* HH_FIXME[4110] */ $json['enum_use_names'] ?? dict['kind' => 'missing'],
+      /* HH_FIXME[4110] */ $json['enum_use_names'],
       $file,
       $offset,
       $source,
-      'Node',
+      'NodeList<ListItem<SimpleTypeSpecifier>>',
     );
-    $offset += $names?->getWidth() ?? 0;
+    $names = $names as nonnull;
+    $offset += $names->getWidth();
     $semicolon = Node::fromJSON(
-      /* HH_FIXME[4110] */ $json['enum_use_semicolon'] ?? dict['kind' => 'missing'],
+      /* HH_FIXME[4110] */ $json['enum_use_semicolon'],
       $file,
       $offset,
       $source,
-      'Node',
+      'SemicolonToken',
     );
-    $offset += $semicolon?->getWidth() ?? 0;
+    $semicolon = $semicolon as nonnull;
+    $offset += $semicolon->getWidth();
     $source_ref = shape(
       'file' => $file,
       'source' => $source,
@@ -91,13 +94,9 @@ final class EnumUse extends Node {
     vec<Node> $parents = vec[],
   ): this {
     $parents[] = $this;
-    $keyword = $this->_keyword === null
-      ? null
-      : $rewriter($this->_keyword, $parents);
-    $names = $this->_names === null ? null : $rewriter($this->_names, $parents);
-    $semicolon = $this->_semicolon === null
-      ? null
-      : $rewriter($this->_semicolon, $parents);
+    $keyword = $rewriter($this->_keyword, $parents);
+    $names = $rewriter($this->_names, $parents);
+    $semicolon = $rewriter($this->_semicolon, $parents);
     if (
       $keyword === $this->_keyword &&
       $names === $this->_names &&
@@ -116,7 +115,7 @@ final class EnumUse extends Node {
     return $this->_keyword;
   }
 
-  public function withKeyword(?Node $value): this {
+  public function withKeyword(UseToken $value): this {
     if ($value === $this->_keyword) {
       return $this;
     }
@@ -128,24 +127,26 @@ final class EnumUse extends Node {
   }
 
   /**
-   * @return unknown
+   * @return UseToken
    */
-  public function getKeyword(): ?Node {
-    return $this->_keyword;
+  public function getKeyword(): UseToken {
+    return TypeAssert\instance_of(UseToken::class, $this->_keyword);
   }
 
   /**
-   * @return unknown
+   * @return UseToken
    */
-  public function getKeywordx(): Node {
-    return TypeAssert\not_null($this->getKeyword());
+  public function getKeywordx(): UseToken {
+    return $this->getKeyword();
   }
 
   public function getNamesUNTYPED(): ?Node {
     return $this->_names;
   }
 
-  public function withNames(?Node $value): this {
+  public function withNames(
+    NodeList<ListItem<SimpleTypeSpecifier>> $value,
+  ): this {
     if ($value === $this->_names) {
       return $this;
     }
@@ -157,24 +158,24 @@ final class EnumUse extends Node {
   }
 
   /**
-   * @return unknown
+   * @return NodeList<ListItem<SimpleTypeSpecifier>>
    */
-  public function getNames(): ?Node {
-    return $this->_names;
+  public function getNames(): NodeList<ListItem<SimpleTypeSpecifier>> {
+    return TypeAssert\instance_of(NodeList::class, $this->_names);
   }
 
   /**
-   * @return unknown
+   * @return NodeList<ListItem<SimpleTypeSpecifier>>
    */
-  public function getNamesx(): Node {
-    return TypeAssert\not_null($this->getNames());
+  public function getNamesx(): NodeList<ListItem<SimpleTypeSpecifier>> {
+    return $this->getNames();
   }
 
   public function getSemicolonUNTYPED(): ?Node {
     return $this->_semicolon;
   }
 
-  public function withSemicolon(?Node $value): this {
+  public function withSemicolon(SemicolonToken $value): this {
     if ($value === $this->_semicolon) {
       return $this;
     }
@@ -186,16 +187,16 @@ final class EnumUse extends Node {
   }
 
   /**
-   * @return unknown
+   * @return SemicolonToken
    */
-  public function getSemicolon(): ?Node {
-    return $this->_semicolon;
+  public function getSemicolon(): SemicolonToken {
+    return TypeAssert\instance_of(SemicolonToken::class, $this->_semicolon);
   }
 
   /**
-   * @return unknown
+   * @return SemicolonToken
    */
-  public function getSemicolonx(): Node {
-    return TypeAssert\not_null($this->getSemicolon());
+  public function getSemicolonx(): SemicolonToken {
+    return $this->getSemicolon();
   }
 }

--- a/codegen/syntax/FunctionDeclarationHeader.hack
+++ b/codegen/syntax/FunctionDeclarationHeader.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e851e00f8362009d6495f2a65a510494>>
+ * @generated SignedSource<<6eab26b2b591acab26828a87e2f29771>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -21,6 +21,7 @@ final class FunctionDeclarationHeader extends Node {
   private RightParenToken $_right_paren;
   private ?Contexts $_contexts;
   private ?ColonToken $_colon;
+  private ?Node $_readonly_return;
   private ?ITypeSpecifier $_type;
   private ?WhereClause $_where_clause;
 
@@ -34,6 +35,7 @@ final class FunctionDeclarationHeader extends Node {
     RightParenToken $right_paren,
     ?Contexts $contexts,
     ?ColonToken $colon,
+    ?Node $readonly_return,
     ?ITypeSpecifier $type,
     ?WhereClause $where_clause,
     ?__Private\SourceRef $source_ref = null,
@@ -47,6 +49,7 @@ final class FunctionDeclarationHeader extends Node {
     $this->_right_paren = $right_paren;
     $this->_contexts = $contexts;
     $this->_colon = $colon;
+    $this->_readonly_return = $readonly_return;
     $this->_type = $type;
     $this->_where_clause = $where_clause;
     parent::__construct($source_ref);
@@ -137,6 +140,14 @@ final class FunctionDeclarationHeader extends Node {
       'ColonToken',
     );
     $offset += $colon?->getWidth() ?? 0;
+    $readonly_return = Node::fromJSON(
+      /* HH_FIXME[4110] */ $json['function_readonly_return'] ?? dict['kind' => 'missing'],
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $readonly_return?->getWidth() ?? 0;
     $type = Node::fromJSON(
       /* HH_FIXME[4110] */ $json['function_type'] ?? dict['kind' => 'missing'],
       $file,
@@ -169,6 +180,7 @@ final class FunctionDeclarationHeader extends Node {
       /* HH_IGNORE_ERROR[4110] */ $right_paren,
       /* HH_IGNORE_ERROR[4110] */ $contexts,
       /* HH_IGNORE_ERROR[4110] */ $colon,
+      /* HH_IGNORE_ERROR[4110] */ $readonly_return,
       /* HH_IGNORE_ERROR[4110] */ $type,
       /* HH_IGNORE_ERROR[4110] */ $where_clause,
       $source_ref,
@@ -187,6 +199,7 @@ final class FunctionDeclarationHeader extends Node {
       'right_paren' => $this->_right_paren,
       'contexts' => $this->_contexts,
       'colon' => $this->_colon,
+      'readonly_return' => $this->_readonly_return,
       'type' => $this->_type,
       'where_clause' => $this->_where_clause,
     ]
@@ -216,6 +229,9 @@ final class FunctionDeclarationHeader extends Node {
       ? null
       : $rewriter($this->_contexts, $parents);
     $colon = $this->_colon === null ? null : $rewriter($this->_colon, $parents);
+    $readonly_return = $this->_readonly_return === null
+      ? null
+      : $rewriter($this->_readonly_return, $parents);
     $type = $this->_type === null ? null : $rewriter($this->_type, $parents);
     $where_clause = $this->_where_clause === null
       ? null
@@ -230,6 +246,7 @@ final class FunctionDeclarationHeader extends Node {
       $right_paren === $this->_right_paren &&
       $contexts === $this->_contexts &&
       $colon === $this->_colon &&
+      $readonly_return === $this->_readonly_return &&
       $type === $this->_type &&
       $where_clause === $this->_where_clause
     ) {
@@ -245,6 +262,7 @@ final class FunctionDeclarationHeader extends Node {
       /* HH_FIXME[4110] use `as` */ $right_paren,
       /* HH_FIXME[4110] use `as` */ $contexts,
       /* HH_FIXME[4110] use `as` */ $colon,
+      /* HH_FIXME[4110] use `as` */ $readonly_return,
       /* HH_FIXME[4110] use `as` */ $type,
       /* HH_FIXME[4110] use `as` */ $where_clause,
     );
@@ -268,6 +286,7 @@ final class FunctionDeclarationHeader extends Node {
       $this->_right_paren,
       $this->_contexts,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_where_clause,
     );
@@ -313,6 +332,7 @@ final class FunctionDeclarationHeader extends Node {
       $this->_right_paren,
       $this->_contexts,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_where_clause,
     );
@@ -354,6 +374,7 @@ final class FunctionDeclarationHeader extends Node {
       $this->_right_paren,
       $this->_contexts,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_where_clause,
     );
@@ -395,6 +416,7 @@ final class FunctionDeclarationHeader extends Node {
       $this->_right_paren,
       $this->_contexts,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_where_clause,
     );
@@ -436,6 +458,7 @@ final class FunctionDeclarationHeader extends Node {
       $this->_right_paren,
       $this->_contexts,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_where_clause,
     );
@@ -479,6 +502,7 @@ final class FunctionDeclarationHeader extends Node {
       $this->_right_paren,
       $this->_contexts,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_where_clause,
     );
@@ -522,6 +546,7 @@ final class FunctionDeclarationHeader extends Node {
       $value,
       $this->_contexts,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_where_clause,
     );
@@ -563,6 +588,7 @@ final class FunctionDeclarationHeader extends Node {
       $this->_right_paren,
       $value,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $this->_where_clause,
     );
@@ -604,6 +630,7 @@ final class FunctionDeclarationHeader extends Node {
       $this->_right_paren,
       $this->_contexts,
       $value,
+      $this->_readonly_return,
       $this->_type,
       $this->_where_clause,
     );
@@ -627,6 +654,48 @@ final class FunctionDeclarationHeader extends Node {
     return TypeAssert\not_null($this->getColon());
   }
 
+  public function getReadonlyReturnUNTYPED(): ?Node {
+    return $this->_readonly_return;
+  }
+
+  public function withReadonlyReturn(?Node $value): this {
+    if ($value === $this->_readonly_return) {
+      return $this;
+    }
+    return new static(
+      $this->_modifiers,
+      $this->_keyword,
+      $this->_name,
+      $this->_type_parameter_list,
+      $this->_left_paren,
+      $this->_parameter_list,
+      $this->_right_paren,
+      $this->_contexts,
+      $this->_colon,
+      $value,
+      $this->_type,
+      $this->_where_clause,
+    );
+  }
+
+  public function hasReadonlyReturn(): bool {
+    return $this->_readonly_return !== null;
+  }
+
+  /**
+   * @return null
+   */
+  public function getReadonlyReturn(): ?Node {
+    return $this->_readonly_return;
+  }
+
+  /**
+   * @return
+   */
+  public function getReadonlyReturnx(): Node {
+    return TypeAssert\not_null($this->getReadonlyReturn());
+  }
+
   public function getTypeUNTYPED(): ?Node {
     return $this->_type;
   }
@@ -645,6 +714,7 @@ final class FunctionDeclarationHeader extends Node {
       $this->_right_paren,
       $this->_contexts,
       $this->_colon,
+      $this->_readonly_return,
       $value,
       $this->_where_clause,
     );
@@ -696,6 +766,7 @@ final class FunctionDeclarationHeader extends Node {
       $this->_right_paren,
       $this->_contexts,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
       $value,
     );

--- a/codegen/syntax/LambdaSignature.hack
+++ b/codegen/syntax/LambdaSignature.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3535524f5df1507fad535b18a5faa4e8>>
+ * @generated SignedSource<<952615353a93a0747219e7d8622de491>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -17,6 +17,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
   private RightParenToken $_right_paren;
   private ?Contexts $_contexts;
   private ?ColonToken $_colon;
+  private ?Node $_readonly_return;
   private ?ITypeSpecifier $_type;
 
   public function __construct(
@@ -25,6 +26,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
     RightParenToken $right_paren,
     ?Contexts $contexts,
     ?ColonToken $colon,
+    ?Node $readonly_return,
     ?ITypeSpecifier $type,
     ?__Private\SourceRef $source_ref = null,
   ) {
@@ -33,6 +35,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
     $this->_right_paren = $right_paren;
     $this->_contexts = $contexts;
     $this->_colon = $colon;
+    $this->_readonly_return = $readonly_return;
     $this->_type = $type;
     parent::__construct($source_ref);
   }
@@ -88,6 +91,14 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       'ColonToken',
     );
     $offset += $colon?->getWidth() ?? 0;
+    $readonly_return = Node::fromJSON(
+      /* HH_FIXME[4110] */ $json['lambda_readonly_return'] ?? dict['kind' => 'missing'],
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $readonly_return?->getWidth() ?? 0;
     $type = Node::fromJSON(
       /* HH_FIXME[4110] */ $json['lambda_type'] ?? dict['kind' => 'missing'],
       $file,
@@ -108,6 +119,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       /* HH_IGNORE_ERROR[4110] */ $right_paren,
       /* HH_IGNORE_ERROR[4110] */ $contexts,
       /* HH_IGNORE_ERROR[4110] */ $colon,
+      /* HH_IGNORE_ERROR[4110] */ $readonly_return,
       /* HH_IGNORE_ERROR[4110] */ $type,
       $source_ref,
     );
@@ -121,6 +133,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       'right_paren' => $this->_right_paren,
       'contexts' => $this->_contexts,
       'colon' => $this->_colon,
+      'readonly_return' => $this->_readonly_return,
       'type' => $this->_type,
     ]
       |> Dict\filter_nulls($$);
@@ -141,6 +154,9 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       ? null
       : $rewriter($this->_contexts, $parents);
     $colon = $this->_colon === null ? null : $rewriter($this->_colon, $parents);
+    $readonly_return = $this->_readonly_return === null
+      ? null
+      : $rewriter($this->_readonly_return, $parents);
     $type = $this->_type === null ? null : $rewriter($this->_type, $parents);
     if (
       $left_paren === $this->_left_paren &&
@@ -148,6 +164,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       $right_paren === $this->_right_paren &&
       $contexts === $this->_contexts &&
       $colon === $this->_colon &&
+      $readonly_return === $this->_readonly_return &&
       $type === $this->_type
     ) {
       return $this;
@@ -158,6 +175,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       /* HH_FIXME[4110] use `as` */ $right_paren,
       /* HH_FIXME[4110] use `as` */ $contexts,
       /* HH_FIXME[4110] use `as` */ $colon,
+      /* HH_FIXME[4110] use `as` */ $readonly_return,
       /* HH_FIXME[4110] use `as` */ $type,
     );
   }
@@ -176,6 +194,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       $this->_right_paren,
       $this->_contexts,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
     );
   }
@@ -212,6 +231,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       $this->_right_paren,
       $this->_contexts,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
     );
   }
@@ -250,6 +270,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       $value,
       $this->_contexts,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
     );
   }
@@ -286,6 +307,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       $this->_right_paren,
       $value,
       $this->_colon,
+      $this->_readonly_return,
       $this->_type,
     );
   }
@@ -322,6 +344,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       $this->_right_paren,
       $this->_contexts,
       $value,
+      $this->_readonly_return,
       $this->_type,
     );
   }
@@ -344,6 +367,43 @@ final class LambdaSignature extends Node implements ILambdaSignature {
     return TypeAssert\not_null($this->getColon());
   }
 
+  public function getReadonlyReturnUNTYPED(): ?Node {
+    return $this->_readonly_return;
+  }
+
+  public function withReadonlyReturn(?Node $value): this {
+    if ($value === $this->_readonly_return) {
+      return $this;
+    }
+    return new static(
+      $this->_left_paren,
+      $this->_parameters,
+      $this->_right_paren,
+      $this->_contexts,
+      $this->_colon,
+      $value,
+      $this->_type,
+    );
+  }
+
+  public function hasReadonlyReturn(): bool {
+    return $this->_readonly_return !== null;
+  }
+
+  /**
+   * @return null
+   */
+  public function getReadonlyReturn(): ?Node {
+    return $this->_readonly_return;
+  }
+
+  /**
+   * @return
+   */
+  public function getReadonlyReturnx(): Node {
+    return TypeAssert\not_null($this->getReadonlyReturn());
+  }
+
   public function getTypeUNTYPED(): ?Node {
     return $this->_type;
   }
@@ -358,6 +418,7 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       $this->_right_paren,
       $this->_contexts,
       $this->_colon,
+      $this->_readonly_return,
       $value,
     );
   }

--- a/codegen/syntax/ParameterDeclaration.hack
+++ b/codegen/syntax/ParameterDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ddab0e9d4aec6fe191368d86a3aae144>>
+ * @generated SignedSource<<6cc0d3260863894ea38ca391c8c8eac6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -19,6 +19,7 @@ final class ParameterDeclaration
   private ?OldAttributeSpecification $_attribute;
   private ?Token $_visibility;
   private ?InoutToken $_call_convention;
+  private ?Node $_readonly;
   private ?ITypeSpecifier $_type;
   private IExpression $_name;
   private ?SimpleInitializer $_default_value;
@@ -27,6 +28,7 @@ final class ParameterDeclaration
     ?OldAttributeSpecification $attribute,
     ?Token $visibility,
     ?InoutToken $call_convention,
+    ?Node $readonly,
     ?ITypeSpecifier $type,
     IExpression $name,
     ?SimpleInitializer $default_value,
@@ -35,6 +37,7 @@ final class ParameterDeclaration
     $this->_attribute = $attribute;
     $this->_visibility = $visibility;
     $this->_call_convention = $call_convention;
+    $this->_readonly = $readonly;
     $this->_type = $type;
     $this->_name = $name;
     $this->_default_value = $default_value;
@@ -74,6 +77,14 @@ final class ParameterDeclaration
       'InoutToken',
     );
     $offset += $call_convention?->getWidth() ?? 0;
+    $readonly = Node::fromJSON(
+      /* HH_FIXME[4110] */ $json['parameter_readonly'] ?? dict['kind' => 'missing'],
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $readonly?->getWidth() ?? 0;
     $type = Node::fromJSON(
       /* HH_FIXME[4110] */ $json['parameter_type'] ?? dict['kind' => 'missing'],
       $file,
@@ -109,6 +120,7 @@ final class ParameterDeclaration
       /* HH_IGNORE_ERROR[4110] */ $attribute,
       /* HH_IGNORE_ERROR[4110] */ $visibility,
       /* HH_IGNORE_ERROR[4110] */ $call_convention,
+      /* HH_IGNORE_ERROR[4110] */ $readonly,
       /* HH_IGNORE_ERROR[4110] */ $type,
       /* HH_IGNORE_ERROR[4110] */ $name,
       /* HH_IGNORE_ERROR[4110] */ $default_value,
@@ -122,6 +134,7 @@ final class ParameterDeclaration
       'attribute' => $this->_attribute,
       'visibility' => $this->_visibility,
       'call_convention' => $this->_call_convention,
+      'readonly' => $this->_readonly,
       'type' => $this->_type,
       'name' => $this->_name,
       'default_value' => $this->_default_value,
@@ -144,6 +157,9 @@ final class ParameterDeclaration
     $call_convention = $this->_call_convention === null
       ? null
       : $rewriter($this->_call_convention, $parents);
+    $readonly = $this->_readonly === null
+      ? null
+      : $rewriter($this->_readonly, $parents);
     $type = $this->_type === null ? null : $rewriter($this->_type, $parents);
     $name = $rewriter($this->_name, $parents);
     $default_value = $this->_default_value === null
@@ -153,6 +169,7 @@ final class ParameterDeclaration
       $attribute === $this->_attribute &&
       $visibility === $this->_visibility &&
       $call_convention === $this->_call_convention &&
+      $readonly === $this->_readonly &&
       $type === $this->_type &&
       $name === $this->_name &&
       $default_value === $this->_default_value
@@ -163,6 +180,7 @@ final class ParameterDeclaration
       /* HH_FIXME[4110] use `as` */ $attribute,
       /* HH_FIXME[4110] use `as` */ $visibility,
       /* HH_FIXME[4110] use `as` */ $call_convention,
+      /* HH_FIXME[4110] use `as` */ $readonly,
       /* HH_FIXME[4110] use `as` */ $type,
       /* HH_FIXME[4110] use `as` */ $name,
       /* HH_FIXME[4110] use `as` */ $default_value,
@@ -181,6 +199,7 @@ final class ParameterDeclaration
       $value,
       $this->_visibility,
       $this->_call_convention,
+      $this->_readonly,
       $this->_type,
       $this->_name,
       $this->_default_value,
@@ -217,6 +236,7 @@ final class ParameterDeclaration
       $this->_attribute,
       $value,
       $this->_call_convention,
+      $this->_readonly,
       $this->_type,
       $this->_name,
       $this->_default_value,
@@ -253,6 +273,7 @@ final class ParameterDeclaration
       $this->_attribute,
       $this->_visibility,
       $value,
+      $this->_readonly,
       $this->_type,
       $this->_name,
       $this->_default_value,
@@ -277,6 +298,43 @@ final class ParameterDeclaration
     return TypeAssert\not_null($this->getCallConvention());
   }
 
+  public function getReadonlyUNTYPED(): ?Node {
+    return $this->_readonly;
+  }
+
+  public function withReadonly(?Node $value): this {
+    if ($value === $this->_readonly) {
+      return $this;
+    }
+    return new static(
+      $this->_attribute,
+      $this->_visibility,
+      $this->_call_convention,
+      $value,
+      $this->_type,
+      $this->_name,
+      $this->_default_value,
+    );
+  }
+
+  public function hasReadonly(): bool {
+    return $this->_readonly !== null;
+  }
+
+  /**
+   * @return null
+   */
+  public function getReadonly(): ?Node {
+    return $this->_readonly;
+  }
+
+  /**
+   * @return
+   */
+  public function getReadonlyx(): Node {
+    return TypeAssert\not_null($this->getReadonly());
+  }
+
   public function getTypeUNTYPED(): ?Node {
     return $this->_type;
   }
@@ -289,6 +347,7 @@ final class ParameterDeclaration
       $this->_attribute,
       $this->_visibility,
       $this->_call_convention,
+      $this->_readonly,
       $value,
       $this->_name,
       $this->_default_value,
@@ -333,6 +392,7 @@ final class ParameterDeclaration
       $this->_attribute,
       $this->_visibility,
       $this->_call_convention,
+      $this->_readonly,
       $this->_type,
       $value,
       $this->_default_value,
@@ -369,6 +429,7 @@ final class ParameterDeclaration
       $this->_attribute,
       $this->_visibility,
       $this->_call_convention,
+      $this->_readonly,
       $this->_type,
       $this->_name,
       $value,

--- a/codegen/token_from_data.hack
+++ b/codegen/token_from_data.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<aa10598438160680db6bbceeb55eb151>>
+ * @generated SignedSource<<e2f60406650cc0567d6d1d8c0a6bcbfd>>
  */
 namespace Facebook\HHAST\__Private;
 use namespace Facebook\HHAST;
@@ -110,6 +110,7 @@ class TokenClassMap {
     'protected' => HHAST\ProtectedToken::class,
     'public' => HHAST\PublicToken::class,
     '?as' => HHAST\QuestionAsToken::class,
+    'readonly' => HHAST\ReadonlyToken::class,
     'real' => HHAST\RealToken::class,
     'recordname' => HHAST\RecordToken::class,
     'record' => HHAST\RecordDecToken::class,

--- a/codegen/tokens/ReadonlyToken.hack
+++ b/codegen/tokens/ReadonlyToken.hack
@@ -1,0 +1,20 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * @generated SignedSource<<90264eb91014dad1400de0818a229765>>
+ */
+namespace Facebook\HHAST;
+
+final class ReadonlyToken extends TokenWithVariableText {
+
+  const string KIND = 'readonly';
+
+  public function __construct(
+    ?NodeList<Trivia> $leading,
+    ?NodeList<Trivia> $trailing,
+    string $token_text = 'readonly',
+    ?__Private\SourceRef $source_ref = null,
+  ) {
+    parent::__construct($leading, $trailing, $token_text, $source_ref);
+  }
+}

--- a/codegen/version.hack
+++ b/codegen/version.hack
@@ -1,12 +1,12 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<36764bf3ab9ba396b8db628e47d84f42>>
+ * @generated SignedSource<<3e3db05ddab26be2410cf45a9e300dab>>
  */
 namespace Facebook\HHAST;
 
-const string SCHEMA_VERSION = '2021-01-21-0001';
+const string SCHEMA_VERSION = '2021-01-22-0001';
 
-const int HHVM_VERSION_ID = 409400;
+const int HHVM_VERSION_ID = 409500;
 
-const string HHVM_VERSION = '4.94.0-dev';
+const string HHVM_VERSION = '4.95.0-dev';

--- a/src/Linters/PreferLambdasLinter.hack
+++ b/src/Linters/PreferLambdasLinter.hack
@@ -65,6 +65,7 @@ final class PreferLambdasLinter extends AutoFixingASTLinter {
       // capabilities are not supported by anonymous functions
       /* capability = */ null,
       $colon,
+      null,
       $type,
     );
 

--- a/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
@@ -260,6 +260,7 @@ final class AddXHPChildrenDeclarationMethodMigration
       new RightParenToken(null, null),
       null,
       new ColonToken(null, $s),
+      null,
       new SimpleTypeSpecifier(
         new QualifiedName(
           new NodeList(vec[

--- a/src/__Private/is_compatible_schema_version.hack
+++ b/src/__Private/is_compatible_schema_version.hack
@@ -21,7 +21,7 @@ use const Facebook\HHAST\SCHEMA_VERSION;
  */
 function is_compatible_schema_version(string $other_version): bool {
   invariant(
-    SCHEMA_VERSION === '2021-01-21-0001',
+    SCHEMA_VERSION === '2021-01-22-0001',
     '%s needs updating',
     __FILE__,
   );
@@ -30,5 +30,10 @@ function is_compatible_schema_version(string $other_version): bool {
   }
 
   // Return true if $other_version is a subset of SCHEMA_VERSION
-  return false;
+  switch ($other_version) {
+    case '2021-01-21-0001': // doesn't have ReadonlyToken
+      return true;
+    default:
+      return false;
+  }
 }

--- a/tests/AppendToNodeListTest.hack
+++ b/tests/AppendToNodeListTest.hack
@@ -35,6 +35,7 @@ final class AppendToNodeListTest extends TestCase {
         null,
         null,
         null,
+        null,
         new SimpleTypeSpecifier(new IntToken(null, null)),
         new VariableToken(
           NodeList::createMaybeEmptyList(vec[new WhiteSpace(' ')]),


### PR DESCRIPTION
The schema is backwards compatible, but the generated code isn't (there's a new argument in the middle for a bunch of constructors). Do we want to release that as 4.94.1 or 4.95.0?