### PR TITLE
Let LinterException support Linter

### DIFF
--- a/src/Linters/LinterException.hack
+++ b/src/Linters/LinterException.hack
@@ -13,7 +13,7 @@ use namespace HH\Lib\Str;
 
 final class LinterException extends \Exception {
   public function __construct(
-    private classname<SingleRuleLinter> $linter,
+    private classname<Linter> $linter,
     private string $fileBeingLinted,
     private string $rawMessage,
     private ?(int, int) $position = null,
@@ -32,7 +32,7 @@ final class LinterException extends \Exception {
     );
   }
 
-  public function getLinterClass(): classname<SingleRuleLinter> {
+  public function getLinterClass(): classname<Linter> {
     return $this->linter;
   }
 


### PR DESCRIPTION
Originally a LinterException is associated with a `BaseLinter`, which was renamed `SingleRuleLinter`. This PR instead let a `LinterException` be associated with the more general `Linter`.

This PR is not backward compatible.

(All the commits except the last commit are included in other PRs)