### PR TITLE
Add simplified hhast-dump utility

### DIFF
--- a/bin/hhast-dump
+++ b/bin/hhast-dump
@@ -1,0 +1,22 @@
+#!/usr/bin/env hhvm
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private;
+
+// As this file does not have an extension, it is not typechecked. Delegate
+// to the typechecked one.
+<<__EntryPoint>>
+async function hhast_dump_main_async_UNSAFE(): Awaitable<noreturn> {
+  (() ==> {
+    // HHAST-generated to avoid pseudomain local leaks
+    require_once(__DIR__.'/hhast-dump.hack');
+  })();
+  await hhast_dump_main_async();
+}

--- a/bin/hhast-dump.hack
+++ b/bin/hhast-dump.hack
@@ -1,0 +1,40 @@
+#!/usr/bin/env hhvm
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private;
+
+<<__EntryPoint>>
+async function hhast_dump_main_async(): Awaitable<noreturn> {
+  $root = \realpath(__DIR__.'/..');
+  $found_autoloader = false;
+  while (true) {
+    $autoloader = $root.'/vendor/autoload.hack';
+    if (\file_exists($autoloader)) {
+      $found_autoloader = true;
+      require_once($autoloader);
+      \Facebook\AutoloadMap\initialize();
+      break;
+    }
+    if ($root === '') {
+      break;
+    }
+    $parts = \explode('/', $root);
+    \array_pop(inout $parts);
+    $root = \implode('/', $parts);
+  }
+
+  if (!$found_autoloader) {
+    \fprintf(\STDERR, "Failed to find autoloader.\n");
+    exit(1);
+  }
+
+  $result = await DumpCLI::runAsync();
+  exit($result);
+}

--- a/src/__Private/DumpCLI.hack
+++ b/src/__Private/DumpCLI.hack
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private;
+use namespace Facebook\HHAST;
+
+use namespace HH\Lib\{C, Dict, Str};
+use type Facebook\CLILib\CLIWithRequiredArguments;
+use namespace Facebook\CLILib\CLIOptions;
+
+final class DumpCLI extends CLIWithRequiredArguments {
+  <<__Override>>
+  public static function getHelpTextForRequiredArguments(): vec<string> {
+    return vec['PATH'];
+  }
+
+  <<__Override>>
+  protected function getSupportedOptions(): vec<CLIOptions\CLIOption> {
+    return vec[];
+  }
+
+  <<__Override>>
+  public async function mainAsync(): Awaitable<int> {
+    $err = $this->getStderr();
+    if (C\count($this->getArguments()) !== 1) {
+      await $err->writeAllAsync("Provide exactly one file name\n");
+    }
+    $file = C\onlyx($this->getArguments());
+    if (!\is_file($file)) {
+      await $err->writeAllAsync("Provided path is not a file.\n");
+      return 1;
+    }
+
+    $ast = await HHAST\from_file_async(HHAST\File::fromPath($file));
+    await $this->getStdout()->writeAllAsync($this->textForNode($ast)."\n");
+    return 0;
+  }
+
+  private function inlineOrIndent(string $text): string {
+    $indent = '  ';
+    if (Str\length($text) < 60 && !Str\contains($text, "\n") && !Str\starts_with($text, '  ')) {
+      return ' '.$text;
+    }
+    return "\n".$indent.Str\replace($text, "\n", "\n".$indent);
+  }
+
+  private function inlineOrIndentNode(HHAST\Node $node): string {
+    return $this->inlineOrIndent($this->textForNode($node));
+  }
+
+  private function textForNode(HHAST\Node $node): string {
+    $class = \get_class($node) |> Str\split($$, '\\') |> C\lastx($$);
+
+    if ($node is HHAST\Token) {
+      return vec[
+        $class.':',
+        '  leading:'.$this->inlineOrIndentNode($node->getLeading()),
+        '  text:'.$this->inlineOrIndent(\var_export($node->getText(), true)),
+        '  trailing:'.$this->inlineOrIndentNode($node->getTrailing()),
+      ] |> Str\join($$, "\n");
+    }
+
+    if ($node is HHAST\NodeList<_>) {
+      $class.= Str\format('[%d]', C\count($node->getChildren()));
+    }
+
+    return
+      Dict\map_with_key($node->getChildren(), ($key, $child) ==>
+        $key.':'.$this->inlineOrIndentNode($child)
+      )
+      |> Str\join($$, "\n")
+      |> $class.':'.$this->inlineOrIndent($$);
+  }
+}


### PR DESCRIPTION
This is primarily for debugging HHAST itself, for cross-checking with
`hh_parse --full-fidelity-json` - for example, to distinguish between missing and 0-width nodes.

hh_parse remains the recommended way to canonically verify the parser's
behavior.

hhast-inspect (https://github.com/hhvm/hhast-inspect) remains the
recommended way to explore the AST of large files.

This distinction is useful when inspecting
