### PR TITLE
Allow for unknown fields in the configuration of HHClientLinter

### DIFF
--- a/src/Linters/HHClientLinter.hack
+++ b/src/Linters/HHClientLinter.hack
@@ -19,7 +19,7 @@ final class HHClientLinter implements Linter {
   use SuppressibleTrait;
 
   const type TConfig =
-    shape(?'ignore_except' => vec<int>, ?'ignore' => vec<int>);
+    shape(?'ignore_except' => vec<int>, ?'ignore' => vec<int>, ...);
 
   const type TErrorCode = int;
 


### PR DESCRIPTION
This PR allows for unknown fields in the configuration of `HHClientLinter` so that:
- we can use the additional fields as comments
- we can keep the forward compatibility when adding new fields

#Thanks @lexidor for discovering the issue in https://github.com/hhvm/hhast/pull/402#issuecomment-978066789