### PR TITLE
Use `vec` instead of `keyset` in `HHClientLinter::TConfig`

### DIFF
--- a/src/Linters/HHClientLinter.hack
+++ b/src/Linters/HHClientLinter.hack
@@ -19,7 +19,7 @@ final class HHClientLinter implements Linter {
   use SuppressibleTrait;
 
   const type TConfig =
-    shape(?'ignore_except' => keyset<int>, ?'ignore' => keyset<int>);
+    shape(?'ignore_except' => vec<int>, ?'ignore' => vec<int>);
 
   const type TErrorCode = int;
 
@@ -31,10 +31,10 @@ final class HHClientLinter implements Linter {
       if ($ignore_except is null) {
         return $_ ==> false;
       }
-      return $error_code ==> !C\contains_key($ignore_except, $error_code);
+      return $error_code ==> !C\contains($ignore_except, $error_code);
     }
     if ($ignore_except is null) {
-      return $error_code ==> C\contains_key($ignore, $error_code);
+      return $error_code ==> C\contains($ignore, $error_code);
     }
     throw new \InvalidOperationException(
       "Must not set both of the 'ignore_except' and 'ignore' fields in the configuration of HHClientLinter",

--- a/tests/HHClientLinterIgnoreExceptTest.hack
+++ b/tests/HHClientLinterIgnoreExceptTest.hack
@@ -26,6 +26,6 @@ final class HHClientLinterIgnoreExceptTest extends TestCase {
     ];
   }
 
-  const HHClientLinter::TConfig CONFIG = shape('ignore_except' => keyset[5611]);
+  const HHClientLinter::TConfig CONFIG = shape('ignore_except' => vec[5611]);
 
 }

--- a/tests/HHClientLinterIgnoreTest.hack
+++ b/tests/HHClientLinterIgnoreTest.hack
@@ -28,6 +28,6 @@ final class HHClientLinterIgnoreTest extends TestCase {
     ];
   }
 
-  const HHClientLinter::TConfig CONFIG = shape('ignore' => keyset[5611]);
+  const HHClientLinter::TConfig CONFIG = shape('ignore' => vec[5611]);
 
 }


### PR DESCRIPTION
`keyset` is not supported according to this comment https://github.com/hhvm/hhast/commit/d12431fae2b37c60adff94fce7407e9ea933007f#diff-ab40415ae577f35a66424f1507ecc7dc1dd41322b54f8a5095ccf1d3f8ceb3c6R72-R73