### PR TITLE
Make autofix suggestion of NoEmptyStatementsLinter safe (previously caused fatal error)

### DIFF
--- a/tests/examples/NoEmptyStatementsLinter/type_error_thrown_on_autofix.php.autofix.expect
+++ b/tests/examples/NoEmptyStatementsLinter/type_error_thrown_on_autofix.php.autofix.expect
@@ -1,19 +1,19 @@
 <?hh
 
 function no_side_effects(): void {
-  if ("NO SIDE EFFECTS") ;
+  if ("NO SIDE EFFECTS") {}
 
   $please_do_not_delete_me = side_effect();
 }
 
 function with_operator(): void {
-  if (1 === 1) ;
+  if (1 === 1) {}
 
   $please_do_not_delete_me = side_effect();
 }
 
 function with_side_effects(): void {
-  if (side_effect()) ;
+  if (side_effect()) {}
 
   $please_do_not_delete_me = side_effect();
 }

--- a/tests/examples/NoEmptyStatementsLinter/type_error_thrown_on_autofix.php.expect
+++ b/tests/examples/NoEmptyStatementsLinter/type_error_thrown_on_autofix.php.expect
@@ -8,5 +8,10 @@
         "blame": ";\n",
         "blame_pretty": ";\n",
         "description": "This statement is empty"
+    },
+    {
+        "blame": ";\n",
+        "blame_pretty": ";\n",
+        "description": "This statement is empty"
     }
 ]

--- a/tests/examples/NoEmptyStatementsLinter/type_error_thrown_on_autofix.php.expect
+++ b/tests/examples/NoEmptyStatementsLinter/type_error_thrown_on_autofix.php.expect
@@ -1,0 +1,12 @@
+[
+    {
+        "blame": ";\n",
+        "blame_pretty": ";\n",
+        "description": "This statement is empty"
+    },
+    {
+        "blame": ";\n",
+        "blame_pretty": ";\n",
+        "description": "This statement is empty"
+    }
+]

--- a/tests/examples/NoEmptyStatementsLinter/type_error_thrown_on_autofix.php.in
+++ b/tests/examples/NoEmptyStatementsLinter/type_error_thrown_on_autofix.php.in
@@ -1,0 +1,17 @@
+<?hh
+
+function no_side_effects(): void {
+  if ("NO SIDE EFFECTS") ;
+
+  $please_do_not_delete_me = side_effect();
+}
+
+function with_side_effects(): void {
+  if (side_effect()) ;
+
+  $please_do_not_delete_me = side_effect();
+}
+
+function side_effect(): null {
+  return null;
+}


### PR DESCRIPTION
Inspired by https://github.com/hhvm/hhast/issues/146
Fixes: _Argument 5 passed to Facebook\HHAST\IfStatement::\_\_construct() must implement interface Facebook\HHAST\IStatement, Facebook\HHAST\NodeList given._
First commit demonstrates the failure.
This also fixes #146, since we replace the `;` with `{}` when dealing with control flow body_likes.