### PR TITLE
Suppress the 4323 typing error

### DIFF
--- a/src/__Private/LintRunCLIEventHandler.hack
+++ b/src/__Private/LintRunCLIEventHandler.hack
@@ -85,8 +85,10 @@ final class LintRunCLIEventHandler implements LintRunEventHandler {
       if ($fixing_linter) {
         /* HHAST_IGNORE_ERROR[DontAwaitInALoop] */
         $should_fix = await $this->shouldFixLintAsync(
-          /* HH_FIXME[4110] TError is lost here*/ $fixing_linter,
-          /* HH_FIXME[4110] TError is lost here*/ $error,
+          $fixing_linter,
+          /* HH_FIXME[4110] TError is lost here*/
+          /* HH_FIXME[4323] TError is lost here*/
+          $error,
         );
         if ($should_fix) {
           $to_fix[] = $error;
@@ -103,7 +105,12 @@ final class LintRunCLIEventHandler implements LintRunEventHandler {
 
     if (!C\is_empty($to_fix)) {
       invariant($fixing_linter, "Can't fix without a fixing linter");
-      self::fixErrors(/* HH_FIXME[4110] TError is lost here */ $fixing_linter, $to_fix);
+      self::fixErrors(
+        $fixing_linter,
+        /* HH_FIXME[4110] TError is lost here */
+        /* HH_FIXME[4323] TError is lost here */
+        $to_fix
+      );
     }
 
     return $result;


### PR DESCRIPTION
The original implementation is not type safe and there was an existing `HH_FIXME[4110]` marker to suppress the error. Unfortunately the marker is not adequate in the nightly HHVM because of the newly introduced 4323 error.
This PR suppresses the error 4323 and should fix the CI.