### PR TITLE
Add linter to identify unreachable code

### DIFF
--- a/src/Linters/UnreachableCodeLinter.hack
+++ b/src/Linters/UnreachableCodeLinter.hack
@@ -35,13 +35,18 @@ final class UnreachableCodeLinter extends ASTLinter {
         $statements = $parent->getStatements();
         invariant($statements is nonnull, 'parent list of stmt cannot be null');
         $children = $statements->getChildren();
-        $return_idx = C\find_key($children, $c ==> $c === $stmt) ?? null;
-        invariant(
-            $return_idx is nonnull,
-            'stmt must be a child of parent list',
-        );
+        $stmt_idx = C\find_key($children, $c ==> $c === $stmt) ?? null;
 
-        if ($return_idx < C\count($children) - 1) {
+        // if the statement is not a direct child of the CompoundStatement,
+        // then it occurs in a position where it cannot cause unreachable code
+        //
+        // For example:
+        // if ($cond) return;
+        if ($stmt_idx is null) {
+            return null;
+        }
+
+        if ($stmt_idx < C\count($children) - 1) {
             if ($stmt is ThrowStatement) {
                 $op = 'throw';
             } else if ($stmt is ReturnStatement) {

--- a/src/Linters/UnreachableCodeLinter.hack
+++ b/src/Linters/UnreachableCodeLinter.hack
@@ -12,50 +12,60 @@ namespace Facebook\HHAST;
 use namespace HH\Lib\{C, Str};
 
 final class UnreachableCodeLinter extends ASTLinter {
-    const type TConfig = shape();
-    const type TNode = IStatement;
-    const type TContext = CompoundStatement;
+  const type TConfig = shape();
+  const type TNode = IStatement;
+  const type TContext = CompoundStatement;
 
-    <<__Override>>
-    public function getLintErrorForNode(
-        CompoundStatement $parent,
-        IStatement $stmt,
-    ): ?ASTLintError {
-        // Evaluate all IStatement because we need to look for additional statements
-        // after return, throw, continue
-        if (!($stmt is ThrowStatement || $stmt is ReturnStatement || $stmt is ContinueStatement)) {
-            return null;
-        }
-
-        $statements = $parent->getStatements();
-        invariant($statements is nonnull, 'parent list of statement cannot be null');
-        $children = $statements->getChildren();
-
-        // A statement causes unreachable code when it is not the last statement in a block
-        //
-        // This occurs when it is not the last child of a CompoundStatement.
-        // In the case of conditional statements used without braces, statements are not a direct
-        // child of CompoundStatement but cannot cause unreachable code.
-        //
-        // For example:
-        //     if ($cond) { $a = 5; return "last statement"; }
-        //     if ($cond) return;
-        if (C\last($children) === $stmt || !C\contains($children, $stmt)) {
-            return null;
-        }
-
-        if ($stmt is ThrowStatement) {
-            $op = 'throw';
-        } else if ($stmt is ReturnStatement) {
-            $op = 'return';
-        } else {
-            $op = 'continue';
-        }
-
-        return new ASTLintError(
-            $this,
-            Str\format('This %s statement creates unreachable code', $op),
-            $stmt,
-        );
+  <<__Override>>
+  public function getLintErrorForNode(
+    CompoundStatement $parent,
+    IStatement $stmt,
+  ): ?ASTLintError {
+    // Evaluate all IStatement because we need to look for additional statements
+    // after return, throw, continue
+    if (
+      !(
+        $stmt is ThrowStatement ||
+        $stmt is ReturnStatement ||
+        $stmt is ContinueStatement
+      )
+    ) {
+      return null;
     }
+
+    $statements = $parent->getStatements();
+    invariant(
+      $statements is nonnull,
+      'parent list of statement cannot be null',
+    );
+    $children = $statements->getChildren();
+
+    // A statement causes unreachable code when it is not the last statement in
+    // a block.
+    //
+    // This occurs when it is not the last child of a CompoundStatement.
+    // In the case of conditional statements used without braces, statements
+    // are not a direct child of CompoundStatement but cannot cause unreachable code.
+    //
+    // For example:
+    //     if ($cond) { $a = 5; return "last statement"; }
+    //     if ($cond) return;
+    if (C\last($children) === $stmt || !C\contains($children, $stmt)) {
+      return null;
+    }
+
+    if ($stmt is ThrowStatement) {
+      $op = 'throw';
+    } else if ($stmt is ReturnStatement) {
+      $op = 'return';
+    } else {
+      $op = 'continue';
+    }
+
+    return new ASTLintError(
+      $this,
+      Str\format('This %s statement creates unreachable code', $op),
+      $stmt,
+    );
+  }
 }

--- a/src/Linters/UnreachableCodeLinter.hack
+++ b/src/Linters/UnreachableCodeLinter.hack
@@ -54,17 +54,12 @@ final class UnreachableCodeLinter extends ASTLinter {
       return null;
     }
 
-    if ($stmt is ThrowStatement) {
-      $op = 'throw';
-    } else if ($stmt is ReturnStatement) {
-      $op = 'return';
-    } else {
-      $op = 'continue';
-    }
-
     return new ASTLintError(
       $this,
-      Str\format('This %s statement creates unreachable code', $op),
+      Str\format(
+        'This %s statement creates unreachable code',
+        $stmt->getKeyword()->getText(),
+      ),
       $stmt,
     );
   }

--- a/src/Linters/UnreachableCodeLinter.hack
+++ b/src/Linters/UnreachableCodeLinter.hack
@@ -21,47 +21,41 @@ final class UnreachableCodeLinter extends ASTLinter {
         CompoundStatement $parent,
         IStatement $stmt,
     ): ?ASTLintError {
-        // Evaluate all IStatement because we need to look for additional statements after return, throw, continue
-        if (
-            !(
-                $stmt is ThrowStatement ||
-                $stmt is ReturnStatement ||
-                $stmt is ContinueStatement
-            )
-        ) {
+        // Evaluate all IStatement because we need to look for additional statements
+        // after return, throw, continue
+        if (!($stmt is ThrowStatement || $stmt is ReturnStatement || $stmt is ContinueStatement)) {
             return null;
         }
 
         $statements = $parent->getStatements();
-        invariant($statements is nonnull, 'parent list of stmt cannot be null');
+        invariant($statements is nonnull, 'parent list of statement cannot be null');
         $children = $statements->getChildren();
-        $stmt_idx = C\find_key($children, $c ==> $c === $stmt) ?? null;
 
-        // if the statement is not a direct child of the CompoundStatement,
-        // then it occurs in a position where it cannot cause unreachable code
+        // A statement causes unreachable code when it is not the last statement in a block
+        //
+        // This occurs when it is not the last child of a CompoundStatement.
+        // In the case of conditional statements used without braces, statements are not a direct
+        // child of CompoundStatement but cannot cause unreachable code.
         //
         // For example:
-        // if ($cond) return;
-        if ($stmt_idx is null) {
+        //     if ($cond) { $a = 5; return "last statement"; }
+        //     if ($cond) return;
+        if (C\last($children) === $stmt || !C\contains($children, $stmt)) {
             return null;
         }
 
-        if ($stmt_idx < C\count($children) - 1) {
-            if ($stmt is ThrowStatement) {
-                $op = 'throw';
-            } else if ($stmt is ReturnStatement) {
-                $op = 'return';
-            } else {
-                $op = 'continue';
-            }
-
-            return new ASTLintError(
-                $this,
-                Str\format('This %s statement creates unreachable code', $op),
-                $stmt,
-            );
+        if ($stmt is ThrowStatement) {
+            $op = 'throw';
+        } else if ($stmt is ReturnStatement) {
+            $op = 'return';
         } else {
-            return null;
+            $op = 'continue';
         }
+
+        return new ASTLintError(
+            $this,
+            Str\format('This %s statement creates unreachable code', $op),
+            $stmt,
+        );
     }
 }

--- a/src/Linters/UnreachableCodeLinter.hack
+++ b/src/Linters/UnreachableCodeLinter.hack
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\C;
+
+final class UnreachableCodeLinter extends ASTLinter {
+    const type TConfig = shape();
+    const type TNode = ReturnStatement;
+    const type TContext = CompoundStatement;
+
+    <<__Override>>
+    public function getLintErrorForNode(
+        CompoundStatement $parent,
+        ReturnStatement $stmt,
+    ): ?ASTLintError {
+        $statements = $parent->getStatements();
+        invariant($statements is nonnull, 'parent list of stmt cannot be null');
+        $children = $statements->getChildren();
+        $return_idx = C\find_key($children, $c ==> $c === $stmt) ?? null;
+        invariant(
+            $return_idx is nonnull,
+            'stmt must be a child of parent list',
+        );
+
+        if ($return_idx < C\count($children) - 1) {
+            return new ASTLintError(
+                $this,
+                'This return creates unreachable code',
+                $stmt,
+            );
+        } else {
+            return null;
+        }
+    }
+}

--- a/tests/UnreachableCodeLinterTest.hack
+++ b/tests/UnreachableCodeLinterTest.hack
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class UnreachableCodeLinterTest extends TestCase {
+    use LinterTestTrait;
+
+    <<__Override>>
+    protected function getLinter(string $file): UnreachableCodeLinter {
+        return UnreachableCodeLinter::fromPath($file);
+    }
+
+    <<__Override>>
+    public function getCleanExamples(): vec<(string)> {
+        return vec[
+            tuple('<?hh function foo(): int { return 5; }'),
+            tuple('<?hh function foo(): void { return; }'),
+            tuple(
+                '<?hh function foo(int $i): int { if ($i == 1) { return 5; } else { return 6; } }',
+            ),
+            tuple(
+                '<?hh function foo(): void { return; /* comment node after return */ }',
+            ),
+        ];
+    }
+}

--- a/tests/UnreachableCodeLinterTest.hack
+++ b/tests/UnreachableCodeLinterTest.hack
@@ -1,6 +1,3 @@
-
-
-
 /*
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.

--- a/tests/UnreachableCodeLinterTest.hack
+++ b/tests/UnreachableCodeLinterTest.hack
@@ -1,3 +1,6 @@
+
+
+
 /*
  *  Copyright (c) 2017-present, Facebook, Inc.
  *  All rights reserved.
@@ -10,25 +13,25 @@
 namespace Facebook\HHAST;
 
 final class UnreachableCodeLinterTest extends TestCase {
-    use LinterTestTrait;
+  use LinterTestTrait;
 
-    <<__Override>>
-    protected function getLinter(string $file): UnreachableCodeLinter {
-        return UnreachableCodeLinter::fromPath($file);
-    }
+  <<__Override>>
+  protected function getLinter(string $file): UnreachableCodeLinter {
+    return UnreachableCodeLinter::fromPath($file);
+  }
 
-    <<__Override>>
-    public function getCleanExamples(): vec<(string)> {
-        return vec[
-            tuple('<?hh function foo(): int { return 5; }'),
-            tuple('<?hh function foo(): void { return; }'),
-            tuple('<?hh function foo(): void { if (true) return; }'),
-            tuple(
-                '<?hh function foo(int $i): int { if ($i == 1) { return 5; } else { return 6; } }',
-            ),
-            tuple(
-                '<?hh function foo(): void { return; /* comment node after return */ }',
-            ),
-        ];
-    }
+  <<__Override>>
+  public function getCleanExamples(): vec<(string)> {
+    return vec[
+      tuple('<?hh function foo(): int { return 5; }'),
+      tuple('<?hh function foo(): void { return; }'),
+      tuple('<?hh function foo(): void { if (true) return; }'),
+      tuple(
+        '<?hh function foo(int $i): int { if ($i == 1) { return 5; } else { return 6; } }',
+      ),
+      tuple(
+        '<?hh function foo(): void { return; /* comment node after return */ }',
+      ),
+    ];
+  }
 }

--- a/tests/UnreachableCodeLinterTest.hack
+++ b/tests/UnreachableCodeLinterTest.hack
@@ -22,6 +22,7 @@ final class UnreachableCodeLinterTest extends TestCase {
         return vec[
             tuple('<?hh function foo(): int { return 5; }'),
             tuple('<?hh function foo(): void { return; }'),
+            tuple('<?hh function foo(): void { if (true) return; }'),
             tuple(
                 '<?hh function foo(int $i): int { if ($i == 1) { return 5; } else { return 6; } }',
             ),

--- a/tests/examples/UnreachableCodeLinter/unreachable.php.expect
+++ b/tests/examples/UnreachableCodeLinter/unreachable.php.expect
@@ -1,0 +1,12 @@
+[
+    {
+        "blame": "    return 5;\n",
+        "blame_pretty": "    return 5;\n",
+        "description": "This return creates unreachable code"
+    },
+    {
+        "blame": "        return $value;\n",
+        "blame_pretty": "        return $value;\n",
+        "description": "This return creates unreachable code"
+    }
+]

--- a/tests/examples/UnreachableCodeLinter/unreachable.php.expect
+++ b/tests/examples/UnreachableCodeLinter/unreachable.php.expect
@@ -2,11 +2,21 @@
     {
         "blame": "    return 5;\n",
         "blame_pretty": "    return 5;\n",
-        "description": "This return creates unreachable code"
+        "description": "This return statement creates unreachable code"
     },
     {
         "blame": "        return $value;\n",
         "blame_pretty": "        return $value;\n",
-        "description": "This return creates unreachable code"
+        "description": "This return statement creates unreachable code"
+    },
+    {
+        "blame": "    throw new RuntimeException();\n",
+        "blame_pretty": "    throw new RuntimeException();\n",
+        "description": "This throw statement creates unreachable code"
+    },
+    {
+        "blame": "        continue;\n",
+        "blame_pretty": "        continue;\n",
+        "description": "This continue statement creates unreachable code"
     }
 ]

--- a/tests/examples/UnreachableCodeLinter/unreachable.php.in
+++ b/tests/examples/UnreachableCodeLinter/unreachable.php.in
@@ -1,0 +1,13 @@
+<?hh
+
+function test_unreachable_1(): int {
+    return 5;
+    return 6;
+}
+
+function test_unreachable_2(): int {
+    foreach (vec[1] as $value) {
+        return $value;
+        return $value * $value;
+    }
+}

--- a/tests/examples/UnreachableCodeLinter/unreachable.php.in
+++ b/tests/examples/UnreachableCodeLinter/unreachable.php.in
@@ -11,3 +11,17 @@ function test_unreachable_2(): int {
         return $value * $value;
     }
 }
+
+function test_unreachable_throw_1(): void {
+    throw new RuntimeException();
+    return;
+}
+
+function test_unreachable_continue_1(): int {
+    $a = 0;
+    for ($i = 0; $i < 10; $i++) {
+        continue;
+        $a = $i;
+    }
+    return $a;
+}


### PR DESCRIPTION
This PR adds UnreachableCodeLinter which flags any `return`, `throw`, or `continue` statement that is followed by other code at the same scope (CompoundStatement is used to approximate "same scope").

This is probably best implemented in the typechecker which can do better analysis than a linter, but as an intermediate solution this might help folks identify potential bugs.