### PR TITLE
Add Facebook\HHAST\HHClientLinter to extraLinters

### DIFF
--- a/hhast-lint.json
+++ b/hhast-lint.json
@@ -1,6 +1,9 @@
 {
   "roots": [ "src/", "codegen/", "tests/" ],
   "builtinLinters": "all",
+  "extraLinters": [
+    "Facebook\\HHAST\\HHClientLinter"
+  ],
   "overrides": [
     {
       "patterns": [ "codegen/*", "tests/examples/*" ],

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -94,7 +94,6 @@ final class LintRunConfig {
     HHAST\NoFinalMethodInFinalClassLinter::class,
     HHAST\NamespacePrivateLinter::class,
     HHAST\DontHaveTwoEmptyLinesInARowLinter::class,
-    HHAST\HHClientLinter::class,
   ];
 
   private static function getNamedLinterGroup(


### PR DESCRIPTION
Even though we don't want to include HHClientLinter in the `NON_DEFAULT_LINTERS` for now, it is still beneficial to dogfood the linter in the hhast repository. This PR is based on #411 and additionally add Facebook\HHAST\HHClientLinter to extraLinters