### PR TITLE
Introduce GenericLinterException for Linters other than BaseLinter

### DIFF
--- a/src/Linters/BaseLinter.hack
+++ b/src/Linters/BaseLinter.hack
@@ -13,12 +13,23 @@ use namespace Facebook\TypeAssert;
 use type Facebook\HHAST\File;
 use namespace HH\Lib\{C, Str};
 
+/**
+ * An HHAST linter
+ */
 <<__ConsistentConstruct>>
-abstract class BaseLinter {
+abstract class BaseLinter implements LintRule, Linter {
   <<__Reifiable>>
   abstract const type TConfig;
 
+  final public function getName(): string {
+    return $this->getLinterName();
+  }
+
   abstract public function getLintErrorsAsync(): Awaitable<vec<LintError>>;
+
+  final public function getProblemsAsync(): Awaitable<vec<Problem>> {
+    return $this->getLintErrorsAsync();
+  }
 
   public static function shouldLintFile(File $_): bool {
     return true;

--- a/src/Linters/GenericLinterException.hack
+++ b/src/Linters/GenericLinterException.hack
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\Str;
+
+/**
+ * The exception thrown when executing any linter
+ */
+<<__Sealed(LinterException::class), __ConsistentConstruct>>
+class GenericLinterException<Tfind as Linter> extends \Exception {
+  public function __construct(
+    private classname<Tfind> $linter,
+    private string $fileBeingLinted,
+    private string $rawMessage,
+    private ?(int, int) $position = null,
+    ?\Throwable $previous = null,
+  ) {
+    parent::__construct(
+      Str\format(
+        "While running '%s' on '%s': %s",
+        $linter,
+        $fileBeingLinted,
+        $rawMessage,
+      ),
+      /* code = */ 0,
+      // Throwable should be fine but causes type errors. facebook/hhvm#8239
+      $previous ?as \Exception,
+    );
+  }
+
+  public function getLinterClass(): classname<Tfind> {
+    return $this->linter;
+  }
+
+  public function getFileBeingLinted(): string {
+    return $this->fileBeingLinted;
+  }
+
+  public function getRawMessage(): string {
+    return $this->rawMessage;
+  }
+
+  public function getPosition(): ?(int, int) {
+    return $this->position;
+  }
+}

--- a/src/Linters/LintError.hack
+++ b/src/Linters/LintError.hack
@@ -11,7 +11,10 @@ namespace Facebook\HHAST;
 
 use type Facebook\HHAST\File;
 
-class LintError {
+/**
+ * A problem detected by an HHAST linter
+ */
+class LintError implements Problem {
   public function __construct(
     private BaseLinter $linter,
     private string $description,
@@ -20,6 +23,10 @@ class LintError {
 
   final public function getFile(): File {
     return $this->linter->getFile();
+  }
+
+  final public function getPath(): string {
+    return $this->getFile()->getPath();
   }
 
   public function getPosition(): ?(int, int) {
@@ -57,4 +64,9 @@ class LintError {
   final public function getLinter(): BaseLinter {
     return $this->linter;
   }
+
+  final public function getLintRule(): LintRule {
+    return $this->getLinter();
+  }
+
 }

--- a/src/Linters/LintRule.hack
+++ b/src/Linters/LintRule.hack
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+/**
+ * An abstract lint rule that provides a single error reason, which could be
+ * either a HHAST linter or a lint rule written in OCaml.
+ */
+<<__Sealed(
+  BaseLinter::class,
+  // HHClientLintRule::class,
+)>>
+interface LintRule {
+  public function getName(): string;
+}

--- a/src/Linters/Linter.hack
+++ b/src/Linters/Linter.hack
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+/**
+ * The process to find problems against a single source file.
+ *
+ * Problems found by a Linter could associated with different LintRules,
+ * especially when the Linter is a proxy calling other linting tools.
+ */
+<<
+  __Sealed(
+    BaseLinter::class,
+    // HHClientLinter::class
+  ),
+  __ConsistentConstruct,
+>>
+interface Linter {
+  abstract const type TConfig;
+
+  public function getProblemsAsync(): Awaitable<vec<Problem>>;
+
+  public static function shouldLintFile(File $_): bool;
+
+  public function __construct(File $file, ?this::TConfig $config);
+
+  public function isLinterSuppressedForFile(): bool;
+
+  public function getFile(): File;
+
+  static public function typeAssertConfig(mixed $config): this::TConfig;
+}

--- a/src/Linters/LinterException.hack
+++ b/src/Linters/LinterException.hack
@@ -9,42 +9,10 @@
 
 namespace Facebook\HHAST;
 
-use namespace HH\Lib\Str;
-
-final class LinterException extends \Exception {
-  public function __construct(
-    private classname<BaseLinter> $linter,
-    private string $fileBeingLinted,
-    private string $rawMessage,
-    private ?(int, int) $position = null,
-    ?\Throwable $previous = null,
-  ) {
-    parent::__construct(
-      Str\format(
-        "While running '%s' on '%s': %s",
-        $linter,
-        $fileBeingLinted,
-        $rawMessage,
-      ),
-      /* code = */ 0,
-      // Throwable should be fine but causes type errors. facebook/hhvm#8239
-      $previous ?as \Exception,
-    );
-  }
-
-  public function getLinterClass(): classname<BaseLinter> {
-    return $this->linter;
-  }
-
-  public function getFileBeingLinted(): string {
-    return $this->fileBeingLinted;
-  }
-
-  public function getRawMessage(): string {
-    return $this->rawMessage;
-  }
-
-  public function getPosition(): ?(int, int) {
-    return $this->position;
-  }
+/**
+ * The exception thrown when executing an HHAST BaseLinter
+ *
+ * @deprecated Use GenericLinterException instead
+ */
+final class LinterException extends GenericLinterException<BaseLinter> {
 }

--- a/src/Linters/Problem.hack
+++ b/src/Linters/Problem.hack
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+/**
+ * A problem detected by an HHAST linter or an OCaml lint rule.
+ *
+ * Problem is more generic than LintError because Problem is associated with a
+ * LintRule, not a BaseLinter.
+ */
+<<__Sealed(
+  LintError::class,
+  // HHClientProblem::class
+)>>
+interface Problem {
+  public function getPath(): string;
+
+  public function getPosition(): ?(int, int);
+
+  public function getRange(): ?((int, int), ?(int, int));
+
+  public function getDescription(): string;
+
+  public function getBlameCode(): ?string;
+
+  public function getPrettyBlame(): ?string;
+
+  public function getLintRule(): LintRule;
+}

--- a/src/__Private/LSPImpl/CodeActionCommand.hack
+++ b/src/__Private/LSPImpl/CodeActionCommand.hack
@@ -11,7 +11,7 @@ namespace Facebook\HHAST\__Private\LSPImpl;
 
 use namespace Facebook\HHAST\__Private\{LSP, LSPLib};
 use type Facebook\HHAST\{AutoFixingLinter, LintError};
-use namespace HH\Lib\{C, Str, Vec};
+use namespace HH\Lib\Vec;
 
 final class CodeActionCommand extends LSPLib\CodeActionCommand {
   const type TResponse = vec<mixed>;
@@ -103,10 +103,7 @@ final class CodeActionCommand extends LSPLib\CodeActionCommand {
   ): ?LintError {
     $pos = position_from_lsp($diagnostic['range']['start']);
     foreach ($errors as $error) {
-      $code = \get_class($error->getLinter())
-        |> Str\split($$, '\\')
-        |> C\lastx($$)
-        |> Str\strip_suffix($$, 'Linter');
+      $code = $error->getLinter()->getLinterName();
       if ($code !== ($diagnostic['code'] ?? null)) {
         continue;
       }

--- a/src/__Private/LintRunLSPPublishDiagnosticsEventHandler.hack
+++ b/src/__Private/LintRunLSPPublishDiagnosticsEventHandler.hack
@@ -11,7 +11,7 @@ namespace Facebook\HHAST\__Private;
 
 use type Facebook\HHAST\{BaseLinter, LintError};
 
-use namespace HH\Lib\{C, Str, Vec};
+use namespace HH\Lib\{C, Vec};
 
 final class LintRunLSPPublishDiagnosticsEventHandler
   implements LintRunEventHandler {
@@ -49,10 +49,7 @@ final class LintRunLSPPublishDiagnosticsEventHandler
     $start = LSPImpl\position_to_lsp($start);
     $end = LSPImpl\position_to_lsp($end);
 
-    $source = \get_class($error->getLinter())
-      |> Str\split($$, '\\')
-      |> C\lastx($$)
-      |> Str\strip_suffix($$, 'Linter');
+    $source = $error->getLinter()->getLinterName();
     return shape(
       'range' => shape('start' => $start, 'end' => $end),
       'severity' => LSP\DiagnosticSeverity::WARNING,


### PR DESCRIPTION
GenericLinterException will be used in #380 for exceptions in Linters other than BaseLinter, as the existing `LinterException` supports only `BaseLinter`.