### PR TITLE
Make var_dump on a node more readable

### DIFF
--- a/src/nodes/Node.hack
+++ b/src/nodes/Node.hack
@@ -361,4 +361,31 @@ abstract class Node implements IMemoizeParam {
     }
     return null;
   }
+
+  public function __debugInfo(): dict<arraykey, mixed> {
+    return Dict\merge(
+      dict[
+        '__ID__' => $this->getUniqueID(),
+        '__CODE_REPRESENTATION__' => $this->getCode(),
+      ],
+      $this->getChildren(),
+    );
+  }
+
+  /**
+   * @return type T = dict<arraykey, arraykey|T>
+   * Tip for IDE users:
+   * If you want to inspect a Node, `json_encode()` the DebugTree to a JSON file.
+   * You can use code folding to explore the tree.
+   * For inspecting with a GUI, see https://github.com/hhvm/hhast-inspect.
+   */
+  public function toDebugTree(): dict<arraykey, mixed> {
+    return Dict\merge(
+      dict[
+        '__ID__' => $this->getUniqueID(),
+        '__CODE_REPRESENTATION__' => $this->getCode(),
+      ],
+      Dict\map($this->getChildren(), $child ==> $child->toDebugTree()),
+    );
+  }
 }


### PR DESCRIPTION
Working with `\var_dump()` in hhast doesn't work most of the time.
Nodes often refer to themselves via another object.
This causes `var_dump()` to print the recursion until the recursion limit is reached.

Also add `->toDebugTree()`, which has the same contents are `__debugInfo()`,
but you can use IDE features to expand sections and walk the tree (see example).