### PR TITLE
Support AST version 2021-12-08-0001

### DIFF
--- a/src/__Private/is_compatible_schema_version.hack
+++ b/src/__Private/is_compatible_schema_version.hack
@@ -26,7 +26,11 @@ function is_compatible_schema_version(string $other_version): bool {
     __FILE__,
   );
   if ($other_version === '2022-01-18-0001') {
-    // adds `attribute_spec` for `const`, and `like` for `xhp_enum`
+    // adds `like` for `xhp_enum`
+    return true;
+  }
+  if ($other_version === '2021-12-08-0001') {
+    // adds `attribute_spec` for `const`
     // removes record types (never supported)
     return true;
   }


### PR DESCRIPTION
#435 supported AST version 2022-01-18-0001 but did not support AST version 2021-12-08-0001, which is the AST version produced by HHVM 4.145.0. This PR supported both 2022-01-18-0001 and 2021-12-08-0001.

- HHVM 4.144.0 produces the AST version `2021-09-13-0001`.
- HHVM 4.145.0 and nightly-2022.01.19 share the same code base and produce the AST version `2021-12-08-0001`, according to https://github.com/facebook/hhvm/commit/4c03fbf28cb0bfb1fbda537d1e5ed3ad2da22cfd
- HHVM nightly-2022.01.20+  produces the AST version `2022-01-18-0001`, according to https://github.com/facebook/hhvm/commit/f14308e07cc39df307d6576f57fcf80db611a9f8

