### PR TITLE
Add the LintMarker utility to build either markers from either a linter or a lint rule

### DIFF
--- a/src/Linters/BaseLinter.hack
+++ b/src/Linters/BaseLinter.hack
@@ -78,7 +78,7 @@ abstract class BaseLinter {
    * whole file using this string as a marker
    */
   public function getIgnoreAllMarker(): string {
-    return 'HHAST_IGNORE_ALL['.$this->getLinterName().']';
+    return LintMarker::getIgnoreAllMarker($this->getLinterName());
   }
 
   /**
@@ -86,7 +86,7 @@ abstract class BaseLinter {
    * using this string as a marker
    */
   public function getIgnoreSingleErrorMarker(): string {
-    return 'HHAST_IGNORE_ERROR['.$this->getLinterName().']';
+    return LintMarker::getIgnoreSingleErrorMarker($this->getLinterName());
   }
 
   /**
@@ -97,7 +97,7 @@ abstract class BaseLinter {
    * fixed.
    */
   public function getFixmeMarker(): string {
-    return 'HHAST_FIXME['.$this->getLinterName().']';
+    return LintMarker::getFixmeMarker($this->getLinterName());
   }
 
   /**

--- a/src/Linters/LintMarker.hack
+++ b/src/Linters/LintMarker.hack
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+/**
+ * An utility class to build lint markers, where the marker format will be
+ * shared between linters and lint rules.
+ */
+abstract final class LintMarker {
+
+  /**
+   * A user can choose to ignore all errors reported by this linter for a
+   * whole file using this string as a marker
+   */
+  public static function getIgnoreAllMarker(
+    string $linter_or_lint_rule,
+  ): string {
+    return 'HHAST_IGNORE_ALL['.$linter_or_lint_rule.']';
+  }
+
+  /**
+   * A user can choose to ignore a specific error reported by this linter
+   * using this string as a marker
+   */
+  public static function getIgnoreSingleErrorMarker(
+    string $linter_or_lint_rule,
+  ): string {
+    return 'HHAST_IGNORE_ERROR['.$linter_or_lint_rule.']';
+  }
+
+  /**
+   * A user can choose to ignore a specific error reported by this linter
+   * using this string as a marker.
+   *
+   * The difference to HHAST_IGNORE_ERROR is that we expect this one to be
+   * fixed.
+   */
+  public static function getFixmeMarker(string $linter_or_lint_rule): string {
+    return 'HHAST_FIXME['.$linter_or_lint_rule.']';
+  }
+
+}


### PR DESCRIPTION
The utility will be reused to build lint rule level markers since the HHClientLinter will be able to apply more than one lint rules