### PR TITLE
Upgrade HHVM version to 4.126

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu , macos ]
         hhvm:
-          - '4.123'
+          - '4.126'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "hhvm/hacktest": "^2.2.0"
     },
     "require": {
-        "hhvm": "^4.123",
+        "hhvm": "^4.126",
         "hhvm/hsl": "^4.25",
         "hhvm/hsl-experimental": "^4.58.0rc1",
         "hhvm/hsl-io": "^0.2.0|0.3.0",


### PR DESCRIPTION
The upcoming commits in #368 will include a test against an `hh_client` lint rule not in 4.123.

