### PR TITLE
New attribute syntax parser support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ tests/lsp/*.out
 *.swo
 .DS_Store
 .var/
+*.hhast.parser-cache
 composer.lock

--- a/.hhconfig
+++ b/.hhconfig
@@ -3,3 +3,5 @@ error_php_lambdas = true
 disable_xhp_children_declarations = false
 allowed_decl_fixme_codes=2053,4045,4047
 allowed_fixme_codes_strict=2011,2049,2050,2053,2083,3084,4027,4045,4047,4104,4106,4107,4108,4110,4128,4135,4188,4223,4240,4323,4390,4401
+disallow_silence = true
+allow_new_attribute_syntax = true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "hack.useHhast": true,
   "files.associations": {
     "*.php": "hack"
-  }
+  },
+  "editor.tabSize": 2
 }

--- a/src/__Private/codegen/CodegenRelations.hack
+++ b/src/__Private/codegen/CodegenRelations.hack
@@ -236,12 +236,26 @@ final class CodegenRelations extends CodegenBase {
       // UTF8, we throw an exception and ignore the file. This is fine as the
       // invalid UTF8 is only in files that are testing encoding, and the odds
       // of them introducing new node relationships are pretty low
-      $lines = await execute_async(
-        'hh_parse',
-        '--full-fidelity-errors',
-        '--full-fidelity-json',
-        $file,
-      );
+
+      if (is_new_attribute_syntax_allowed()) {
+        $lines = await execute_async(
+          'hh_parse',
+          '--full-fidelity-errors',
+          '--full-fidelity-json',
+          '--allow-unstable-features',
+          '--allow-new-attribute-syntax',
+          $file,
+        );
+      } else {
+        $lines = await execute_async(
+          'hh_parse',
+          '--full-fidelity-errors',
+          '--full-fidelity-json',
+          '--allow-unstable-features',
+          $file,
+        );
+      }
+
       $lines = Vec\filter($lines, $line ==> $line !== '');
       if (C\count($lines) !== 1) {
         return dict[];

--- a/src/__Private/is_new_attribute_syntax_allowed.hack
+++ b/src/__Private/is_new_attribute_syntax_allowed.hack
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private;
+
+<<__Memoize>>
+function is_new_attribute_syntax_allowed(): bool {
+  return !!\ini_get('hhvm.hack.lang.allow_new_attribute_syntax');
+}

--- a/src/__Private/is_xhp_element_mangling_disabled.hack
+++ b/src/__Private/is_xhp_element_mangling_disabled.hack
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private;
+
+<<__Memoize>>
+function is_xhp_element_mangling_disabled(): bool {
+  return !!\ini_get('hhvm.hack.lang.disable_xhp_element_mangling');
+}

--- a/src/entrypoints.hack
+++ b/src/entrypoints.hack
@@ -24,7 +24,14 @@ async function from_file_async(
   $path = $odf->getPath();
 
   $args = Vec\concat(
-    vec['--php5-compat-mode', '--full-fidelity-json'],
+    vec[
+      '--php5-compat-mode',
+      '--full-fidelity-json',
+      '--allow-unstable-features',
+    ],
+    __Private\is_new_attribute_syntax_allowed()
+      ? vec['--allow-new-attribute-syntax']
+      : vec[],
     $user_args,
     vec[$path],
   );

--- a/src/get_unresolved_referenced_names.hack
+++ b/src/get_unresolved_referenced_names.hack
@@ -16,9 +16,7 @@ use namespace HH\Lib\{C, Str};
  * These are not resolved to fully-qualified names; for example, `use`
  * and `namespace` statements to not affect the return value.
  */
-function get_unresolved_referenced_names(
-  Node $root,
-): shape(
+function get_unresolved_referenced_names(Node $root): shape(
   'namespaces' => keyset<string>,
   'types' => keyset<string>,
   'functions' => keyset<string>,
@@ -80,7 +78,7 @@ function get_unresolved_referenced_names(
 
     if (
       $node is XHPElementNameToken &&
-      \ini_get('hhvm.hack.lang.disable_xhp_element_mangling')
+      __Private\is_xhp_element_mangling_disabled()
     ) {
       $parts = Str\split($node->getText(), ':');
       if (C\count($parts) === 1) {

--- a/test-data/new_attribute_on_function.hack
+++ b/test-data/new_attribute_on_function.hack
@@ -1,0 +1,16 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+// The old parser mode would think this is top level code.
+// It "looks" like a function call with an error suppression `@`
+// and a missing semicolon.
+@__Memoize()
+function new_attribute_on_function(): void {}

--- a/test-data/new_attribute_on_method.hack
+++ b/test-data/new_attribute_on_method.hack
@@ -1,0 +1,17 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class NewAttribute {
+  // The old parser mode would complain that a classlike
+  // element, (use, public, etc...) is expected here.
+  @__Memoize()
+  public function onMethod(): void {}
+}

--- a/tests/NewAttributeParsingTest.hack
+++ b/tests/NewAttributeParsingTest.hack
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use type Facebook\HackTest\HackTest;
+use function Facebook\FBExpect\expect;
+
+final class NewAttributeParsingTest extends HackTest {
+  public async function testTopLevelAttribute(): Awaitable<void> {
+    if (!__Private\is_new_attribute_syntax_allowed()) {
+      self::markTestSkipped('Requires new attribute syntax');
+    }
+    $script = await from_file_async(
+      File::fromPath(__DIR__.'/../test-data/new_attribute_on_function.hack'),
+    );
+    expect($script->getFirstDescendantByType<AttributeSpecification>())
+      ->toNotBeNull();
+  }
+
+  public async function testClassLevelAttribute(): Awaitable<void> {
+    if (!__Private\is_new_attribute_syntax_allowed()) {
+      self::markTestSkipped('Requires new attribute syntax');
+    }
+    $script = await from_file_async(
+      File::fromPath(__DIR__.'/../test-data/new_attribute_on_method.hack'),
+    );
+    expect($script->getFirstDescendantByType<AttributeSpecification>())
+      ->toNotBeNull();
+  }
+}

--- a/tests/UnusedUseClauseLinterTest.hack
+++ b/tests/UnusedUseClauseLinterTest.hack
@@ -32,13 +32,10 @@ final class UnusedUseClauseLinterTest extends TestCase {
       tuple("<?hh\nuse const FOO; var_dump(FOO);"),
     ];
 
-    if (\HHVM_VERSION_ID < 41700) {
-      $examples[] = tuple("<?hh\nuse type Foo; \$x instanceof Foo;");
-    }
-
-    if (\ini_get('hhvm.hack.lang.disable_xhp_element_mangling')) {
-      $examples[] =
-        tuple("<?hh\nuse type foo; function bar(): void { \$_ = <foo />; }");
+    if (__Private\is_xhp_element_mangling_disabled()) {
+      $examples[] = tuple(
+        "<?hh\nuse type foo; function bar(): void { \$_ = <foo />; }",
+      );
     }
 
     return $examples;

--- a/tests/UnusedUseClauseLinterXHPTest.hack
+++ b/tests/UnusedUseClauseLinterXHPTest.hack
@@ -13,7 +13,7 @@ final class UnusedUseClauseLinterXHPTest extends TestCase {
   use AutoFixingLinterTestTrait<ASTLintError>;
 
   protected function getLinter(string $file): AutoFixingASTLinter {
-    if (!\ini_get('hhvm.hack.lang.disable_xhp_element_mangling')) {
+    if (!__Private\is_xhp_element_mangling_disabled()) {
       self::markTestSkipped(
         'requires hhvm.hack.lang.disable_xhp_element_mangling=true',
       );


### PR DESCRIPTION
The codegen doesn't know about the new attribute syntax just yet.
`must be of type ?Facebook\HHAST\OldAttributeSpecification, Facebook\HHAST\AttributeSpecification given`
We must give examples of the new attribute syntax to hhast and rebuild the codegen.