### PR TITLE
Support multiple forms of inline suppression

### DIFF
--- a/hhast-lint.json
+++ b/hhast-lint.json
@@ -22,5 +22,8 @@
         "Facebook\\HHAST\\DataProviderTypesLinter"
       ]
     }
-  ]
+  ],
+  "suppressionAliases": {
+    "Facebook\\HHAST\\DontAwaitInALoopLinter": [ "This is a polling loop" ]
+  }
 }

--- a/src/Linters/BaseLinter.hack
+++ b/src/Linters/BaseLinter.hack
@@ -27,7 +27,7 @@ abstract class BaseLinter {
   public function __construct(
     private File $file,
     private ?this::TConfig $config,
-    private keyset<string> $extraSuppressors,
+    private keyset<string> $suppressionAliases,
   ) {
   }
 
@@ -92,13 +92,14 @@ abstract class BaseLinter {
 
   /**
    * Provided for consistency with other (internal) linting frameworks.
+   * Identical to HHAST_IGNORE_ALL.
    */
   final public function getFrameworkAgnosticIgnoreAllMarker(): string {
     return '@lint-ignore-all '.$this->getLinterName();
   }
 
   final public function getAllSuppressors(): keyset<string> {
-    return Keyset\union($this->defaultSuppressors(), $this->extraSuppressors);
+    return Keyset\union($this->defaultSuppressors(), $this->suppressionAliases);
   }
 
   final public function defaultSuppressors(): keyset<string> {

--- a/src/Linters/LineLinter.hack
+++ b/src/Linters/LineLinter.hack
@@ -50,8 +50,10 @@ abstract class LineLinter<+Terror as LineLintError> extends BaseLinter {
   /** Check if this linter has been disabled by a comment on the previous line.
    */
   protected function isLinterSuppressed(string $previous_line): bool {
-    return Str\contains($previous_line, $this->getFixmeMarker()) ||
-      Str\contains($previous_line, $this->getIgnoreSingleErrorMarker());
+    return C\any(
+      $this->getAllSuppressors(),
+      $supp ==> Str\contains($previous_line, $supp),
+    );
   }
 
   /** Parse a single line of code and attempts to find lint errors */

--- a/src/__Private/LSPLib/ServerState.hack
+++ b/src/__Private/LSPLib/ServerState.hack
@@ -46,7 +46,7 @@ class ServerState {
       ServerStatus::INITIALIZING,
     ];
     while (C\contains_key($pre_init, $this->getStatus())) {
-      /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
+      // This is a polling loop
       await \HH\Asio\usleep(100 * 1000);
     }
   }

--- a/src/__Private/LintRun.hack
+++ b/src/__Private/LintRun.hack
@@ -78,6 +78,7 @@ final class LintRun {
           $class,
           $file,
           $config->getLinterConfigForLinter($class),
+          $config->getSuppressionAliasesForLinter($class),
         );
         $result->v = self::worstResult($result->v, $this_result);
       } catch (LinterException $e) {
@@ -104,12 +105,13 @@ final class LintRun {
     classname<TLinter> $linter,
     File $file,
     ?TLinterConfig $linter_config,
+    keyset<string> $suppression_aliases,
   ): Awaitable<LintRunResult> where TLinterConfig = TLinter::TConfig {
     if (!$file->isHackFile() || !$linter::shouldLintFile($file)) {
       return LintRunResult::NO_ERRORS;
     }
 
-    $linter = new $linter($file, $linter_config);
+    $linter = new $linter($file, $linter_config, $suppression_aliases);
 
     if ($linter->isLinterSuppressedForFile()) {
       return LintRunResult::NO_ERRORS;

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -54,6 +54,12 @@ final class LintRunConfig {
     // Each linter may specify a type for itself.
     // The type of this key is effectively `dict<classname<T1 ... Tn>, Tx>`
     ?'linterConfigs' => dict<string, BaseLinter::TConfig>,
+    // Maps FQN linter names to suppression aliases.
+    // "suppressionAliases": {
+    //   "Facebook\\HHAST\\DontAwaitInALoopLinter": [ "This is a polling loop" ]
+    // }
+    // Comments with "This is a lopping loop" now act like "HHAST_FIXME[DontAwaitInALoop]" would.
+    ?'suppressionAliases' => dict<string, vec<string>>,
   );
 
   const type TFileConfig = shape(
@@ -264,6 +270,12 @@ final class LintRunConfig {
         $e,
       );
     }
+  }
+
+  public function getSuppressionAliasesForLinter(
+    classname<BaseLinter> $classname,
+  ): keyset<string> {
+    return keyset($this->configFile['suppressionAliases'][$classname] ?? vec[]);
   }
 
   private function getFullyQualifiedLinterName(string $name): string {

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -58,7 +58,7 @@ final class LintRunConfig {
     // "suppressionAliases": {
     //   "Facebook\\HHAST\\DontAwaitInALoopLinter": [ "This is a polling loop" ]
     // }
-    // Comments with "This is a lopping loop" now act like "HHAST_FIXME[DontAwaitInALoop]" would.
+    // Comments with "This is a polling loop" now act like "HHAST_FIXME[DontAwaitInALoop]" would.
     ?'suppressionAliases' => dict<string, vec<string>>,
   );
 

--- a/tests/LinterTestTrait.hack
+++ b/tests/LinterTestTrait.hack
@@ -85,6 +85,14 @@ trait LinterTestTrait {
 
     $linter = $this->getLinter(__DIR__.'/examples/'.$example.'.in');
 
+    if ($linter->isLinterSuppressedForFile()) {
+      // @see tests/examples/NewLintErrorSuppressionMechanism/old_style_global.php.in
+      // We want to be able to explicitly suppress the linter under test.
+      $global_suppression = 'Linter was suppressed globally';
+      expect($global_suppression)->toMatchExpectFile($example.'.expect');
+      return;
+    }
+
     /*HHAST_FIXME[DontUseAsioJoin]*/
     $out = \HH\Asio\join($linter->getLintErrorsAsync())
       |> Vec\map($$, $error ==> self::getErrorAsShape($error))

--- a/tests/NewLintErrorSuppressionMechanismTest.hack
+++ b/tests/NewLintErrorSuppressionMechanismTest.hack
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class NewLintErrorSuppressionMechanismTest extends TestCase {
+  use LinterTestTrait;
+
+  protected function getLinter(string $file): BaseLinter {
+    return DontAwaitInALoopLinter::fromPathWithConfigAndSuppressionAliasses(
+      $file,
+      null,
+      keyset['This is a polling loop'],
+    );
+  }
+
+  public function getCleanExamples(): vec<(string)> {
+    return vec[
+      tuple(<<<'HACK'
+<?hh
+
+async function old_styles(): Awaitable<void> {
+  while(false) {
+    /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
+    await in_a_loop();
+    // HHAST_IGNORE_ERROR[DontAwaitInALoop]
+    await in_a_loop();
+    /* HHAST_FIXME[DontAwaitInALoop] */
+    await in_a_loop();
+    // HHAST_FIXME[DontAwaitInALoop]
+    await in_a_loop();
+  }
+}
+HACK
+      ),
+      tuple(<<<'HACK'
+<?hh
+
+async function new_styles(): Awaitable<void> {
+  while(false) {
+    /* HHAST_IGNORE[DontAwaitInALoop] */
+    await in_a_loop();
+    // HHAST_IGNORE[DontAwaitInALoop]
+    await in_a_loop();
+    /* @lint-ignore DontAwaitInALoop */
+    await in_a_loop();
+    // @lint-ignore DontAwaitInALoop
+    await in_a_loop();
+    /* @lint-fixme DontAwaitInALoop */
+    await in_a_loop();
+    // @lint-fixme DontAwaitInALoop
+    await in_a_loop();
+  }
+}
+HACK
+      ),
+      tuple(<<<'HACK'
+<?hh
+
+async function aliased(): Awaitable<void> {
+  while(false) {
+    // This is a polling loop
+    await in_a_loop();
+  }
+}
+HACK
+      ),
+    ];
+  }
+}

--- a/tests/examples/NewLintErrorSuppressionMechanism/new_global_style.php.expect
+++ b/tests/examples/NewLintErrorSuppressionMechanism/new_global_style.php.expect
@@ -1,0 +1,1 @@
+Linter was suppressed globally

--- a/tests/examples/NewLintErrorSuppressionMechanism/new_global_style.php.in
+++ b/tests/examples/NewLintErrorSuppressionMechanism/new_global_style.php.in
@@ -1,0 +1,9 @@
+<?hh
+
+// @lint-ignore-all DontAwaitInALoop
+
+async function old_style(): Awaitable<void> {
+  while(false) {
+    await in_a_loop();
+  }
+}

--- a/tests/examples/NewLintErrorSuppressionMechanism/old_style_global.php.expect
+++ b/tests/examples/NewLintErrorSuppressionMechanism/old_style_global.php.expect
@@ -1,0 +1,1 @@
+Linter was suppressed globally

--- a/tests/examples/NewLintErrorSuppressionMechanism/old_style_global.php.in
+++ b/tests/examples/NewLintErrorSuppressionMechanism/old_style_global.php.in
@@ -1,0 +1,9 @@
+<?hh
+
+// HHAST_IGNORE_ALL[DontAwaitInALoop]
+
+async function old_style(): Awaitable<void> {
+  while(false) {
+    await in_a_loop();
+  }
+}


### PR DESCRIPTION
Fixes #308
This PR adds the following default suppressors.
@lint-ignore x, @lint-fixme x, @lint-ignore-all x, HHAST_IGNORE[x].
You may now also specify suppression aliases in hhast-lint.json.