### PR TITLE
Remove HHClientLinter from NON_DEFAULT_LINTERS

### DIFF
--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -94,7 +94,6 @@ final class LintRunConfig {
     HHAST\NoFinalMethodInFinalClassLinter::class,
     HHAST\NamespacePrivateLinter::class,
     HHAST\DontHaveTwoEmptyLinesInARowLinter::class,
-    HHAST\HHClientLinter::class,
   ];
 
   private static function getNamedLinterGroup(


### PR DESCRIPTION
Having it here enables it with the `all` option, but #408 and #409 are release blockers

It should be possible to enable this just for HHAST via `extraLinters` in the config, in a followup, but on vacation atm so doing the minimum here to get `main` back to a releasable state