### PR TITLE
Support current nightlies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "hhvm/hsl-experimental": "^4.58.0rc1",
         "hhvm/hsl-io": "^0.2.0|0.3.0",
         "hhvm/hhvm-autoload": "^2.0.4|^3.0",
-        "hhvm/type-assert": "^3.0|^4.0",
+        "hhvm/type-assert": "^4.2.2",
         "facebook/hh-clilib": "^2.5.0rc1",
         "facebook/difflib": "^1.0.0"
     }

--- a/src/Linters/AsyncFunctionAndMethodLinter.hack
+++ b/src/Linters/AsyncFunctionAndMethodLinter.hack
@@ -12,6 +12,8 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\Str;
 
 class AsyncFunctionAndMethodLinter extends FunctionNamingLinter {
+  const type TConfig = shape();
+
   <<__Override>>
   final public function getSuggestedNameForFunction(
     string $name,

--- a/src/Linters/BaseLinter.hack
+++ b/src/Linters/BaseLinter.hack
@@ -16,7 +16,7 @@ use namespace HH\Lib\{C, Str};
 <<__ConsistentConstruct>>
 abstract class BaseLinter {
   <<__Reifiable>>
-  const type TConfig as shape(...) = shape(...);
+  abstract const type TConfig;
 
   abstract public function getLintErrorsAsync(): Awaitable<vec<LintError>>;
 

--- a/src/Linters/CamelCasedMethodsUnderscoredFunctionsLinter.hack
+++ b/src/Linters/CamelCasedMethodsUnderscoredFunctionsLinter.hack
@@ -13,6 +13,8 @@ use type Facebook\HHAST\{FunctionDeclaration, MethodishDeclaration};
 use namespace HH\Lib\{C, Str};
 
 class CamelCasedMethodsUnderscoredFunctionsLinter extends FunctionNamingLinter {
+  const type TConfig = shape();
+
   <<__Override>>
   final public function getSuggestedNameForFunction(
     string $name,

--- a/src/Linters/DataProviderTypesLinter.hack
+++ b/src/Linters/DataProviderTypesLinter.hack
@@ -12,6 +12,8 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Dict, Math, Str, Vec};
 
 final class DataProviderTypesLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
+
   const type TContext = ClassishDeclaration;
   const type TNode = FunctionDeclarationHeader;
   //dict<provider, vec<(test, provider again)>>

--- a/src/Linters/DontAwaitInALoopLinter.hack
+++ b/src/Linters/DontAwaitInALoopLinter.hack
@@ -13,6 +13,7 @@ use namespace HH\Lib\{C, Str, Vec};
 use function Facebook\HHAST\find_position;
 
 final class DontAwaitInALoopLinter extends ASTLinter {
+  const type TConfig = shape();
   const type TNode = PrefixUnaryExpression;
   const type TContext = Script;
 

--- a/src/Linters/DontHaveTwoEmptyLinesInARowLinter.hack
+++ b/src/Linters/DontHaveTwoEmptyLinesInARowLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Str};
 
 final class DontHaveTwoEmptyLinesInARowLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TContext = Script;
   const type TNode = Token;
 

--- a/src/Linters/DontUseAsioJoinLinter.hack
+++ b/src/Linters/DontUseAsioJoinLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{Str, Vec};
 
 final class DontUseAsioJoinLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TContext = Script;
   const type TNode = FunctionCallExpression;
   const string F_JOIN = 'HH\\Asio\\join';

--- a/src/Linters/FinalOrAbstractClassLinter.hack
+++ b/src/Linters/FinalOrAbstractClassLinter.hack
@@ -13,6 +13,7 @@ namespace Facebook\HHAST;
  * This linter ensures we always qualify classes as final or abstract
  */
 final class FinalOrAbstractClassLinter extends ASTLinter {
+  const type TConfig = shape();
   const type TNode = ClassishDeclaration;
   const type TContext = Script;
 

--- a/src/Linters/GroupUseStatementAlphabetizationLinter.hack
+++ b/src/Linters/GroupUseStatementAlphabetizationLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Dict, Str, Vec};
 
 final class GroupUseStatementAlphabetizationLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = NamespaceGroupUseDeclaration;
   const type TContext = Script;
 

--- a/src/Linters/GroupUseStatementsLinter.hack
+++ b/src/Linters/GroupUseStatementsLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Dict, Str, Vec};
 
 final class GroupUseStatementsLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = Script;
   const type TContext = Script;
 

--- a/src/Linters/LicenseHeaderLinter.hack
+++ b/src/Linters/LicenseHeaderLinter.hack
@@ -13,6 +13,7 @@ use namespace Facebook\TypeAssert;
 use namespace HH\Lib\{C, Str, Vec};
 
 final class LicenseHeaderLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = Script;
 
   public static ?string $forcedHeader = null;

--- a/src/Linters/MustUseBracesForControlFlowLinter.hack
+++ b/src/Linters/MustUseBracesForControlFlowLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{Str, Vec};
 
 class MustUseBracesForControlFlowLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = IControlFlowStatement;
   const type TContext = Script;
 

--- a/src/Linters/MustUseOverrideAttributeLinter.hack
+++ b/src/Linters/MustUseOverrideAttributeLinter.hack
@@ -13,6 +13,7 @@ use function Facebook\HHAST\resolve_type;
 use namespace HH\Lib\{C, Str, Vec};
 
 final class MustUseOverrideAttributeLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = MethodishDeclaration;
 
   <<__Override>>

--- a/src/Linters/NamespacePrivateLinter.hack
+++ b/src/Linters/NamespacePrivateLinter.hack
@@ -10,6 +10,7 @@
 namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Str, Vec};
 final class NamespacePrivateLinter extends ASTLinter {
+  const type TConfig = shape();
   const type TContext = Script;
   const type TNode = Script;
 

--- a/src/Linters/NewlineAtEndOfFileLinter.hack
+++ b/src/Linters/NewlineAtEndOfFileLinter.hack
@@ -15,6 +15,7 @@ use namespace HH\Lib\{C, Math, Str, Vec};
 final class NewlineAtEndOfFileLinter
   extends BaseLinter
   implements AutoFixingLinter<LintError> {
+  const type TConfig = shape();
   use AutoFixingLinterTrait<LintError>;
 
   <<__Override>>

--- a/src/Linters/NoElseifLinter.hack
+++ b/src/Linters/NoElseifLinter.hack
@@ -10,6 +10,7 @@
 namespace Facebook\HHAST;
 
 final class NoElseifLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = ElseifClause;
   const type TContext = Script;
 

--- a/src/Linters/NoEmptyStatementsLinter.hack
+++ b/src/Linters/NoEmptyStatementsLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use type Facebook\HHAST\{ExpressionStatement, Node, NodeList, Script, Token};
 
 final class NoEmptyStatementsLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = ExpressionStatement;
 
   <<__Override>>

--- a/src/Linters/NoFinalMethodInFinalClassLinter.hack
+++ b/src/Linters/NoFinalMethodInFinalClassLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Str};
 
 final class NoFinalMethodInFinalClassLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = MethodishDeclaration;
   const type TContext = ClassishDeclaration;
 

--- a/src/Linters/NoNewlineAtStartOfControlFlowBlockLinter.hack
+++ b/src/Linters/NoNewlineAtStartOfControlFlowBlockLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Vec};
 
 class NoNewlineAtStartOfControlFlowBlockLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = IControlFlowStatement;
   const type TContext = Script;
 

--- a/src/Linters/NoPHPEqualityLinter.hack
+++ b/src/Linters/NoPHPEqualityLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\Str;
 
 final class NoPHPEqualityLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = BinaryExpression;
 
   <<__Override>>

--- a/src/Linters/NoStringInterpolationLinter.hack
+++ b/src/Linters/NoStringInterpolationLinter.hack
@@ -11,7 +11,9 @@ namespace Facebook\HHAST;
 
 use namespace HH\Lib\{C, Vec};
 
-final class NoStringInterpolationLinter extends AutoFixingASTLinter {
+final class NoStringInterpolationLinter
+extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = LiteralExpression;
   const type TContext = Script;
 

--- a/src/Linters/NoWhitespaceAtEndOfLineLinter.hack
+++ b/src/Linters/NoWhitespaceAtEndOfLineLinter.hack
@@ -13,6 +13,7 @@ use namespace HH\Lib\Str;
 
 final class NoWhitespaceAtEndOfLineLinter
   extends AutoFixingLineLinter<LineLintError> {
+  const type TConfig = shape();
 
   <<__Override>>
   public function getTitleForFix(LineLintError $_): string {

--- a/src/Linters/PreferLambdasLinter.hack
+++ b/src/Linters/PreferLambdasLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\C;
 
 final class PreferLambdasLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TContext = Script;
   const type TNode = AnonymousFunction;
 

--- a/src/Linters/PreferRequireOnceLinter.hack
+++ b/src/Linters/PreferRequireOnceLinter.hack
@@ -10,6 +10,7 @@
 namespace Facebook\HHAST;
 
 final class PreferRequireOnceLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TContext = Script;
   const type TNode = InclusionExpression;
 

--- a/src/Linters/PreferSingleQuotedStringLiteralLinter.hack
+++ b/src/Linters/PreferSingleQuotedStringLiteralLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Regex, Str};
 
 final class PreferSingleQuotedStringLiteralLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TContext = Script;
   const type TNode = DoubleQuotedStringLiteralToken;
 

--- a/src/Linters/ShoutCaseEnumMembersLinter.hack
+++ b/src/Linters/ShoutCaseEnumMembersLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Dict, Regex, Str, Vec};
 
 final class ShoutCaseEnumMembersLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TContext = EnumDeclaration;
   const type TNode = Enumerator;
 

--- a/src/Linters/StrictModeOnlyLinter.hack
+++ b/src/Linters/StrictModeOnlyLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\Str;
 
 class StrictModeOnlyLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = MarkupSuffix;
   const type TContext = Script;
 

--- a/src/Linters/UnusedParameterLinter.hack
+++ b/src/Linters/UnusedParameterLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\Str;
 
 final class UnusedParameterLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = ParameterDeclaration;
   const type TContext = IFunctionishDeclaration;
 

--- a/src/Linters/UnusedUseClauseLinter.hack
+++ b/src/Linters/UnusedUseClauseLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Keyset, Str, Vec};
 
 final class UnusedUseClauseLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = INamespaceUseDeclaration;
   const type TContext = Script;
 

--- a/src/Linters/UnusedVariableLinter.hack
+++ b/src/Linters/UnusedVariableLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Keyset, Str, Vec};
 
 final class UnusedVariableLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = VariableExpression;
   const type TContext = IFunctionishDeclaration;
 

--- a/src/Linters/UseStatementWIthoutKindLinter.hack
+++ b/src/Linters/UseStatementWIthoutKindLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Keyset};
 
 final class UseStatementWithoutKindLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = INamespaceUseDeclaration;
   const type TContext = Script;
 

--- a/src/Linters/UseStatementWithAsLinter.hack
+++ b/src/Linters/UseStatementWithAsLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use type Facebook\HHAST\{NamespaceUseClause, Script};
 
 final class UseStatementWithAsLinter extends ASTLinter {
+  const type TConfig = shape();
   const type TNode = NamespaceUseClause;
   const type TContext = Script;
 

--- a/src/Linters/UseStatementWithLeadingBackslashLinter.hack
+++ b/src/Linters/UseStatementWithLeadingBackslashLinter.hack
@@ -12,6 +12,7 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\C;
 
 final class UseStatementWithLeadingBackslashLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
   const type TNode = INamespaceUseDeclaration;
   const type TContext = Script;
 

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -53,7 +53,7 @@ final class LintRunConfig {
     >,
     // Each linter may specify a type for itself.
     // The type of this key is effectively `dict<classname<T1 ... Tn>, Tx>`
-    ?'linterConfigs' => dict<string, BaseLinter::TConfig>,
+    ?'linterConfigs' => dict<string, dynamic>,
   );
 
   const type TFileConfig = shape(

--- a/tests/LinterConfigTest.hack
+++ b/tests/LinterConfigTest.hack
@@ -13,7 +13,6 @@ use type Facebook\HackTest\HackTest;
 use function Facebook\FBExpect\expect;
 use type Facebook\HHAST\{
   BaseLinter,
-  FinalOrAbstractClassLinter,
   LintError,
   PreferRequireOnceLinter,
 };

--- a/tests/LinterConfigTest.hack
+++ b/tests/LinterConfigTest.hack
@@ -108,18 +108,6 @@ final class LinterConfigTest extends HackTest {
     expect($config)->toBeNull('No config supplied');
   }
 
-  public function testConfigSuppliedAndLinterDoesNotSpecify(): void {
-    $lrc = static::getLintRunConfig();
-
-    $config = $lrc->getLinterConfigForLinter<FinalOrAbstractClassLinter, _>(
-      FinalOrAbstractClassLinter::class,
-    );
-
-    expect($config)->toEqual(
-      shape('I can supply a config' => "even if the linter doesn't need one"),
-    );
-  }
-
   public function testConfigTypeIsNotSupportedByTypeAssertLinter(): void {
     $lrc = static::getLintRunConfig();
 


### PR DESCRIPTION
- removes partially abstract type constant for linter config
- sets TConfig to `shape()` for all linters without a configuration
- removes test asserting that it's fine to provide a configuration to a
  linter that doesn't want one.

RE that last point: if a configuration changes the behavior of a linter,
and the user needs that configuration, it's probably not safe to run with
multiple versions of HHAST anyway.
