### PR TITLE
Bug fix UnusedUseClauseLinter unqualified function reference syntax

### DIFF
--- a/src/get_unresolved_referenced_names.hack
+++ b/src/get_unresolved_referenced_names.hack
@@ -16,9 +16,7 @@ use namespace HH\Lib\{C, Str};
  * These are not resolved to fully-qualified names; for example, `use`
  * and `namespace` statements to not affect the return value.
  */
-function get_unresolved_referenced_names(
-  Node $root,
-): shape(
+function get_unresolved_referenced_names(Node $root): shape(
   'namespaces' => keyset<string>,
   'types' => keyset<string>,
   'functions' => keyset<string>,
@@ -65,6 +63,17 @@ function get_unresolved_referenced_names(
       $name = $node->getReceiver();
       if ($name is NameToken) {
         $ret['functions'][] = $name->getText();
+      }
+      continue;
+    }
+
+    if ($node is FunctionPointerExpression) {
+      $name = $node->getReceiver();
+      if ($name is NameExpression) {
+        $name = $name->getWrappedNode();
+        if ($name is NameToken) {
+          $ret['functions'][] = $name->getText();
+        }
       }
       continue;
     }

--- a/tests/UnusedUseClauseLinterTest.hack
+++ b/tests/UnusedUseClauseLinterTest.hack
@@ -30,15 +30,18 @@ final class UnusedUseClauseLinterTest extends TestCase {
       tuple("<?hh\nuse Foo; new Foo\Bar();"),
       tuple("<?hh\nuse function foo; foo();"),
       tuple("<?hh\nuse const FOO; var_dump(FOO);"),
+      tuple(
+        "<?hh\nuse namespace HH\Lib\{C, Vec};\n Vec\map(vec[], C\count<>);",
+      ),
+      tuple(
+        "<?hh\nuse namespace HH\Lib\Vec;\n use function HH\Lib\C\count; Vec\map(vec[], count<>);",
+      ),
     ];
 
-    if (\HHVM_VERSION_ID < 41700) {
-      $examples[] = tuple("<?hh\nuse type Foo; \$x instanceof Foo;");
-    }
-
     if (\ini_get('hhvm.hack.lang.disable_xhp_element_mangling')) {
-      $examples[] =
-        tuple("<?hh\nuse type foo; function bar(): void { \$_ = <foo />; }");
+      $examples[] = tuple(
+        "<?hh\nuse type foo; function bar(): void { \$_ = <foo />; }",
+      );
     }
 
     return $examples;


### PR DESCRIPTION
This teaches the linter to treat `x<>` as a function usage of `x`.
`use namespace HH\Lib\C; C\count<>` is still namespace usage of `C`.