### PR TITLE
Add -latest suffix to the OS in the Github Action configuration

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
       # Run tests on all OS's and HHVM versions, even if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu , macos ]
+        os: [ ubuntu-latest , macos-latest ]
         hhvm:
           - '4.128'
           - latest


### PR DESCRIPTION
According to https://docs.github.com/cn/actions/using-github-hosted-runners/about-github-hosted-runners , the `-latest` suffix is standard.

Hopefully this PR would fix CI.

