### PR TITLE
Treat 'start' and 'end' returned by `hh_client --lint` as a 1-based inclusive range

### DIFF
--- a/src/Linters/HHClientLinter.hack
+++ b/src/Linters/HHClientLinter.hack
@@ -35,8 +35,8 @@ final class HHClientLinter implements Linter {
     $line_content = $file_lines[$line_index_0base];
     return Str\slice(
       $line_content,
-      $error['start'],
-      $error['end'] - $error['start'],
+      $error['start'] - 1,
+      $error['end'] - $error['start'] + 1,
     );
   }
 

--- a/tests/examples/HHClientLinter/invalid_null_check.hack.expect
+++ b/tests/examples/HHClientLinter/invalid_null_check.hack.expect
@@ -1,7 +1,7 @@
 [
     {
-        "blame": "cannot_be_null is null",
-        "blame_pretty": "cannot_be_null is null",
+        "blame": "$cannot_be_null is null",
+        "blame_pretty": "$cannot_be_null is null",
         "description": "Invalid null check: This expression will always return `false`.\nA value of type `int` can never be null."
     }
 ]


### PR DESCRIPTION
See `invalid_null_check.hack.expect`. The dollar sign should be included.