### PR TITLE
Don't ignore 5607 lint error under src/Migrations and fix an existing 5607 lint error

### DIFF
--- a/hhast-lint.json
+++ b/hhast-lint.json
@@ -24,6 +24,14 @@
       "extraLinters": [
         "Facebook\\HHAST\\DataProviderTypesLinter"
       ]
+    },
+    {
+      "patterns": ["src/Migrations/*"],
+      "linterConfigs": {
+        "Facebook\\HHAST\\HHClientLinter": {
+          "ignore": [5624, 5639]
+        }
+      }
     }
   ],
   "linterConfigs": {

--- a/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
@@ -43,19 +43,14 @@ final class AddXHPChildrenDeclarationMethodMigration
     $before = C\firstx($decls->getChildrenByType<IDeclaration>());
     $t = $before->getFirstTokenx();
     $use = self::getUseNamespace();
-    if ($t->getLeading() !== $t->getLeadingWhitespace()) {
-      $ut = $use->getFirstTokenx();
-      return $in->withDeclarations(
-        $in->getDeclarations()->insertBefore(
-          $before,
-          $use->replace($ut, $ut->withLeading($t->getLeading())),
-        ),
-      )
-        ->replace($t, $t->withLeading(null));
-    }
+    $ut = $use->getFirstTokenx();
     return $in->withDeclarations(
-      $decls->insertBefore($before, self::getUseNamespace()),
-    );
+      $in->getDeclarations()->insertBefore(
+        $before,
+        $use->replace($ut, $ut->withLeading($t->getLeading())),
+      ),
+    )
+      ->replace($t, $t->withLeading(null));
   }
 
   private static function addUseNamespaceToNamespaceBlock(


### PR DESCRIPTION
This PR is to fix a 5607 linter error under `src/Migrations`. I reviewed `$t->getLeading() !== $t->getLeadingWhitespace()` and I believe the condition is always `true`, therefore, I removed the `if` clause.