### PR TITLE
Add VS Code extensions to recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "pranayagarwal.vscode-hack"
+    ]
+}


### PR DESCRIPTION
Not sure if we should recommend git extensions, but we definitely want to recommend the Hack extension.

Unlike the extensions installed from `.devcontainer/devcontainer.json`, the extensions in `extensions.json` works for workspaces that are not in a container or Codespace. See [this document](https://code.visualstudio.com/docs/editor/extension-marketplace#_workspace-recommended-extensions) for more information.