### PR TITLE
Separate SingleRuleLinter into Linter and LintRule

### DIFF
--- a/src/Linters/LintError.hack
+++ b/src/Linters/LintError.hack
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+/**
+ * A problem detected by a lint rule
+ *
+ * LintError is more generic than SingleRuleLintError because LintError is
+ * associated with any LintRule, not necessarily a SingleRuleLinter.
+ */
+<<__Sealed(
+  SingleRuleLintError::class,
+  // HHClientProblem::class
+)>>
+interface LintError {
+  public function getFile(): File;
+
+  public function getPosition(): ?(int, int);
+
+  public function getRange(): ?((int, int), ?(int, int));
+
+  public function getDescription(): string;
+
+  public function getBlameCode(): ?string;
+
+  public function getPrettyBlame(): ?string;
+
+  public function getLintRule(): LintRule;
+}

--- a/src/Linters/LintRule.hack
+++ b/src/Linters/LintRule.hack
@@ -19,8 +19,14 @@ namespace Facebook\HHAST;
 )>>
 interface LintRule {
   /**
-   * The name of the lint rule, which can be used to determine markers to
-   * suppress lint errors.
+   * The human readable name of the lint rule, which can be used to report
+   * the lint error.
    */
   public function getName(): string;
+
+  /**
+   * The error code of the lint rule, which can be used to determine markers to
+   * suppress lint errors.
+   */
+  public function getErrorCode(): string;
 }

--- a/src/Linters/LintRule.hack
+++ b/src/Linters/LintRule.hack
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+/**
+ * An abstract lint rule that provides a single error reason, which could be
+ * either a HHAST linter or a lint rule written in OCaml.
+ */
+<<__Sealed(
+  SingleRuleLinter::class,
+  // HHClientLintRule::class,
+)>>
+interface LintRule {
+  /**
+   * The name of the lint rule, which can be used to determine markers to
+   * suppress lint errors.
+   */
+  public function getName(): string;
+}

--- a/src/Linters/Linter.hack
+++ b/src/Linters/Linter.hack
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+/**
+ * The process to find problems against a single source file.
+ *
+ * Problems found by a Linter could associated with different LintRules,
+ * especially when the Linter is a proxy calling other linting tools.
+ */
+<<
+  __Sealed(
+    SingleRuleLinter::class,
+    // HHClientLinter::class
+  )
+>>
+interface Linter {
+  abstract const type TConfig;
+
+  public function getLintErrorsAsync(): Awaitable<vec<LintError>>;
+
+  public static function shouldLintFile(File $_): bool;
+
+  public static function newInstance(File $file, ?this::TConfig $config): this;
+
+  public function isLinterSuppressedForFile(): bool;
+
+  public function getFile(): File;
+
+  public static function typeAssertConfig(mixed $config): this::TConfig;
+}

--- a/src/Linters/SingleRuleLintError.hack
+++ b/src/Linters/SingleRuleLintError.hack
@@ -11,7 +11,10 @@ namespace Facebook\HHAST;
 
 use type Facebook\HHAST\File;
 
-class SingleRuleLintError {
+/**
+ * A problem detected by a SingleRuleLinter
+ */
+class SingleRuleLintError implements LintError {
   public function __construct(
     private SingleRuleLinter $linter,
     private string $description,
@@ -57,4 +60,9 @@ class SingleRuleLintError {
   final public function getLinter(): SingleRuleLinter {
     return $this->linter;
   }
+
+  final public function getLintRule(): LintRule {
+    return $this->getLinter();
+  }
+
 }

--- a/src/Linters/SingleRuleLinter.hack
+++ b/src/Linters/SingleRuleLinter.hack
@@ -13,10 +13,17 @@ use namespace Facebook\TypeAssert;
 use type Facebook\HHAST\File;
 use namespace HH\Lib\{C, Str};
 
+/**
+ * A linter that applies a single lint rule.
+ */
 <<__ConsistentConstruct>>
-abstract class SingleRuleLinter {
+abstract class SingleRuleLinter implements LintRule, Linter {
   <<__Reifiable>>
   abstract const type TConfig;
+
+  final public function getName(): string {
+    return $this->getLinterName();
+  }
 
   abstract public function getLintErrorsAsync(): Awaitable<vec<SingleRuleLintError>>;
 
@@ -28,6 +35,10 @@ abstract class SingleRuleLinter {
     private File $file,
     private ?this::TConfig $config,
   ) {
+  }
+
+  public static function newInstance(File $file, ?this::TConfig $config): this {
+    return new static($file, $config);
   }
 
   protected function getConfig(): ?this::TConfig {

--- a/src/Linters/SingleRuleLinter.hack
+++ b/src/Linters/SingleRuleLinter.hack
@@ -25,6 +25,10 @@ abstract class SingleRuleLinter implements LintRule, Linter {
     return $this->getLinterName();
   }
 
+  final public function getErrorCode(): string {
+    return $this->getLinterName();
+  }
+
   abstract public function getLintErrorsAsync(): Awaitable<vec<SingleRuleLintError>>;
 
   public static function shouldLintFile(File $_): bool {


### PR DESCRIPTION
Reviewing each commit one by one would be easier, because there are multiple commits, which are too messy when reviewing them together. 