### PR TITLE
Allow MemberSelectionExpressions as defaults in function headers

### DIFF
--- a/src/Linters/UnusedVariableLinter.hack
+++ b/src/Linters/UnusedVariableLinter.hack
@@ -21,6 +21,11 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
     VariableExpression $node,
   ): ?ASTLintError {
 
+    $parent = $functionish->getParentOfDescendant($node);
+    if ($parent is MemberSelectionExpression) {
+      return null;
+    }
+
     $var = $node->getExpression();
     if (!$var is VariableToken) {
       return null;

--- a/tests/UnusedVariableLinterTest.hack
+++ b/tests/UnusedVariableLinterTest.hack
@@ -47,7 +47,6 @@ final class UnusedVariableLinterTest extends TestCase {
       tuple('<?hh class C { public function foo(inout $d) { $d = 5; } }'),
       tuple('<?hh class C { public function foo() { $users = dict[]; $u = dict["id" => 15]; $users[$u["id"]] = 5; return $users; } }'),
       tuple('<?hh class C { public function foo() { $s = "a"; echo "{$s}"; } }'),
-      tuple('<?hh class C { public function foo() { $x = 3; echo $x; } }'),
       tuple('<?hh class C { public function foo(string $x = $this->x) { echo $x; } }'),
       tuple('<?hh class C { public int $x = 1; public function foo() { $this->x = 3; } }'),
       tuple(<<<HACK

--- a/tests/UnusedVariableLinterTest.hack
+++ b/tests/UnusedVariableLinterTest.hack
@@ -47,6 +47,20 @@ final class UnusedVariableLinterTest extends TestCase {
       tuple('<?hh class C { public function foo(inout $d) { $d = 5; } }'),
       tuple('<?hh class C { public function foo() { $users = dict[]; $u = dict["id" => 15]; $users[$u["id"]] = 5; return $users; } }'),
       tuple('<?hh class C { public function foo() { $s = "a"; echo "{$s}"; } }'),
-    ];
-  }
+      tuple('<?hh class C { public function foo() { $x = 3; echo $x; } }'),
+      tuple('<?hh class C { public function foo(string $x = $this->x) { echo $x; } }'),
+      tuple('<?hh class C { public int $x = 1; public function foo() { $this->x = 3; } }'),
+      tuple(<<<HACK
+<?hh
+class C {
+  public int \$x = 1;
+}
+function foo(): void {
+  \$c = new C();
+  \$c->x = 2;
+}
+HACK
+      ),
+   ];
+ }
 }

--- a/tests/UnusedVariableLinterTest.hack
+++ b/tests/UnusedVariableLinterTest.hack
@@ -60,6 +60,6 @@ function foo(): void {
 }
 HACK
       ),
-   ];
- }
+    ];
+  }
 }

--- a/tests/examples/UnusedVariableLinter/unused_variable.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_variable.php.autofix.expect
@@ -28,6 +28,8 @@ function lambdas(
 }
 
 class C {
+  private int $x = 1;
+
   public function simple(int $bar): int {
     $baz = $bar;
     return $bar;
@@ -41,5 +43,9 @@ class C {
     $c .= ' world';
 
     return;
+  }
+
+  public function with_member_selection(): void {
+    $y = $this->x;
   }
 }

--- a/tests/examples/UnusedVariableLinter/unused_variable.php.expect
+++ b/tests/examples/UnusedVariableLinter/unused_variable.php.expect
@@ -68,5 +68,10 @@
         "blame": "    $c ",
         "blame_pretty": "    $c ",
         "description": "Variable is unused"
+    },
+    {
+        "blame": "    $y ",
+        "blame_pretty": "    $y ",
+        "description": "Variable is unused"
     }
 ]

--- a/tests/examples/UnusedVariableLinter/unused_variable.php.in
+++ b/tests/examples/UnusedVariableLinter/unused_variable.php.in
@@ -28,6 +28,8 @@ function lambdas(
 }
 
 class C {
+  private int $x = 1;
+
   public function simple(int $bar): int {
     $baz = $bar;
     return $bar;
@@ -41,5 +43,9 @@ class C {
     $c .= ' world';
 
     return;
+  }
+
+  public function with_member_selection(): void {
+    $y = $this->x;
   }
 }


### PR DESCRIPTION
Fixes #354.

The fix I came up with is just to bail out immediately if the variable expression is part of a `MemberSelectionExpression`, as these can never result in unused variables. For example:

* `$this->x = 1`. All variables are used.
* `$x = $this->y` .`$this` is used. `$x` will be linted separately.

I don't love introducing a special case for `MemberSelectionExpression`, however, and I'm wondering how else I might approach this. This is my first time hacking on HHAST so suggestions are very welcome.

Thanks!