### PR TITLE
Add new reified generic apis where classname<T> was previously used

### DIFF
--- a/src/Linters/DataProviderTypesLinter.hack
+++ b/src/Linters/DataProviderTypesLinter.hack
@@ -180,9 +180,7 @@ final class DataProviderTypesLinter extends AutoFixingASTLinter {
   }
 
   <<__Memoize>>
-  private function getInfoAboutTestFile(
-    this::TContext $context,
-  ): ?shape(
+  private function getInfoAboutTestFile(this::TContext $context): ?shape(
     'data_providers' => this::TProviders,
     'hhast_methods' => dict<string, FunctionDeclarationHeader>,
   ) {
@@ -190,7 +188,7 @@ final class DataProviderTypesLinter extends AutoFixingASTLinter {
       return null;
     }
 
-    $methods = $context->getDescendantsOfType(MethodishDeclaration::class);
+    $methods = $context->getDescendantsByType<MethodishDeclaration>();
 
     $data_providers = $methods
       |> Vec\map(
@@ -243,7 +241,7 @@ final class DataProviderTypesLinter extends AutoFixingASTLinter {
         if ($name is NameToken) {
           $string_name = $name->getText();
         } else if ($name is QualifiedName) {
-          $string_name = $name->getDescendantsOfType(NameToken::class)
+          $string_name = $name->getDescendantsByType<NameToken>()
             |> Vec\map($$, $name ==> $name->getText())
             |> Str\join($$, '\\');
           if (qualified_name_is_fully_qualified($name)) {

--- a/src/Linters/DontUseAsioJoinLinter.hack
+++ b/src/Linters/DontUseAsioJoinLinter.hack
@@ -26,7 +26,7 @@ final class DontUseAsioJoinLinter extends AutoFixingASTLinter {
     if ($name is NameToken) {
       $string_name = $name->getText();
     } else if ($name is QualifiedName) {
-      $string_name = $name->getDescendantsOfType(NameToken::class)
+      $string_name = $name->getDescendantsByType<NameToken>()
         |> Vec\map($$, $n ==> $n->getText())
         |> Str\join($$, '\\');
       if (qualified_name_is_fully_qualified($name)) {

--- a/src/Linters/FunctionNamingLinter.hack
+++ b/src/Linters/FunctionNamingLinter.hack
@@ -9,7 +9,7 @@
 
 namespace Facebook\HHAST;
 
-use namespace HH\Lib\{C, Str};
+use namespace HH\Lib\Str;
 
 abstract class FunctionNamingLinter extends AutoFixingASTLinter {
   const type TContext = IFunctionishDeclaration;
@@ -85,9 +85,7 @@ abstract class FunctionNamingLinter extends AutoFixingASTLinter {
     } else if ($func is MethodishDeclaration) {
       if (
         $header->getModifiers()
-          ?->getDescendantsOfType(StaticToken::class)
-        |> ($$ ?? vec[])
-        |> C\is_empty(vec($$))
+          ?->getFirstDescendantByType<StaticToken>() is null
       ) {
         $what = 'Method';
         $new = $this->getSuggestedNameForInstanceMethod($old, $func);

--- a/src/Linters/GroupUseStatementAlphabetizationLinter.hack
+++ b/src/Linters/GroupUseStatementAlphabetizationLinter.hack
@@ -40,7 +40,7 @@ final class GroupUseStatementAlphabetizationLinter extends AutoFixingASTLinter {
     $list = $node->getClauses();
     foreach ($list->toVec() as $item) {
       $name = $item->getItem()->getName();
-      $str = $name->getDescendantsOfType(NameToken::class)
+      $str = $name->getDescendantsByType<NameToken>()
         |> Vec\map($$, $t ==> $t->getText())
         |> Str\join($$, '\\');
       $items[$str] = $item;

--- a/src/Linters/MustUseBracesForControlFlowLinter.hack
+++ b/src/Linters/MustUseBracesForControlFlowLinter.hack
@@ -9,7 +9,7 @@
 
 namespace Facebook\HHAST;
 
-use namespace HH\Lib\{C, Str, Vec};
+use namespace HH\Lib\{Str, Vec};
 
 class MustUseBracesForControlFlowLinter extends AutoFixingASTLinter {
   const type TNode = IControlFlowStatement;
@@ -95,8 +95,7 @@ class MustUseBracesForControlFlowLinter extends AutoFixingASTLinter {
 
     if (
       $last_token->getTrailingWhitespace()
-        ->getDescendantsOfType(EndOfLine::class)
-      |> C\is_empty(vec($$))
+        ->getFirstDescendantByType<EndOfLine>() is null
     ) {
       $right_brace_leading = new NodeList(vec[new WhiteSpace(' ')]);
       $body_trailing = null;

--- a/src/Linters/MustUseOverrideAttributeLinter.hack
+++ b/src/Linters/MustUseOverrideAttributeLinter.hack
@@ -91,8 +91,7 @@ final class MustUseOverrideAttributeLinter extends AutoFixingASTLinter {
 
     $private = $method->getFunctionDeclHeader()
       ->getModifiersx()
-      ->getDescendantsOfType(PrivateToken::class)
-      |> C\first($$);
+      ->getFirstDescendantByType<PrivateToken>();
     if ($private !== null) {
       return true;
     }

--- a/src/Linters/NamespacePrivateLinter.hack
+++ b/src/Linters/NamespacePrivateLinter.hack
@@ -46,13 +46,13 @@ final class NamespacePrivateLinter extends ASTLinter {
 
     $traversed_qualified_names = varray[];
     foreach (
-      $node->getDescendantsOfType(QualifiedName::class) as $qualified_name_token
+      $node->getDescendantsByType<QualifiedName>() as $qualified_name_token
     ) {
       $name_token_key = '';
       if ($qualified_name_token->hasParts()) {
-        $name_token_key = $qualified_name_token->getDescendantsOfType(
-          NameToken::class,
-        )
+        $name_token_key = $qualified_name_token->getDescendantsByType<
+          NameToken,
+        >()
           |> Vec\map(
             $$,
             $qualified_name_token ==> $qualified_name_token->getText(),

--- a/src/Linters/PreferLambdasLinter.hack
+++ b/src/Linters/PreferLambdasLinter.hack
@@ -30,7 +30,7 @@ final class PreferLambdasLinter extends AutoFixingASTLinter {
 
     $uses_references = $use_expr is nonnull &&
       C\any(
-        $use_expr->getDescendantsOfType(PrefixUnaryExpression::class),
+        $use_expr->getDescendantsByType<PrefixUnaryExpression>(),
         $expr ==> $expr->getOperator() is AmpersandToken,
       );
 

--- a/src/Linters/UnusedUseClauseLinter.hack
+++ b/src/Linters/UnusedUseClauseLinter.hack
@@ -173,6 +173,7 @@ final class UnusedUseClauseLinter extends AutoFixingASTLinter {
         )
         |> $node->withClauses(new NodeList($$));
     }
+    // ->getChildrenByType<ListItem>() can't be used, because ListItem is generic.
     $last = C\lastx($fixed->getClauses()->getChildrenOfType(ListItem::class));
     $sep = $last->getSeparator();
 
@@ -183,8 +184,7 @@ final class UnusedUseClauseLinter extends AutoFixingASTLinter {
   }
 
   <<__Memoize>>
-  private function getUnresolvedReferencedNames(
-  ): shape(
+  private function getUnresolvedReferencedNames(): shape(
     'namespaces' => keyset<string>,
     'types' => keyset<string>,
     'functions' => keyset<string>,

--- a/src/Migrations/DemangleXHP.hack
+++ b/src/Migrations/DemangleXHP.hack
@@ -15,28 +15,22 @@ final class DemangleXHPMigration extends StepBasedMigration {
   <<__Override>>
   public function getSteps(): Traversable<IMigrationStep> {
     return vec[
-      new TypedMigrationStep(
+      new NodeTypeMigrationStep<XHPClassNameToken, _>(
         'Demangle XHP class names (`class :foo:bar-baz`, `:foo:bar-baz::class` etc)',
-        XHPClassNameToken::class,
-        XHPClassNameToken::class,
         $node ==> $node->withText(Str\replace($node->getText(), '-', '_')),
       ),
       // We can't just demangle XHPElementNameToken as that's also used for
       // attribute names - `<foo:bar-baz herp-derp="x" />` needs to be
       // `<foo:bar_baz herp-derp="x" />`, not `herp_derp`.
-      new TypedMigrationStep(
+      new NodeTypeMigrationStep<XHPOpen, _>(
         'Demangle XHP open tags (`<foo:bar-baz>`)',
-        XHPOpen::class,
-        XHPOpen::class,
         $node ==> $node->withName(
           $node->getName()
             ->withText(Str\replace($node->getName()->getText(), '-', '_')),
         ),
       ),
-      new TypedMigrationStep(
+      new NodeTypeMigrationStep<XHPClose, _>(
         'Demangle XHP close tags (`</foo:bar-baz>`)',
-        XHPClose::class,
-        XHPClose::class,
         $node ==> $node->withName(
           $node->getName()
             ->withText(Str\replace($node->getName()->getText(), '-', '_')),

--- a/src/Migrations/DollarBraceEmbeddedVariableMigration.hack
+++ b/src/Migrations/DollarBraceEmbeddedVariableMigration.hack
@@ -67,10 +67,8 @@ final class DollarBraceEmbeddedVariableMigration extends StepBasedMigration {
   <<__Override>>
   public function getSteps(): Traversable<IMigrationStep> {
     return vec[
-      new TypedMigrationStep(
+      new NodeTypeMigrationStep<LiteralExpression, _>(
         'convert "${foo}" to "{$foo}"',
-        LiteralExpression::class,
-        LiteralExpression::class,
         $node ==> self::migrateLiteralExpression($node),
       ),
     ];

--- a/src/Migrations/HSLMigration.hack
+++ b/src/Migrations/HSLMigration.hack
@@ -10,7 +10,6 @@
 namespace Facebook\HHAST;
 
 use namespace HH\Lib\{C, Keyset, Math, Str, Vec};
-use type Facebook\HHAST\_Private\SoftDeprecated;
 use function Facebook\HHAST\__Private\find_type_for_node_async;
 
 enum HslNamespace: string {
@@ -609,7 +608,7 @@ final class HSLMigration extends BaseMigration {
       // single namespace use declaration
       $ns = C\firstx($suffixes);
     }
-    return $this->nodeByTypeFromCode<INamespaceUseDeclaration>(
+    return $this->nodeFromCode<INamespaceUseDeclaration>(
       "\nuse namespace HH\\Lib\\".$ns.";\n",
     );
   }
@@ -663,27 +662,7 @@ final class HSLMigration extends BaseMigration {
     return $node->replace($receiver, $new_receiver);
   }
 
-  <<SoftDeprecated('$this->nodeOfTypeFromCode<T>($code)')>>
-  protected function nodeFromCode<T as Node>(
-    string $code,
-    classname<T> $expected,
-  ): T {
-    /*HHAST_FIXME[DontUseAsioJoin]*/
-    $script = \HH\Asio\join(
-      from_file_async(File::fromPathAndContents('/dev/null', $code)),
-    );
-    // Using getFirstDescendantOfType(), see nodeOfTypeFromCode<T>().
-    $node = $script->getDeclarations()->getFirstDescendantOfType($expected);
-    invariant(
-      $node !== null,
-      "Failed to find node of type '%s' in code '%s'",
-      $expected,
-      $code,
-    );
-    return $node;
-  }
-
-  protected function nodeByTypeFromCode<<<__Enforceable>> reify T as Node>(
+  private function nodeFromCode<<<__Enforceable>> reify T as Node>(
     string $code,
   ): T {
     /*HHAST_FIXME[DontUseAsioJoin]*/

--- a/src/Migrations/HardenVarrayOrDarrayTypehintsMigration.hack
+++ b/src/Migrations/HardenVarrayOrDarrayTypehintsMigration.hack
@@ -16,22 +16,16 @@ final class HardenVarrayOrDarrayTypehintsMigration extends StepBasedMigration {
   <<__Override>>
   public function getSteps(): Traversable<IMigrationStep> {
     return vec[
-      new TypedMigrationStep(
+      new NodeTypeMigrationStep<ParameterDeclaration, _>(
         'Migrate varray_or_darray parameters',
-        ParameterDeclaration::class,
-        ParameterDeclaration::class,
         $node ==> self::migrateParameter($node),
       ),
-      new TypedMigrationStep(
+      new NodeTypeMigrationStep<FunctionDeclarationHeader, _>(
         'Migrate varray_or_darray return types',
-        FunctionDeclarationHeader::class,
-        FunctionDeclarationHeader::class,
         $node ==> $node->withType(self::migrateReturnType($node->getType())),
       ),
-      new TypedMigrationStep(
+      new NodeTypeMigrationStep<LambdaSignature, _>(
         'Migrate varray_or_darray return types in lambda functions',
-        LambdaSignature::class,
-        LambdaSignature::class,
         $node ==> $node->withType(static::migrateReturnType($node->getType())),
       ),
     ];
@@ -58,7 +52,8 @@ final class HardenVarrayOrDarrayTypehintsMigration extends StepBasedMigration {
     list($attr, $type) = static::migrate($wrapper?->getAttributeSpec(), $type);
     return $wrapper is null || $attr is null || $type is null
       ? $type
-      : $wrapper->withAttributeSpec($attr)->withType($type as ISimpleCreationSpecifier);
+      : $wrapper->withAttributeSpec($attr)
+        ->withType($type as ISimpleCreationSpecifier);
   }
 
   /**

--- a/src/Migrations/ImplicitShapeSubtypesMigration.hack
+++ b/src/Migrations/ImplicitShapeSubtypesMigration.hack
@@ -59,8 +59,7 @@ final class ImplicitShapeSubtypesMigration extends StepBasedMigration {
     if ($shape->hasEllipsis()) {
       return $shape;
     }
-    $fields = $shape->getDescendantsOfType(FieldSpecifier::class);
-    $first_field = C\first($fields);
+    $first_field = $shape->getFirstDescendantByType<FieldSpecifier>();
     if ($first_field === null) {
       return $shape->withEllipsis(new DotDotDotToken(null, null));
     }
@@ -84,12 +83,7 @@ final class ImplicitShapeSubtypesMigration extends StepBasedMigration {
     $make_step = (
       string $name,
       (function(ShapeTypeSpecifier): ShapeTypeSpecifier) $impl,
-    ) ==> new TypedMigrationStep(
-      $name,
-      ShapeTypeSpecifier::class,
-      ShapeTypeSpecifier::class,
-      $impl,
-    );
+    ) ==> new NodeTypeMigrationStep<ShapeTypeSpecifier, _>($name, $impl);
 
     return vec[
       $make_step(

--- a/src/Migrations/NodeTypeMigrationStep.hack
+++ b/src/Migrations/NodeTypeMigrationStep.hack
@@ -10,16 +10,14 @@
 namespace Facebook\HHAST;
 
 use type Facebook\HHAST\Node;
-use type Facebook\HHAST\_Private\SoftDeprecated;
 
-final class TypedMigrationStep<Tin as Node, Tout as Node>
-  implements IMigrationStep {
+final class NodeTypeMigrationStep<
+  <<__Enforceable>> reify Tin as Node,
+  Tout as Node,
+> implements IMigrationStep {
 
-  <<SoftDeprecated(NodeTypeMigrationStep::class)>>
   public function __construct(
     private string $name,
-    private classname<Tin> $tin,
-    classname<Tout> $_tout,
     private (function(Tin): Tout) $rewriter,
   ) {
   }
@@ -29,10 +27,9 @@ final class TypedMigrationStep<Tin as Node, Tout as Node>
   }
 
   public function rewrite(Node $node): Node {
-    if (!\is_a($node, $this->tin)) {
+    if (!$node is Tin) {
       return $node;
     }
-    $rewriter = $this->rewriter;
-    return $rewriter(/* HH_FIXME[4110] need reified generics */ $node);
+    return ($this->rewriter)($node);
   }
 }

--- a/src/Migrations/OptionalShapeFieldsMigration.hack
+++ b/src/Migrations/OptionalShapeFieldsMigration.hack
@@ -40,6 +40,7 @@ final class OptionalShapeFieldsMigration extends StepBasedMigration {
   <<__Override>>
   public function getSteps(): Traversable<IMigrationStep> {
     return vec[
+      // Can't use NodeTypeMigrationStep<ListItem, _>, because ListItem is generic.
       new TypedMigrationStep(
         'make nullable fields optional',
         ListItem::class,

--- a/src/Migrations/RemoveXHPChildDeclarationsMigration.hack
+++ b/src/Migrations/RemoveXHPChildDeclarationsMigration.hack
@@ -13,7 +13,7 @@ use namespace HH\Lib\{C, Vec};
 
 final class RemoveXHPChildDeclarationsMigration extends StepBasedMigration {
   private static function replaceTrait(ClassishBody $in): ClassishBody {
-    $uses = $in->getElements()?->getChildrenOfType(TraitUse::class) ?? vec[]
+    $uses = $in->getElements()?->getChildrenByType<TraitUse>() ?? vec[]
       |> Vec\map($$, $use ==> $use->getNames()->getChildrenOfItems())
       |> Vec\flatten($$);
     foreach ($uses as $use) {
@@ -36,7 +36,7 @@ final class RemoveXHPChildDeclarationsMigration extends StepBasedMigration {
     ClassishBody $in,
   ): ClassishBody {
     $decls = $in->getElements()
-      ?->getChildrenOfType(XHPChildrenDeclaration::class) ??
+      ?->getChildrenByType<XHPChildrenDeclaration>() ??
       vec[];
     if (C\is_empty($decls)) {
       return $in;
@@ -73,16 +73,12 @@ final class RemoveXHPChildDeclarationsMigration extends StepBasedMigration {
   <<__Override>>
   public function getSteps(): Traversable<IMigrationStep> {
     return vec[
-      new TypedMigrationStep(
+      new NodeTypeMigrationStep<ClassishBody, _>(
         'Replace consistency trait with validation trait',
-        ClassishBody::class,
-        ClassishBody::class,
         $node ==> self::replaceTrait($node),
       ),
-      new TypedMigrationStep(
+      new NodeTypeMigrationStep<ClassishBody, _>(
         'Remove `children` declarations',
-        ClassishBody::class,
-        ClassishBody::class,
         $node ==> self::removeChildrenDeclaration($node),
       ),
     ];

--- a/src/Migrations/TopLevelRequiresMigration.hack
+++ b/src/Migrations/TopLevelRequiresMigration.hack
@@ -21,12 +21,12 @@ final class TopLevelRequiresMigration extends BaseMigration {
 
   private async function migrateFileAsync(Script $script): Awaitable<Script> {
     $decls = $script->getDeclarations();
-    $includes = $decls->getChildrenOfType(InclusionDirective::class);
+    $includes = $decls->getChildrenByType<InclusionDirective>();
     if (C\is_empty($includes)) {
       return $script;
     }
 
-    $entrypoint = $decls->getChildrenOfType(FunctionDeclaration::class)
+    $entrypoint = $decls->getChildrenByType<FunctionDeclaration>()
       |> Vec\filter(
         $$,
         $f ==> C\any(
@@ -41,7 +41,7 @@ final class TopLevelRequiresMigration extends BaseMigration {
     if (!$entrypoint) {
       return $script;
     }
-    $classes = $script->getDescendantsOfType(ClassishDeclaration::class);
+    $classes = $script->getDescendantsByType<ClassishDeclaration>();
     if (
       C\any(
         $classes,

--- a/src/Migrations/XHPClassModifierMigration.hack
+++ b/src/Migrations/XHPClassModifierMigration.hack
@@ -47,10 +47,8 @@ final class XHPClassModifierMigration extends StepBasedMigration {
   <<__Override>>
   public function getSteps(): Traversable<IMigrationStep> {
     return vec[
-      new TypedMigrationStep(
+      new NodeTypeMigrationStep<ClassishDeclaration, _>(
         'Replace `class :foo:bar` with `xhp class foo:bar`',
-        ClassishDeclaration::class,
-        ClassishDeclaration::class,
         $node ==> self::replaceXHPClassWithModifier($node),
       ),
     ];

--- a/src/Migrations/XHPLibV3ToV4Migration.hack
+++ b/src/Migrations/XHPLibV3ToV4Migration.hack
@@ -546,7 +546,7 @@ final class XHPLibV3ToV4Migration extends BaseMigration {
    * `Foo \ Bar \ Baz // comment` -> `Foo\Bar\Baz`
    */
   private static function withoutTrivia(Node $node): string {
-    return $node->getDescendantsOfType(Token::class)
+    return $node->getDescendantsByType<Token>()
       |> Vec\map($$, $token ==> $token->getText())
       |> Str\join($$, '');
   }

--- a/src/__Private/Resolution/get_uses_directly_in_scope.hack
+++ b/src/__Private/Resolution/get_uses_directly_in_scope.hack
@@ -37,11 +37,11 @@ function get_uses_directly_in_scope(?NodeList<Node> $scope): shape(
   $uses = vec[];
 
   // use [kind] Foo, [kind] Bar;
-  $statements = $scope->getChildrenOfType(NamespaceUseDeclaration::class);
+  $statements = $scope->getChildrenByType<NamespaceUseDeclaration>();
   foreach ($statements as $statement) {
     $kind = $statement->getKind();
     $clauses = $statement->getClauses()
-      ->getDescendantsOfType(NamespaceUseClause::class);
+      ->getDescendantsByType<NamespaceUseClause>();
     foreach ($clauses as $clause) {
       $uses[] = tuple(
         $clause->hasClauseKind() ? $clause->getClauseKind() : $kind,
@@ -53,14 +53,14 @@ function get_uses_directly_in_scope(?NodeList<Node> $scope): shape(
   }
 
   // use [kind] Foo\{Bar, [kind] Baz}
-  $statements = $scope->getChildrenOfType(NamespaceGroupUseDeclaration::class);
+  $statements = $scope->getChildrenByType<NamespaceGroupUseDeclaration>();
   foreach ($statements as $statement) {
     $kind = $statement->getKind();
     $prefix = $statement->getPrefix()->getCode()
       |> Str\trim($$)
       |> Str\strip_prefix($$, '\\');
     $clauses = $statement->getClauses()
-      ->getDescendantsOfType(NamespaceUseClause::class);
+      ->getDescendantsByType<NamespaceUseClause>();
     foreach ($clauses as $clause) {
       $uses[] = tuple(
         $clause->hasClauseKind() ? $clause->getClauseKind() : $kind,

--- a/src/__Private/SoftDeprecated.hack
+++ b/src/__Private/SoftDeprecated.hack
@@ -1,0 +1,14 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\_Private;
+
+final class SoftDeprecated implements \HH\MethodAttribute {
+  public function __construct(public string $useThisInstead) {}
+}

--- a/src/nodes/NamespaceDeclaration.hack
+++ b/src/nodes/NamespaceDeclaration.hack
@@ -36,7 +36,7 @@ final class NamespaceDeclaration extends NamespaceDeclarationGeneratedBase {
       return '';
     }
 
-    return $name->getDescendantsOfType(NameToken::class)
+    return $name->getDescendantsByType<NameToken>()
       |> Vec\map($$, $t ==> $t->getText())
       |> Str\join($$, '\\');
   }

--- a/src/nodes/Script.hack
+++ b/src/nodes/Script.hack
@@ -14,7 +14,7 @@ use namespace HH\Lib\{C, Dict, Vec};
 final class Script extends ScriptGeneratedBase {
   <<__Memoize>>
   public function getTokens(): vec<Token> {
-    return $this->getDescendantsOfType(Token::class);
+    return $this->getDescendantsByType<Token>();
   }
 
   <<__Memoize>>
@@ -125,8 +125,9 @@ final class Script extends ScriptGeneratedBase {
         if ($ns['name'] === '') {
           $ns['name'] = null;
         }
-        $inner =
-          __Private\Resolution\get_uses_directly_in_scope($ns['children']);
+        $inner = __Private\Resolution\get_uses_directly_in_scope(
+          $ns['children'],
+        );
         $ns['uses'] = shape(
           'namespaces' =>
             Dict\merge($outer['namespaces'], $inner['namespaces']),
@@ -151,30 +152,30 @@ final class Script extends ScriptGeneratedBase {
     $nodes_with_maybe_generics = Vec\concat(
       // classes/interfaces/traits
       Vec\map(
-        $root->getDescendantsOfType(ClassishDeclaration::class),
+        $root->getDescendantsByType<ClassishDeclaration>(),
         $n ==> tuple($n, $n->getTypeParameters()),
       ),
       // type declarations
       Vec\map(
-        $root->getDescendantsOfType(AliasDeclaration::class),
+        $root->getDescendantsByType<AliasDeclaration>(),
         $n ==> tuple($n, $n->getGenericParameter()),
       ),
       Vec\map(
-        $root->getDescendantsOfType(TypeConstDeclaration::class),
+        $root->getDescendantsByType<TypeConstDeclaration>(),
         $n ==> tuple($n, $n->getTypeParameters() as ?TypeParameters),
       ),
       // functions/methods
       Vec\map(
-        $root->getDescendantsOfType(FunctionDeclaration::class),
+        $root->getDescendantsByType<FunctionDeclaration>(),
         $n ==> tuple($n, $n->getDeclarationHeader()->getTypeParameterList()),
       ),
       Vec\map(
-        $root->getDescendantsOfType(MethodishDeclaration::class),
+        $root->getDescendantsByType<MethodishDeclaration>(),
         $n ==> tuple($n, $n->getFunctionDeclHeader()->getTypeParameterList()),
       ),
       // whatever this is
       Vec\map(
-        $root->getDescendantsOfType(MethodishTraitResolution::class),
+        $root->getDescendantsByType<MethodishTraitResolution>(),
         $n ==> tuple(
           $n,
           $n->getFunctionDeclHeader() as FunctionDeclarationHeader

--- a/tests/EncodingTest.hack
+++ b/tests/EncodingTest.hack
@@ -20,7 +20,8 @@ final class EncodingTest extends TestCase {
     $ast = await from_file_async(
       File::fromPath(__DIR__.'/examples/eucjp2sjis.php'),
     );
-    $str = $ast->getDescendantsOfType(SingleQuotedStringLiteralToken::class)[0];
+    $str = $ast->getFirstDescendantByType<SingleQuotedStringLiteralToken>()
+      as nonnull;
 
     // Make sure that we get the same binary string back, not converted...
     $second_line = $str->getText()

--- a/tests/FixtureRewritingTest.hack
+++ b/tests/FixtureRewritingTest.hack
@@ -11,16 +11,15 @@
 namespace Facebook\HHAST;
 
 use function Facebook\HHAST\TestLib\expect;
-use namespace Facebook\HHAST;
 use namespace HH\Lib\Str;
 
 final class FixtureRewritingTest extends TestCase {
   public async function testRewriteComments(): Awaitable<void> {
-    $rewriter = (HHAST\Node $node, ?vec<HHAST\Node> $_parents) ==> {
-      if ($node is HHAST\SingleLineComment) {
+    $rewriter = (Node $node, ?vec<Node> $_parents) ==> {
+      if ($node is SingleLineComment) {
         return $node->withText('// blah blah blah');
       }
-      if ($node is HHAST\DelimitedComment) {
+      if ($node is DelimitedComment) {
         if (Str\contains($node->getText(), 'Copyright')) {
           return $node;
         }
@@ -29,8 +28,8 @@ final class FixtureRewritingTest extends TestCase {
       return $node;
     };
 
-    $ast = await HHAST\from_file_async(
-      HHAST\File::fromPath(__DIR__.'/examples/rewrite_comments.php.in'),
+    $ast = await from_file_async(
+      File::fromPath(__DIR__.'/examples/rewrite_comments.php.in'),
     );
     $code = $ast->rewrite($rewriter)->getCode();
     expect($code)->toMatchExpectFile('rewrite_comments.php.expect');

--- a/tests/MigrationTest.hack
+++ b/tests/MigrationTest.hack
@@ -10,7 +10,6 @@
 namespace Facebook\HHAST;
 
 use function Facebook\HHAST\TestLib\expect;
-use namespace Facebook\HHAST;
 use type Facebook\HackTest\DataProvider;
 use namespace HH\Lib\{C, Str};
 
@@ -50,7 +49,7 @@ abstract class MigrationTest extends TestCase {
       __DIR__.'/examples/'.$example.'.in',
     );
     $file = $temp->getFilePath();
-    $ast = await HHAST\from_file_async(HHAST\File::fromPath($file));
+    $ast = await from_file_async(File::fromPath($file));
 
     $migration = new $migration($temp->getRootPath());
 
@@ -68,7 +67,7 @@ abstract class MigrationTest extends TestCase {
       __DIR__.'/examples/'.$example.'.in',
     );
     $file = $temp->getFilePath();
-    $ast = await HHAST\from_file_async(HHAST\File::fromPath($file));
+    $ast = await from_file_async(File::fromPath($file));
 
     $root = $temp->getRootPath();
     $migration = () ==> new $migration($root);

--- a/tests/NodeTypesTest.hack
+++ b/tests/NodeTypesTest.hack
@@ -87,7 +87,7 @@ final class NodeTypesTest extends TestCase {
     $qualified_name = expect($some_namespaced_const->getWrappedNode())
       ->toBeInstanceOf(QualifiedName::class);
     expect(
-      $qualified_name->getDescendantsOfType(Token::class)
+      $qualified_name->getDescendantsByType<Token>()
         |> Vec\map($$, $t ==> $t->getText())
         |> Str\join($$, ''),
     )->toBeSame('SOME\\NAMESPACED\\CONST');
@@ -117,7 +117,7 @@ final class NodeTypesTest extends TestCase {
     expect($c1->getText())->toBeSame('SOME_CONST');
     $c2 = expect($c2->getWrappedNode())->toBeInstanceOf(QualifiedName::class);
     expect(
-      $c2->getDescendantsOfType(Token::class)
+      $c2->getDescendantsByType<Token>()
         |> Vec\map($$, $t ==> $t->getText())
         |> Str\join($$, ''),
     )->toBeSame('SOME\\NAMESPACED\\CONST');
@@ -130,11 +130,11 @@ final class NodeTypesTest extends TestCase {
     $class = expect($x)->toBeInstanceOf(ClassishDeclaration::class);
     $decl = $class->getBody()
       ->getElementsx()
-      ->getChildrenOfType(XHPChildrenDeclaration::class)
+      ->getChildrenByType<XHPChildrenDeclaration>()
       |> C\onlyx($$);
 
     // :bar+
-    $bin_expr = $decl->getDescendantsOfType(PostfixUnaryExpression::class)
+    $bin_expr = $decl->getDescendantsByType<PostfixUnaryExpression>()
       |> C\onlyx($$);
     $lhs = $bin_expr->getOperand();
     $lhs = expect($lhs)->toBeInstanceOf(NameExpression::class);
@@ -151,10 +151,10 @@ final class NodeTypesTest extends TestCase {
     $class = expect($x)->toBeInstanceOf(ClassishDeclaration::class);
     $decl = $class->getBody()
       ->getElementsx()
-      ->getChildrenOfType(XHPChildrenDeclaration::class)
+      ->getChildrenByType<XHPChildrenDeclaration>()
       |> C\onlyx($$);
 
-    $bin_expr = $decl->getDescendantsOfType(PostfixUnaryExpression::class)
+    $bin_expr = $decl->getDescendantsByType<PostfixUnaryExpression>()
       |> C\onlyx($$);
     $lhs = $bin_expr->getOperand();
     $lhs = expect($lhs)->toBeInstanceOf(XHPChildrenParenthesizedList::class);

--- a/tests/StepBasedMigrationTest.hack
+++ b/tests/StepBasedMigrationTest.hack
@@ -10,7 +10,6 @@
 namespace Facebook\HHAST;
 use function Facebook\HHAST\TestLib\expect;
 
-use namespace Facebook\HHAST;
 use type Facebook\HackTest\DataProvider;
 
 abstract class StepBasedMigrationTest extends MigrationTest {
@@ -33,11 +32,10 @@ abstract class StepBasedMigrationTest extends MigrationTest {
     IMigrationStep $step,
     string $example,
   ): Awaitable<void> {
-    $rewrite = (HHAST\Node $ast) ==>
-      $ast->rewrite(($n, $_) ==> $step->rewrite($n));
+    $rewrite = (Node $ast) ==> $ast->rewrite(($n, $_) ==> $step->rewrite($n));
 
-    $ast = await HHAST\from_file_async(
-      HHAST\File::fromPath(__DIR__.'/examples/'.$example.'.in'),
+    $ast = await from_file_async(
+      File::fromPath(__DIR__.'/examples/'.$example.'.in'),
     );
     $ast = $rewrite($ast);
 

--- a/tests/TypeSpecifierOrContextsTest.hack
+++ b/tests/TypeSpecifierOrContextsTest.hack
@@ -43,8 +43,7 @@ final class TypeSpecifierOrContextsTest extends TestCase {
         'abstract class Foo { '.$code.'; }',
       ),
     );
-    $constraint = $ast->getFirstDescendantOfType(TypeConstraint::class)
-      as nonnull;
+    $constraint = $ast->getFirstDescendantByType<TypeConstraint>() as nonnull;
     expect($constraint->getType())->toBeInstanceOf($expected);
   }
 }


### PR DESCRIPTION
Addresses #269 partially.
This doesn't replace the classname api with a reified one.
It supplements it with new one that are reified.
This way linters can remain hhast version agnostic.
The old api can be removed when the new ones have been around for a long time.
The `<<SoftDeprecated>>` was used instead of `<<__Deprecated>>`.
We can later grep for this and really `<<__Deprecated>>` them.

The first commit adds the new api and starts using it in the file itself.
The second commit converts as many uses as possible through the entire codebase.
The third commit is a realization that one of the deprecated methods was protected and in a final class.
It could be removed without breaking BC.