### PR TITLE
Suppress the errors about name already bound

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -1,4 +1,4 @@
-ignored_paths = [ "tests/examples/NonHackFileTest/php_files/*" ]
+ignored_paths = [ "tests/examples/NonHackFileTest/php_files/*", "vendor/bin" ]
 error_php_lambdas = true
 disable_xhp_children_declarations = false
 allowed_decl_fixme_codes=2053,4045,4047


### PR DESCRIPTION
## Before
```
hh_client
```
```
Naming[2012] Name already bound: Facebook\HackCodegen\CLIVerifier [1]
-> Previous definition is here [2]

/workspaces/hhast/vendor/facebook/hack-codegen/bin/hh-codegen-verify-signatures.hack:15:13
    13 | use namespace HH\Lib\{C, Vec};
    14 | 
[1] 15 | final class CLIVerifier {
    16 |   private vec<string> $targets;
    17 | 

/workspaces/hhast/vendor/bin/hh-codegen-verify-signatures.hack:15:13
    13 | use namespace HH\Lib\{C, Vec};
    14 | 
[2] 15 | final class CLIVerifier {
    16 |   private vec<string> $targets;
    17 | 

Naming[2012] Name already bound: Facebook\HackCodegen\verify_signatures_main [1]
-> Previous definition is here [2]

/workspaces/hhast/vendor/facebook/hack-codegen/bin/hh-codegen-verify-signatures.hack:84:10
    82 | 
    83 | <<__EntryPoint>>
[1] 84 | function verify_signatures_main(): noreturn {
    85 |   $dir = __DIR__;
    86 |   while (true) {

/workspaces/hhast/vendor/bin/hh-codegen-verify-signatures.hack:84:10
    82 | 
    83 | <<__EntryPoint>>
[2] 84 | function verify_signatures_main(): noreturn {
    85 |   $dir = __DIR__;
    86 |   while (true) {

2 errors found.
```
## After
```
hh_client
```
```
No errors!
```