### PR TITLE
Fix MustUseBracesForControlFlowLinter autofix

### DIFF
--- a/src/Linters/MustUseBracesForControlFlowLinter.hack
+++ b/src/Linters/MustUseBracesForControlFlowLinter.hack
@@ -42,24 +42,17 @@ class MustUseBracesForControlFlowLinter extends AutoFixingASTLinter {
   }
 
   private function getLastHeadToken(Node $node): Token {
-    if ($node is IfStatement) {
-      $paren = $node->getRightParen();
-      if ($paren !== null) {
-        return $paren->getLastTokenx();
-      }
-      return $node->getCondition()->getLastTokenx();
+    if (
+      $node is IfStatement ||
+      $node is ElseifClause ||
+      $node is ForeachStatement ||
+      $node is ForStatement ||
+      $node is WhileStatement
+    ) {
+      return $node->getRightParen()->getLastToken();
     }
-    if ($node is ElseClause) {
-      return $node->getKeyword();
-    }
-    if ($node is ElseifClause) {
-      return $node->getRightParen()->getLastTokenx();
-    }
-    if ($node is ForeachStatement) {
-      return $node->getRightParen()->getLastTokenx();
-    }
-    if ($node is WhileStatement) {
-      return $node->getRightParen()->getLastTokenx();
+    if ($node is ElseClause || $node is DoStatement) {
+      return $node->getKeyword()->getLastToken();
     }
     invariant_violation('unhandled type: %s', \get_class($node));
   }

--- a/tests/examples/MustUseBracesForControlFlowLinter/all_statement_types.php.autofix.expect
+++ b/tests/examples/MustUseBracesForControlFlowLinter/all_statement_types.php.autofix.expect
@@ -1,0 +1,10 @@
+function all_statement_types(): void {
+  $something = 0;
+  if (true) { $something++; }
+  if (true) {} else { $something++; }
+  if (true) {} else if (true) { $something++; }
+  do { $something; } while(true);
+  foreach(vec[] as $_) { $something++; }
+  for(;;) { $something++; }
+  while(true) { $something++; }
+}

--- a/tests/examples/MustUseBracesForControlFlowLinter/all_statement_types.php.expect
+++ b/tests/examples/MustUseBracesForControlFlowLinter/all_statement_types.php.expect
@@ -1,0 +1,37 @@
+[
+    {
+        "blame": "  if (true) $something++;\n",
+        "blame_pretty": "  if (true) $something++;\n",
+        "description": "if statement without braces"
+    },
+    {
+        "blame": "else $something++;\n",
+        "blame_pretty": "else $something++;\n",
+        "description": "else clause without braces"
+    },
+    {
+        "blame": "if (true) $something++;\n",
+        "blame_pretty": "if (true) $something++;\n",
+        "description": "if statement without braces"
+    },
+    {
+        "blame": "  do $something; while(true);\n",
+        "blame_pretty": "  do $something; while(true);\n",
+        "description": "do statement without braces"
+    },
+    {
+        "blame": "  foreach(vec[] as $_) $something++;\n",
+        "blame_pretty": "  foreach(vec[] as $_) $something++;\n",
+        "description": "foreach statement without braces"
+    },
+    {
+        "blame": "  for(;;) $something++;\n",
+        "blame_pretty": "  for(;;) $something++;\n",
+        "description": "for statement without braces"
+    },
+    {
+        "blame": "  while(true) $something++;\n",
+        "blame_pretty": "  while(true) $something++;\n",
+        "description": "while statement without braces"
+    }
+]

--- a/tests/examples/MustUseBracesForControlFlowLinter/all_statement_types.php.in
+++ b/tests/examples/MustUseBracesForControlFlowLinter/all_statement_types.php.in
@@ -1,0 +1,10 @@
+function all_statement_types(): void {
+  $something = 0;
+  if (true) $something++;
+  if (true) {} else $something++;
+  if (true) {} else if (true) $something++;
+  do $something; while(true);
+  foreach(vec[] as $_) $something++;
+  for(;;) $something++;
+  while(true) $something++;
+}


### PR DESCRIPTION
for and do were checked, but could not be fixed.
This resulted in an invariant exception.