### PR TITLE
[ Do not merge] HHClientLinter does not spew lint errors

### DIFF
--- a/hhast-lint.json
+++ b/hhast-lint.json
@@ -27,7 +27,7 @@
     "Facebook\\HHAST\\HHClientLinter": {
       "Comments (not an actual setting)":
         "The following error codes are ignored with no good reason. They are just existing issues and need to be fixed.",
-      "ignore": [5562, 5583, 5568, 5607, 5609, 5611, 5616, 5618, 5624, 5628, 5630, 5639]
+      "ignore": []
     }
   }
 }


### PR DESCRIPTION
This PR runs hhast in GA. I removed the ignores for hh_client linter. I expected to have a failed CI result, but it passes. We know this code base contains awaits in loops and that hh_client linter reports an error for those. These awaits only have hhast DontAwaitInALoop suppression, no HHClient(Linter) suppression.