### PR TITLE
Mismatched configuration for a linter should fail the lint run (fix #405)

### DIFF
--- a/src/__Private/LintRun.hack
+++ b/src/__Private/LintRun.hack
@@ -83,7 +83,7 @@ final class LintRun {
       } catch (LinterException $e) {
         throw $e;
       } catch (\Throwable $t) {
-        new LinterException(
+        throw new LinterException(
           $class,
           $file->getPath(),
           $t->getMessage(),

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -117,7 +117,7 @@ final class LintRunConfig {
   }
 
   <<__Memoize>>
-  private static function getFromConfigFile(string $path): this {
+  public static function getFromConfigFile(string $path): this {
     return new self(\dirname($path), self::getConfigFromFile($path));
   }
 

--- a/src/__Private/LinterCLI.hack
+++ b/src/__Private/LinterCLI.hack
@@ -121,7 +121,7 @@ final class LinterCLI extends CLIWithArguments {
       if (C\is_empty($roots)) {
         await $err->writeAllAsync(
           'You must either specify PATH arguments, or provide a configuration'.
-          "file.\n",
+          "file, in which the `roots` setting is not empty.\n",
         );
         return 1;
       }
@@ -133,10 +133,9 @@ final class LinterCLI extends CLIWithArguments {
           if (\file_exists($config_file)) {
             /* HHAST_IGNORE_ERROR[DontAwaitInALoop] HHAST_IGNORE_ERROR[5583]*/
             await $err->writeAllAsync(
-              'Warning: PATH arguments contain a hhast-lint.json, '.
-              'which modifies the linters used and customizes behavior. '.
-              "Consider 'cd ".
-              $root.
+              'Warning: PATH arguments contain a lint config file at '.$path.
+              'hhast-lint.json, which modifies the linters used and '.
+              "customizes behavior. Consider 'cd ".$root.
               "; vendor/bin/hhast-lint'\n\n",
             );
           }

--- a/test-data/hhast-lint.json
+++ b/test-data/hhast-lint.json
@@ -1,5 +1,11 @@
 {
-  "roots": [],
+  "roots": [ "." ],
+  "extraLinters": [
+    "Facebook\\HHAST\\Tests\\ValidConfigForLinter",
+    "Facebook\\HHAST\\Tests\\InvalidConfigForLinter",
+    "Facebook\\HHAST\\FinalOrAbstractClassLinter",
+    "Facebook\\HHAST\\Tests\\ConfigTypeIsNotSupportedByTypeAssertLinter"
+  ],
   "linterConfigs": {
     "Facebook\\HHAST\\Tests\\ValidConfigForLinter": {
       "the answer": 42,

--- a/tests/IgnorePHPFilesTest.hack
+++ b/tests/IgnorePHPFilesTest.hack
@@ -14,7 +14,7 @@ use type Facebook\HackTest\HackTest;
 final class IgnorePHPFilesTest extends HackTest {
   public async function testUnparsablePHPFileAsync(): Awaitable<void> {
     $lint_run = new __Private\LintRun(
-      null,
+      __Private\LintRunConfig::getForPath(\getcwd()),
       new DoNotSendMeEventsHandler(),
       vec[__DIR__.'/../test-data/unparsable_php_file.php'],
     );


### PR DESCRIPTION
I added a `cwd` parameter to `LinterCLI` for the test purpose so we could test it without actual `chdir`, in case of interfering other tests.