### PR TITLE
Add a test to detect duplicated lint rules

### DIFF
--- a/src/Linters/HHClientLinter.hack
+++ b/src/Linters/HHClientLinter.hack
@@ -27,6 +27,7 @@ final class HHClientLinter implements Linter {
    * The error code that are always ignored
    */
   const keyset<int> ALWAYS_IGNORE_ERRORS = keyset[
+    0 /* InternalError, indicating a bug in the OCaml linter, not a real lint error */,
     5583 /* DontAwaitInALoop, which should have been covered by DontAwaitInALoopLinter */,
   ];
 

--- a/tests/HHClientDuplicatedLintErrorTest.hack
+++ b/tests/HHClientDuplicatedLintErrorTest.hack
@@ -12,6 +12,18 @@ namespace Facebook\HHAST;
 use type Facebook\HackTest\DataProvider;
 use namespace HH\Lib\{C, Str, Vec};
 
+/**
+ * The test suite ensures that no lint error is found by `HHClientLinter` in
+ * the examples for `SingleRuleLinter`s.
+ *
+ * If an example triggers hh_client lint errors that indicate problems other
+ * than the `SingleRuleLinter` supposes to detect, add HHAST_IGNORE_ALL markers
+ * to suppress them. If an example triggers hh_client lint errors that
+ * indicate problems that are essentially the same as the `SingleRuleLinter`
+ * supposes to detect, it means the `SingleRuleLinter` is a duplicate of the
+ * hh_client lint error, and we should either disable the hh_client lint error
+ * code or remove the `SingleRuleLinter`.
+ */
 final class HHClientDuplicatedLintErrorTest extends TestCase {
   use HHClientLinterTestTrait;
   const HHClientLinter::TConfig CONFIG = shape();

--- a/tests/HHClientDuplicatedLintErrorTest.hack
+++ b/tests/HHClientDuplicatedLintErrorTest.hack
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use type Facebook\HackTest\DataProvider;
+use namespace HH\Lib\{C, Str, Vec};
+
+final class HHClientDuplicatedLintErrorTest extends TestCase {
+  use HHClientLinterTestTrait;
+  const HHClientLinter::TConfig CONFIG = shape();
+
+  public function getDirtyFixturesFromOtherLinters(): vec<(string)> {
+    return \glob(__DIR__.'/examples/*/*.in')
+      |> Vec\filter($$, $path ==> !Str\contains($path, 'HHClientLinter'))
+      |> Vec\map($$, $path ==> tuple($path));
+  }
+
+  <<DataProvider('getDirtyFixturesFromOtherLinters')>>
+  public async function testDuplicatedLintError(string $path): Awaitable<void> {
+    $linter = $this->getLinter($path);
+    $errors = await $linter->getLintErrorsAsync();
+    if (C\is_empty($errors)) {
+      return;
+    }
+    Vec\map(
+      $errors,
+      $error ==> Str\format(
+        "- %s: %s at line %s:%d:\n%s",
+        $error->getLintRule()->getName(),
+        $error->getDescription(),
+        $path,
+        $error->getRange()[0][1] ?? -1,
+        $error->getPrettyBlame() ?? '',
+      ),
+    )
+      |> Str\join($$, "\n")
+      |> self::fail("Expected no errors, got:\n".$$);
+  }
+}

--- a/tests/HHClientLinterIgnoreExceptTest.hack
+++ b/tests/HHClientLinterIgnoreExceptTest.hack
@@ -10,6 +10,7 @@
 namespace Facebook\HHAST;
 
 final class HHClientLinterIgnoreExceptTest extends TestCase {
+  use LinterTestTrait;
   use HHClientLinterTestTrait;
 
   <<__Override>>

--- a/tests/HHClientLinterIgnoreTest.hack
+++ b/tests/HHClientLinterIgnoreTest.hack
@@ -10,6 +10,7 @@
 namespace Facebook\HHAST;
 
 final class HHClientLinterIgnoreTest extends TestCase {
+  use LinterTestTrait;
   use HHClientLinterTestTrait;
 
   <<__Override>>

--- a/tests/HHClientLinterTest.hack
+++ b/tests/HHClientLinterTest.hack
@@ -10,6 +10,7 @@
 namespace Facebook\HHAST;
 
 final class HHClientLinterTest extends TestCase {
+  use LinterTestTrait;
   use HHClientLinterTestTrait;
 
   <<__Override>>

--- a/tests/HHClientLinterTestTrait.hack
+++ b/tests/HHClientLinterTestTrait.hack
@@ -12,7 +12,6 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Str};
 
 trait HHClientLinterTestTrait {
-  use LinterTestTrait;
 
   abstract const HHClientLinter::TConfig CONFIG;
 
@@ -28,7 +27,6 @@ trait HHClientLinterTestTrait {
       __DIR__.'/../.var/tmp/hhast/'.C\lastx(Str\split(static::class, '\\'));
   }
 
-  <<__Override>>
   protected function getLinter(string $file): HHClientLinter {
     $ext = Str\strip_suffix($file, '.in')
       |> Str\ends_with($$, '.php')

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.autofix.expect
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.autofix.expect
@@ -1,6 +1,7 @@
 namespace Herp\Derp;
 
 /*HHAST_IGNORE_ALL[CamelCasedMethodsUnderscoredFunctions]*/
+// HHAST_IGNORE_ALL[5623] HHAST_IGNORE_ALL[5624] because the error code is not the interested in this example
 
 use type Facebook\HackTest\{DataProvider, HackTest};
 use function Facebook\FBExpect\expect;

--- a/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.in
+++ b/tests/examples/DataProviderTypesLinter/aa_test_typechecks.hack.in
@@ -1,6 +1,7 @@
 namespace Herp\Derp;
 
 /*HHAST_IGNORE_ALL[CamelCasedMethodsUnderscoredFunctions]*/
+// HHAST_IGNORE_ALL[5623] HHAST_IGNORE_ALL[5624] because the error code is not the interested in this example
 
 use type Facebook\HackTest\{DataProvider, HackTest};
 use function Facebook\FBExpect\expect;

--- a/tests/examples/NamespacePrivateLinter/namespace_private_type_annotation.php.in
+++ b/tests/examples/NamespacePrivateLinter/namespace_private_type_annotation.php.in
@@ -8,6 +8,8 @@
  */
 namespace BlahNew;
 
+// HHAST_IGNORE_ALL[5624] because the error code is not the interested in this example
+
 final class Test {
   // using private type as type annotations
   function anotherTest<T as \Blah\__Private\some_private_type_t>(

--- a/tests/examples/NoEmptyStatementsLinter/type_error_thrown_on_autofix.php.autofix.expect
+++ b/tests/examples/NoEmptyStatementsLinter/type_error_thrown_on_autofix.php.autofix.expect
@@ -1,4 +1,5 @@
 <?hh
+// HHAST_IGNORE_ALL[5581] HHAST_IGNORE_ALL[5622] HHAST_IGNORE_ALL[5623] HHAST_IGNORE_ERROR[5624] because the error code is not the interested in this example
 
 function no_side_effects(): void {
   if ("NO SIDE EFFECTS") {}

--- a/tests/examples/NoEmptyStatementsLinter/type_error_thrown_on_autofix.php.in
+++ b/tests/examples/NoEmptyStatementsLinter/type_error_thrown_on_autofix.php.in
@@ -1,4 +1,5 @@
 <?hh
+// HHAST_IGNORE_ALL[5581] HHAST_IGNORE_ALL[5622] HHAST_IGNORE_ALL[5623] HHAST_IGNORE_ERROR[5624] because the error code is not the interested in this example
 
 function no_side_effects(): void {
   if ("NO SIDE EFFECTS") ;

--- a/tests/examples/UnusedVariableLinter/unused_foreach.php.autofix.expect
+++ b/tests/examples/UnusedVariableLinter/unused_foreach.php.autofix.expect
@@ -1,5 +1,6 @@
 <?hh
 
+// HHAST_IGNORE_ALL[5568] because the error code is not the interested in this example
 function foreach_value($items) {
   foreach ($items as $_item) {
   }

--- a/tests/examples/UnusedVariableLinter/unused_foreach.php.in
+++ b/tests/examples/UnusedVariableLinter/unused_foreach.php.in
@@ -1,5 +1,6 @@
 <?hh
 
+// HHAST_IGNORE_ALL[5568] because the error code is not the interested in this example
 function foreach_value($items) {
   foreach ($items as $item) {
   }


### PR DESCRIPTION
`HHClientDuplicatedLintErrorTest` ensures that no lint error is found by `HHClientLinter` in examples for `SingleRuleLinter`s, closing #409.