### PR TITLE
Add the configuration for a dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+  "name": "Hack",
+  "runArgs": [
+    "--init"
+  ],
+  "image": "hhvm/hhvm:latest",
+
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.profiles.linux": {
+      "bash": {
+        "path": "/bin/bash",
+        "args": [
+          // This argument is necessary,
+          // because hhvm crashes in a non-login shell.
+          "--login",
+        ]
+      }
+    },
+    "terminal.integrated.defaultProfile.linux": "bash"
+  },
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "pranayagarwal.vscode-hack",
+  ],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer && composer install"
+
+}


### PR DESCRIPTION
This PR adds the configuration for a dev container, which could be used in the [Visual Studio Code Remote - Containers](https://code.visualstudio.com/docs/remote/containers) extension. 
