### PR TITLE
add lambda support to Unused.*Linter

### DIFF
--- a/src/Linters/GroupUseStatementsLinter.hack
+++ b/src/Linters/GroupUseStatementsLinter.hack
@@ -388,7 +388,7 @@ final class GroupUseStatementsLinter extends AutoFixingASTLinter {
                       $alias_trailing,
                       $comma_trailing,
                     ),
-                    ($lt, $trivia) ==> Str\length($trivia->getCode()),
+                    ($_lt, $trivia) ==> Str\length($trivia->getCode()),
                     0,
                   );
               },

--- a/src/Linters/LinterException.hack
+++ b/src/Linters/LinterException.hack
@@ -27,8 +27,8 @@ final class LinterException extends \Exception {
         $rawMessage,
       ),
       /* code = */ 0,
-      /* HH_IGNORE_ERROR[4110] : Throwable is fine. facebook/hhvm#8239 */
-      $previous,
+      // Throwable should be fine but causes type errors. facebook/hhvm#8239
+      $previous ?as \Exception,
     );
   }
 

--- a/tests/RewriteBehaviorTest.hack
+++ b/tests/RewriteBehaviorTest.hack
@@ -125,7 +125,7 @@ final class RewriteBehaviorTest extends TestCase {
     );
 
     $new = $orig->rewrite(
-      ($node, $parents) ==> {
+      ($node, $_parents) ==> {
         if (!$node is HHAST\Trivia) {
           return $node;
         }

--- a/tests/examples/UnusedParameterLinter/function_param.php.autofix.expect
+++ b/tests/examples/UnusedParameterLinter/function_param.php.autofix.expect
@@ -3,3 +3,12 @@
 function foo(int $bar, int $_baz) {
   return $bar;
 }
+
+function lambdas(
+  int $a,
+  int $b,
+  (function(int, int): int) $_c = ($_c1, $c2) ==> $c2,
+): void {
+  $d = ($d1, $_d2) ==> tuple($d1, $b);
+  $e = $a ==> $a; // shadowed parameter, currently causes a false negative
+}

--- a/tests/examples/UnusedParameterLinter/function_param.php.expect
+++ b/tests/examples/UnusedParameterLinter/function_param.php.expect
@@ -3,5 +3,20 @@
         "blame": "int $baz",
         "blame_pretty": "int $baz",
         "description": "Parameter is unused"
+    },
+    {
+        "blame": "  (function(int, int): int) $c = ($c1, $c2) ==> $c2",
+        "blame_pretty": "  (function(int, int): int) $c = ($c1, $c2) ==> $c2",
+        "description": "Parameter is unused"
+    },
+    {
+        "blame": "$c1",
+        "blame_pretty": "$c1",
+        "description": "Parameter is unused"
+    },
+    {
+        "blame": "$d2",
+        "blame_pretty": "$d2",
+        "description": "Parameter is unused"
     }
 ]

--- a/tests/examples/UnusedParameterLinter/function_param.php.in
+++ b/tests/examples/UnusedParameterLinter/function_param.php.in
@@ -3,3 +3,12 @@
 function foo(int $bar, int $baz) {
   return $bar;
 }
+
+function lambdas(
+  int $a,
+  int $b,
+  (function(int, int): int) $c = ($c1, $c2) ==> $c2,
+): void {
+  $d = ($d1, $d2) ==> tuple($d1, $b);
+  $e = $a ==> $a; // shadowed parameter, currently causes a false negative
+}

--- a/tests/examples/UnusedVariableLinter/unused_variable.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_variable.php.autofix.expect
@@ -15,6 +15,18 @@ function with_mutation(): void {
   return;
 }
 
+function lambdas(
+  (function(int, int): void) $fun = ($x, $y) ==> { $z = $x; },
+): void {
+  $a = $a ==> $a; // shadowed name, currently causes a false negative
+  $b = 42;
+  $c = $b ==> $b; // same here
+  $d = () ==> {
+    $fun = ($x, $y) ==> { $z = $x; };
+  };
+  $d();
+}
+
 class C {
   public function simple(int $bar): int {
     $baz = $bar;

--- a/tests/examples/UnusedVariableLinter/unused_variable.php.expect
+++ b/tests/examples/UnusedVariableLinter/unused_variable.php.expect
@@ -25,6 +25,26 @@
         "description": "Variable is unused"
     },
     {
+        "blame": "$z ",
+        "blame_pretty": "$z ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "  $c ",
+        "blame_pretty": "  $c ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "    $fun ",
+        "blame_pretty": "    $fun ",
+        "description": "Variable is unused"
+    },
+    {
+        "blame": "$z ",
+        "blame_pretty": "$z ",
+        "description": "Variable is unused"
+    },
+    {
         "blame": "    $baz ",
         "blame_pretty": "    $baz ",
         "description": "Variable is unused"

--- a/tests/examples/UnusedVariableLinter/unused_variable.php.in
+++ b/tests/examples/UnusedVariableLinter/unused_variable.php.in
@@ -15,6 +15,18 @@ function with_mutation(): void {
   return;
 }
 
+function lambdas(
+  (function(int, int): void) $fun = ($x, $y) ==> { $z = $x; },
+): void {
+  $a = $a ==> $a; // shadowed name, currently causes a false negative
+  $b = 42;
+  $c = $b ==> $b; // same here
+  $d = () ==> {
+    $fun = ($x, $y) ==> { $z = $x; };
+  };
+  $d();
+}
+
 class C {
   public function simple(int $bar): int {
     $baz = $bar;


### PR DESCRIPTION
Fixes #341

- improves some other cases (unused params/variables *inside* lambdas are caught)
- some false negatives still exist (using a shadowed param/variable inside a lambda also marks it as used in the enclosing function) -- probably fixable but I didn't want to do too much in one PR