### PR TITLE
Update codegen for 4.156 and require 4.156

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@ src/codegen/data/ export-ignore
 tests/ export-ignore
 codegen/**/* linguist-generated
 .hhconfig export-ignore
+.hhvmconfig.hdf export-ignore
 *.hack linguist-language=Hack
 .vscode/** export-ignore
 test-data/** export-ignore

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu , macos ]
         hhvm:
-          - '4.128'
+          - '4.156'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.hhvmconfig.hdf
+++ b/.hhvmconfig.hdf
@@ -1,0 +1,3 @@
+Autoload {
+  Query = {"expression": ["allof", ["type", "f"], ["suffix", ["anyof", "hack", "php"]], ["not",["anyof",["dirname",".var"],["dirname",".git"]]]]}
+}

--- a/codegen/inferred_relationships.hack
+++ b/codegen/inferred_relationships.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<456d5fb5d4d64ca382edb8ab203f0ffd>>
+ * @generated SignedSource<<18404b499f4eaed37d0e4117e4460a3d>>
  */
 namespace Facebook\HHAST\__Private;
 
@@ -112,6 +112,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'member_selection_expression',
     'parenthesized_expression',
     'prefix_unary_expression',
+    'shape_expression',
     'subscript_expression',
     'tuple_expression',
     'variable',
@@ -159,6 +160,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'collection_literal_expression',
     'darray_intrinsic_expression',
     'dictionary_intrinsic_expression',
+    'enum_class_label',
     'function_call_expression',
     'function_pointer_expression',
     'is_expression',
@@ -295,6 +297,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   'case_label.case_expression' => keyset[
     'cast_expression',
     'collection_literal_expression',
+    'enum_class_label',
     'function_call_expression',
     'literal',
     'object_creation_expression',
@@ -385,6 +388,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<property_declaration|xhp_class_attribute_declaration>',
     'list<require_clause>',
     'list<require_clause|trait_use>',
+    'list<require_clause|type_const_declaration>',
     'list<trait_use>',
     'list<trait_use_conflict_resolution>',
     'list<trait_use|trait_use_conflict_resolution>',
@@ -523,6 +527,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   ],
   'closure_type_specifier.closure_readonly_return' => keyset[
     'missing',
+    'token:readonly',
   ],
   'closure_type_specifier.closure_return_type' => keyset[
     'closure_type_specifier',
@@ -1323,6 +1328,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   'enum_class_declaration.enum_class_base' => keyset[
     'generic_type_specifier',
     'simple_type_specifier',
+    'tuple_type_specifier',
   ],
   'enum_class_declaration.enum_class_class_keyword' => keyset[
     'token:class',
@@ -1374,6 +1380,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   ],
   'enum_class_enumerator.enum_class_enumerator_type' => keyset[
     'generic_type_specifier',
+    'nullable_type_specifier',
     'simple_type_specifier',
   ],
   'enum_declaration.enum_attribute_spec' => keyset[
@@ -1670,7 +1677,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<anonymous_function>|list_item<variable>>',
     'list<list_item<anonymous_function>|list_item<varray_intrinsic_expression>>',
     'list<list_item<as_expression>>',
-    'list<list_item<as_expression>|list_item<variable>>',
     'list<list_item<awaitable_creation_expression>>',
     'list<list_item<awaitable_creation_expression>|list_item<function_call_expression>>',
     'list<list_item<binary_expression>>',
@@ -1815,6 +1821,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<decorated_expression>|list_item<literal>|list_item<variable>>',
     'list<list_item<decorated_expression>|list_item<literal>|list_item<variable>|list_item<varray_intrinsic_expression>>',
     'list<list_item<decorated_expression>|list_item<literal>|list_item<varray_intrinsic_expression>>',
+    'list<list_item<decorated_expression>|list_item<literal>|list_item<vector_intrinsic_expression>>',
     'list<list_item<decorated_expression>|list_item<member_selection_expression>|list_item<prefix_unary_expression>|list_item<variable>>',
     'list<list_item<decorated_expression>|list_item<member_selection_expression>|list_item<variable>>',
     'list<list_item<decorated_expression>|list_item<object_creation_expression>>',
@@ -1839,6 +1846,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<dictionary_intrinsic_expression>|list_item<keyset_intrinsic_expression>|list_item<vector_intrinsic_expression>>',
     'list<list_item<dictionary_intrinsic_expression>|list_item<lambda_expression>>',
     'list<list_item<dictionary_intrinsic_expression>|list_item<lambda_expression>|list_item<variable>>',
+    'list<list_item<dictionary_intrinsic_expression>|list_item<lambda_expression>|list_item<vector_intrinsic_expression>>',
     'list<list_item<dictionary_intrinsic_expression>|list_item<literal>>',
     'list<list_item<dictionary_intrinsic_expression>|list_item<literal>|list_item<pipe_variable>>',
     'list<list_item<dictionary_intrinsic_expression>|list_item<literal>|list_item<pipe_variable>|list_item<variable>>',
@@ -2045,10 +2053,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<xhp_expression>>',
     'missing',
   ],
-  'function_call_expression.function_call_enum_class_label' => keyset[
-    'enum_class_label',
-    'missing',
-  ],
   'function_call_expression.function_call_left_paren' => keyset[
     'token:(',
   ],
@@ -2082,7 +2086,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   ],
   'function_declaration.function_body' => keyset[
     'compound_statement',
-    'token:;',
   ],
   'function_declaration.function_declaration_header' => keyset[
     'function_declaration_header',
@@ -2409,6 +2412,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'token:)',
   ],
   'lambda_signature.lambda_type' => keyset[
+    'closure_type_specifier',
     'generic_type_specifier',
     'keyset_type_specifier',
     'missing',
@@ -2594,6 +2598,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<const_declaration>',
     'list<const_declaration|function_declaration>',
     'list<const_declaration|function_declaration|namespace_group_use_declaration>',
+    'list<enum_class_declaration>',
     'list<enum_declaration>',
     'list<function_declaration>',
     'list<function_declaration|namespace_group_use_declaration>',
@@ -2844,6 +2849,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'prefix_unary_expression',
     'qualified_name',
     'scope_resolution_expression',
+    'shape_expression',
     'subscript_expression',
     'token:name',
     'variable',
@@ -3016,14 +3022,12 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<alias_declaration|end_of_file|function_declaration|markup_section>',
     'list<alias_declaration|end_of_file|function_declaration|markup_section|namespace_declaration>',
     'list<alias_declaration|end_of_file|markup_section>',
-    'list<classish_declaration|const_declaration|end_of_file|enum_declaration|function_declaration|markup_section>',
     'list<classish_declaration|const_declaration|end_of_file|function_declaration|markup_section>',
     'list<classish_declaration|const_declaration|end_of_file|function_declaration|markup_section|namespace_declaration>',
     'list<classish_declaration|const_declaration|end_of_file|function_declaration|markup_section|namespace_declaration|namespace_use_declaration>',
     'list<classish_declaration|const_declaration|end_of_file|markup_section>',
     'list<classish_declaration|context_alias_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section>',
     'list<classish_declaration|end_of_file|enum_class_declaration|expression_statement|function_declaration|markup_section>',
-    'list<classish_declaration|end_of_file|enum_class_declaration|file_attribute_specification|function_declaration|markup_section>',
     'list<classish_declaration|end_of_file|enum_class_declaration|function_declaration|markup_section>',
     'list<classish_declaration|end_of_file|enum_class_declaration|markup_section>',
     'list<classish_declaration|end_of_file|enum_declaration|function_declaration|markup_section>',
@@ -3046,9 +3050,8 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<const_declaration|end_of_file|markup_section|namespace_declaration>',
     'list<const_declaration|end_of_file|markup_section|namespace_use_declaration>',
     'list<context_alias_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section>',
-    'list<end_of_file|enum_class_declaration|file_attribute_specification|function_declaration|markup_section>',
-    'list<end_of_file|enum_class_declaration|file_attribute_specification|markup_section>',
     'list<end_of_file|enum_class_declaration|function_declaration|markup_section>',
+    'list<end_of_file|enum_class_declaration|markup_section>',
     'list<end_of_file|enum_declaration|expression_statement|function_declaration|markup_section>',
     'list<end_of_file|enum_declaration|function_declaration|markup_section>',
     'list<end_of_file|enum_declaration|markup_section>',
@@ -3447,6 +3450,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<dictionary_type_specifier>|list_item<simple_type_specifier>>',
     'list<list_item<generic_type_specifier>>',
     'list<list_item<generic_type_specifier>|list_item<simple_type_specifier>>',
+    'list<list_item<generic_type_specifier>|list_item<type_constant>>',
     'list<list_item<keyset_type_specifier>>',
     'list<list_item<like_type_specifier>>',
     'list<list_item<nullable_type_specifier>>',
@@ -3512,6 +3516,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'vector_type_specifier',
   ],
   'type_constant.type_constant_left_type' => keyset[
+    'qualified_name',
     'token:name',
     'token:self',
     'token:this',
@@ -3812,7 +3817,9 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<awaitable_creation_expression>|list_item<binary_expression>>',
     'list<list_item<binary_expression>>',
     'list<list_item<binary_expression>|list_item<function_call_expression>|list_item<literal>|list_item<variable>>',
+    'list<list_item<binary_expression>|list_item<literal>>',
     'list<list_item<binary_expression>|list_item<literal>|list_item<variable>>',
+    'list<list_item<cast_expression>|list_item<literal>>',
     'list<list_item<collection_literal_expression>>',
     'list<list_item<collection_literal_expression>|list_item<darray_intrinsic_expression>|list_item<dictionary_intrinsic_expression>|list_item<varray_intrinsic_expression>|list_item<vector_intrinsic_expression>>',
     'list<list_item<collection_literal_expression>|list_item<literal>|list_item<varray_intrinsic_expression>|list_item<vector_intrinsic_expression>>',

--- a/codegen/schema.json
+++ b/codegen/schema.json
@@ -1,6 +1,6 @@
 { "description" :
   "@generated JSON schema of the Hack Full Fidelity Parser AST",
-  "version" : "2022-01-21-0001",
+  "version" : "2022-04-06-0001",
   "trivia" : [
     { "trivia_kind_name" : "WhiteSpace",
       "trivia_type_name" : "whitespace" },
@@ -383,6 +383,8 @@
       "token_text" : "#" },
     { "token_kind" : "Readonly",
       "token_text" : "readonly" },
+    { "token_kind" : "Internal",
+      "token_text" : "internal" },
 
     { "token_kind" : "ErrorToken",
       "token_text" : null },
@@ -1481,7 +1483,6 @@
       "fields" : [
         { "field_name" : "receiver" },
         { "field_name" : "type_args" },
-        { "field_name" : "enum_class_label" },
         { "field_name" : "left_paren" },
         { "field_name" : "argument_list" },
         { "field_name" : "right_paren" }

--- a/codegen/syntax/AsExpression.hack
+++ b/codegen/syntax/AsExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e3dba2be3a66b6a146f4aabec2b186af>>
+ * @generated SignedSource<<4aa3681cf5924d40e1e6cd951626c039>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -131,8 +131,8 @@ final class AsExpression extends Node implements ILambdaBody, IExpression {
   /**
    * @return FunctionCallExpression | LiteralExpression |
    * MemberSelectionExpression | ParenthesizedExpression |
-   * PrefixUnaryExpression | SubscriptExpression | TupleExpression |
-   * VariableExpression
+   * PrefixUnaryExpression | ShapeExpression | SubscriptExpression |
+   * TupleExpression | VariableExpression
    */
   public function getLeftOperand(): IExpression {
     return TypeAssert\instance_of(IExpression::class, $this->_left_operand);
@@ -141,8 +141,8 @@ final class AsExpression extends Node implements ILambdaBody, IExpression {
   /**
    * @return FunctionCallExpression | LiteralExpression |
    * MemberSelectionExpression | ParenthesizedExpression |
-   * PrefixUnaryExpression | SubscriptExpression | TupleExpression |
-   * VariableExpression
+   * PrefixUnaryExpression | ShapeExpression | SubscriptExpression |
+   * TupleExpression | VariableExpression
    */
   public function getLeftOperandx(): IExpression {
     return $this->getLeftOperand();

--- a/codegen/syntax/BinaryExpression.hack
+++ b/codegen/syntax/BinaryExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7710229c4479e94ef2b2477d3d7f285d>>
+ * @generated SignedSource<<38bcc98afa24fc8c24ef4e98813ff68c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -134,9 +134,10 @@ final class BinaryExpression
    * @return AnonymousFunction | AsExpression | AwaitableCreationExpression |
    * BinaryExpression | CastExpression | CollectionLiteralExpression |
    * DarrayIntrinsicExpression | DictionaryIntrinsicExpression |
-   * FunctionCallExpression | FunctionPointerExpression | IsExpression |
-   * IssetExpression | KeysetIntrinsicExpression | ListExpression |
-   * LiteralExpression | MemberSelectionExpression | ObjectCreationExpression |
+   * EnumClassLabelExpression | FunctionCallExpression |
+   * FunctionPointerExpression | IsExpression | IssetExpression |
+   * KeysetIntrinsicExpression | ListExpression | LiteralExpression |
+   * MemberSelectionExpression | ObjectCreationExpression |
    * ParenthesizedExpression | PipeVariableExpression | PostfixUnaryExpression
    * | PrefixUnaryExpression | QualifiedName | SafeMemberSelectionExpression |
    * ScopeResolutionExpression | SubscriptExpression | NameToken |
@@ -151,9 +152,10 @@ final class BinaryExpression
    * @return AnonymousFunction | AsExpression | AwaitableCreationExpression |
    * BinaryExpression | CastExpression | CollectionLiteralExpression |
    * DarrayIntrinsicExpression | DictionaryIntrinsicExpression |
-   * FunctionCallExpression | FunctionPointerExpression | IsExpression |
-   * IssetExpression | KeysetIntrinsicExpression | ListExpression |
-   * LiteralExpression | MemberSelectionExpression | ObjectCreationExpression |
+   * EnumClassLabelExpression | FunctionCallExpression |
+   * FunctionPointerExpression | IsExpression | IssetExpression |
+   * KeysetIntrinsicExpression | ListExpression | LiteralExpression |
+   * MemberSelectionExpression | ObjectCreationExpression |
    * ParenthesizedExpression | PipeVariableExpression | PostfixUnaryExpression
    * | PrefixUnaryExpression | QualifiedName | SafeMemberSelectionExpression |
    * ScopeResolutionExpression | SubscriptExpression | NameToken |

--- a/codegen/syntax/CaseLabel.hack
+++ b/codegen/syntax/CaseLabel.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b0a4c8639f71de5fc8329cb8744910b2>>
+ * @generated SignedSource<<a1229044fadfc77a63456728028beaae>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -159,9 +159,10 @@ final class CaseLabel extends Node implements ISwitchLabel {
 
   /**
    * @return CastExpression | CollectionLiteralExpression |
-   * FunctionCallExpression | LiteralExpression | ObjectCreationExpression |
-   * PrefixUnaryExpression | ScopeResolutionExpression | NameToken |
-   * VariableExpression | VectorIntrinsicExpression
+   * EnumClassLabelExpression | FunctionCallExpression | LiteralExpression |
+   * ObjectCreationExpression | PrefixUnaryExpression |
+   * ScopeResolutionExpression | NameToken | VariableExpression |
+   * VectorIntrinsicExpression
    */
   public function getExpression(): IExpression {
     return TypeAssert\instance_of(IExpression::class, $this->_expression);
@@ -169,9 +170,10 @@ final class CaseLabel extends Node implements ISwitchLabel {
 
   /**
    * @return CastExpression | CollectionLiteralExpression |
-   * FunctionCallExpression | LiteralExpression | ObjectCreationExpression |
-   * PrefixUnaryExpression | ScopeResolutionExpression | NameToken |
-   * VariableExpression | VectorIntrinsicExpression
+   * EnumClassLabelExpression | FunctionCallExpression | LiteralExpression |
+   * ObjectCreationExpression | PrefixUnaryExpression |
+   * ScopeResolutionExpression | NameToken | VariableExpression |
+   * VectorIntrinsicExpression
    */
   public function getExpressionx(): IExpression {
     return $this->getExpression();

--- a/codegen/syntax/ClosureTypeSpecifier.hack
+++ b/codegen/syntax/ClosureTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2af73a9f19d23ba1c7039598479044b3>>
+ * @generated SignedSource<<9c84879ef1b8682f02bbf8aafc171109>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -22,7 +22,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
   private RightParenToken $_inner_right_paren;
   private ?Contexts $_contexts;
   private ColonToken $_colon;
-  private ?Node $_readonly_return;
+  private ?ReadonlyToken $_readonly_return;
   private ITypeSpecifier $_return_type;
   private RightParenToken $_outer_right_paren;
 
@@ -35,7 +35,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
     RightParenToken $inner_right_paren,
     ?Contexts $contexts,
     ColonToken $colon,
-    ?Node $readonly_return,
+    ?ReadonlyToken $readonly_return,
     ITypeSpecifier $return_type,
     RightParenToken $outer_right_paren,
     ?__Private\SourceRef $source_ref = null,
@@ -140,7 +140,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
-      'Node',
+      'ReadonlyToken',
     );
     $offset += $readonly_return?->getWidth() ?? 0;
     $return_type = Node::fromJSON(
@@ -249,7 +249,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $inner_right_paren as RightParenToken,
       $contexts as ?Contexts,
       $colon as ColonToken,
-      $readonly_return as ?Node,
+      $readonly_return as ?ReadonlyToken,
       $return_type as ITypeSpecifier,
       $outer_right_paren as RightParenToken,
     );
@@ -596,7 +596,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
     return $this->_readonly_return;
   }
 
-  public function withReadonlyReturn(?Node $value): this {
+  public function withReadonlyReturn(?ReadonlyToken $value): this {
     if ($value === $this->_readonly_return) {
       return $this;
     }
@@ -620,16 +620,16 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
   }
 
   /**
-   * @return null
+   * @return null | ReadonlyToken
    */
-  public function getReadonlyReturn(): ?Node {
+  public function getReadonlyReturn(): ?ReadonlyToken {
     return $this->_readonly_return;
   }
 
   /**
-   * @return
+   * @return ReadonlyToken
    */
-  public function getReadonlyReturnx(): Node {
+  public function getReadonlyReturnx(): ReadonlyToken {
     return TypeAssert\not_null($this->getReadonlyReturn());
   }
 

--- a/codegen/syntax/EnumClassDeclaration.hack
+++ b/codegen/syntax/EnumClassDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9ba25e407009d32e5c4b50a27f8f694d>>
+ * @generated SignedSource<<a7c30d2187e8388b7cf01c673e566e82>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -20,7 +20,7 @@ final class EnumClassDeclaration extends Node {
   private ClassToken $_class_keyword;
   private NameToken $_name;
   private ColonToken $_colon;
-  private ISimpleCreationSpecifier $_base;
+  private ITypeSpecifier $_base;
   private ?ExtendsToken $_extends;
   private ?NodeList<ListItem<SimpleTypeSpecifier>> $_extends_list;
   private LeftBraceToken $_left_brace;
@@ -34,7 +34,7 @@ final class EnumClassDeclaration extends Node {
     ClassToken $class_keyword,
     NameToken $name,
     ColonToken $colon,
-    ISimpleCreationSpecifier $base,
+    ITypeSpecifier $base,
     ?ExtendsToken $extends,
     ?NodeList<ListItem<SimpleTypeSpecifier>> $extends_list,
     LeftBraceToken $left_brace,
@@ -125,7 +125,7 @@ final class EnumClassDeclaration extends Node {
       $file,
       $offset,
       $source,
-      'ISimpleCreationSpecifier',
+      'ITypeSpecifier',
     );
     $base = $base as nonnull;
     $offset += $base->getWidth();
@@ -263,7 +263,7 @@ final class EnumClassDeclaration extends Node {
       $class_keyword as ClassToken,
       $name as NameToken,
       $colon as ColonToken,
-      $base as ISimpleCreationSpecifier,
+      $base as ITypeSpecifier,
       $extends as ?ExtendsToken,
       /* HH_FIXME[4110] ?NodeList<ListItem<SimpleTypeSpecifier>> may not be enforceable */ $extends_list,
       $left_brace as LeftBraceToken,
@@ -528,7 +528,7 @@ final class EnumClassDeclaration extends Node {
     return $this->_base;
   }
 
-  public function withBase(ISimpleCreationSpecifier $value): this {
+  public function withBase(ITypeSpecifier $value): this {
     if ($value === $this->_base) {
       return $this;
     }
@@ -553,17 +553,16 @@ final class EnumClassDeclaration extends Node {
   }
 
   /**
-   * @return GenericTypeSpecifier | SimpleTypeSpecifier
+   * @return GenericTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier
    */
-  public function getBase(): ISimpleCreationSpecifier {
-    return
-      TypeAssert\instance_of(ISimpleCreationSpecifier::class, $this->_base);
+  public function getBase(): ITypeSpecifier {
+    return TypeAssert\instance_of(ITypeSpecifier::class, $this->_base);
   }
 
   /**
-   * @return GenericTypeSpecifier | SimpleTypeSpecifier
+   * @return GenericTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier
    */
-  public function getBasex(): ISimpleCreationSpecifier {
+  public function getBasex(): ITypeSpecifier {
     return $this->getBase();
   }
 

--- a/codegen/syntax/EnumClassEnumerator.hack
+++ b/codegen/syntax/EnumClassEnumerator.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3fcdae586bf21cba57304c5d9792e15b>>
+ * @generated SignedSource<<2f6ca00a20eed650f03db2996c441559>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -15,14 +15,14 @@ final class EnumClassEnumerator extends Node {
   const string SYNTAX_KIND = 'enum_class_enumerator';
 
   private ?NodeList<AbstractToken> $_modifiers;
-  private ISimpleCreationSpecifier $_type;
+  private ITypeSpecifier $_type;
   private NameToken $_name;
   private ?SimpleInitializer $_initializer;
   private SemicolonToken $_semicolon;
 
   public function __construct(
     ?NodeList<AbstractToken> $modifiers,
-    ISimpleCreationSpecifier $type,
+    ITypeSpecifier $type,
     NameToken $name,
     ?SimpleInitializer $initializer,
     SemicolonToken $semicolon,
@@ -59,7 +59,7 @@ final class EnumClassEnumerator extends Node {
       $file,
       $offset,
       $source,
-      'ISimpleCreationSpecifier',
+      'ITypeSpecifier',
     );
     $type = $type as nonnull;
     $offset += $type->getWidth();
@@ -144,7 +144,7 @@ final class EnumClassEnumerator extends Node {
     }
     return new static(
       /* HH_FIXME[4110] ?NodeList<AbstractToken> may not be enforceable */ $modifiers,
-      $type as ISimpleCreationSpecifier,
+      $type as ITypeSpecifier,
       $name as NameToken,
       $initializer as ?SimpleInitializer,
       $semicolon as SemicolonToken,
@@ -190,7 +190,7 @@ final class EnumClassEnumerator extends Node {
     return $this->_type;
   }
 
-  public function withType(ISimpleCreationSpecifier $value): this {
+  public function withType(ITypeSpecifier $value): this {
     if ($value === $this->_type) {
       return $this;
     }
@@ -208,17 +208,16 @@ final class EnumClassEnumerator extends Node {
   }
 
   /**
-   * @return GenericTypeSpecifier | SimpleTypeSpecifier
+   * @return GenericTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier
    */
-  public function getType(): ISimpleCreationSpecifier {
-    return
-      TypeAssert\instance_of(ISimpleCreationSpecifier::class, $this->_type);
+  public function getType(): ITypeSpecifier {
+    return TypeAssert\instance_of(ITypeSpecifier::class, $this->_type);
   }
 
   /**
-   * @return GenericTypeSpecifier | SimpleTypeSpecifier
+   * @return GenericTypeSpecifier | NullableTypeSpecifier | SimpleTypeSpecifier
    */
-  public function getTypex(): ISimpleCreationSpecifier {
+  public function getTypex(): ITypeSpecifier {
     return $this->getType();
   }
 

--- a/codegen/syntax/FunctionCallExpression.hack
+++ b/codegen/syntax/FunctionCallExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9600f44317ae881bd473e126ff0dd2c1>>
+ * @generated SignedSource<<ceec486490f77cc663653419c5a9ea00>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -18,7 +18,6 @@ final class FunctionCallExpression
 
   private Node $_receiver;
   private ?TypeArguments $_type_args;
-  private ?EnumClassLabelExpression $_enum_class_label;
   private LeftParenToken $_left_paren;
   private ?NodeList<ListItem<IExpression>> $_argument_list;
   private RightParenToken $_right_paren;
@@ -26,7 +25,6 @@ final class FunctionCallExpression
   public function __construct(
     Node $receiver,
     ?TypeArguments $type_args,
-    ?EnumClassLabelExpression $enum_class_label,
     LeftParenToken $left_paren,
     ?NodeList<ListItem<IExpression>> $argument_list,
     RightParenToken $right_paren,
@@ -34,7 +32,6 @@ final class FunctionCallExpression
   ) {
     $this->_receiver = $receiver;
     $this->_type_args = $type_args;
-    $this->_enum_class_label = $enum_class_label;
     $this->_left_paren = $left_paren;
     $this->_argument_list = $argument_list;
     $this->_right_paren = $right_paren;
@@ -68,15 +65,6 @@ final class FunctionCallExpression
       'TypeArguments',
     );
     $offset += $type_args?->getWidth() ?? 0;
-    $enum_class_label = Node::fromJSON(
-      ($json['function_call_enum_class_label'] ?? dict['kind' => 'missing'])
-        as dict<_, _>,
-      $file,
-      $offset,
-      $source,
-      'EnumClassLabelExpression',
-    );
-    $offset += $enum_class_label?->getWidth() ?? 0;
     $left_paren = Node::fromJSON(
       ($json['function_call_left_paren']) as dict<_, _>,
       $file,
@@ -113,7 +101,6 @@ final class FunctionCallExpression
     return new static(
       /* HH_IGNORE_ERROR[4110] */ $receiver,
       /* HH_IGNORE_ERROR[4110] */ $type_args,
-      /* HH_IGNORE_ERROR[4110] */ $enum_class_label,
       /* HH_IGNORE_ERROR[4110] */ $left_paren,
       /* HH_IGNORE_ERROR[4110] */ $argument_list,
       /* HH_IGNORE_ERROR[4110] */ $right_paren,
@@ -126,7 +113,6 @@ final class FunctionCallExpression
     return dict[
       'receiver' => $this->_receiver,
       'type_args' => $this->_type_args,
-      'enum_class_label' => $this->_enum_class_label,
       'left_paren' => $this->_left_paren,
       'argument_list' => $this->_argument_list,
       'right_paren' => $this->_right_paren,
@@ -144,9 +130,6 @@ final class FunctionCallExpression
     $type_args = $this->_type_args === null
       ? null
       : $rewriter($this->_type_args, $parents);
-    $enum_class_label = $this->_enum_class_label === null
-      ? null
-      : $rewriter($this->_enum_class_label, $parents);
     $left_paren = $rewriter($this->_left_paren, $parents);
     $argument_list = $this->_argument_list === null
       ? null
@@ -155,7 +138,6 @@ final class FunctionCallExpression
     if (
       $receiver === $this->_receiver &&
       $type_args === $this->_type_args &&
-      $enum_class_label === $this->_enum_class_label &&
       $left_paren === $this->_left_paren &&
       $argument_list === $this->_argument_list &&
       $right_paren === $this->_right_paren
@@ -165,7 +147,6 @@ final class FunctionCallExpression
     return new static(
       $receiver as Node,
       $type_args as ?TypeArguments,
-      $enum_class_label as ?EnumClassLabelExpression,
       $left_paren as LeftParenToken,
       /* HH_FIXME[4110] ?NodeList<ListItem<IExpression>> may not be enforceable */ $argument_list,
       $right_paren as RightParenToken,
@@ -183,7 +164,6 @@ final class FunctionCallExpression
     return new static(
       $value,
       $this->_type_args,
-      $this->_enum_class_label,
       $this->_left_paren,
       $this->_argument_list,
       $this->_right_paren,
@@ -225,7 +205,6 @@ final class FunctionCallExpression
     return new static(
       $this->_receiver,
       $value,
-      $this->_enum_class_label,
       $this->_left_paren,
       $this->_argument_list,
       $this->_right_paren,
@@ -250,42 +229,6 @@ final class FunctionCallExpression
     return TypeAssert\not_null($this->getTypeArgs());
   }
 
-  public function getEnumClassLabelUNTYPED(): ?Node {
-    return $this->_enum_class_label;
-  }
-
-  public function withEnumClassLabel(?EnumClassLabelExpression $value): this {
-    if ($value === $this->_enum_class_label) {
-      return $this;
-    }
-    return new static(
-      $this->_receiver,
-      $this->_type_args,
-      $value,
-      $this->_left_paren,
-      $this->_argument_list,
-      $this->_right_paren,
-    );
-  }
-
-  public function hasEnumClassLabel(): bool {
-    return $this->_enum_class_label !== null;
-  }
-
-  /**
-   * @return EnumClassLabelExpression | null
-   */
-  public function getEnumClassLabel(): ?EnumClassLabelExpression {
-    return $this->_enum_class_label;
-  }
-
-  /**
-   * @return EnumClassLabelExpression
-   */
-  public function getEnumClassLabelx(): EnumClassLabelExpression {
-    return TypeAssert\not_null($this->getEnumClassLabel());
-  }
-
   public function getLeftParenUNTYPED(): ?Node {
     return $this->_left_paren;
   }
@@ -297,7 +240,6 @@ final class FunctionCallExpression
     return new static(
       $this->_receiver,
       $this->_type_args,
-      $this->_enum_class_label,
       $value,
       $this->_argument_list,
       $this->_right_paren,
@@ -335,7 +277,6 @@ final class FunctionCallExpression
     return new static(
       $this->_receiver,
       $this->_type_args,
-      $this->_enum_class_label,
       $this->_left_paren,
       $value,
       $this->_right_paren,
@@ -439,7 +380,6 @@ final class FunctionCallExpression
     return new static(
       $this->_receiver,
       $this->_type_args,
-      $this->_enum_class_label,
       $this->_left_paren,
       $this->_argument_list,
       $value,

--- a/codegen/syntax/FunctionDeclaration.hack
+++ b/codegen/syntax/FunctionDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<357059e64232775c7411ada8399f0546>>
+ * @generated SignedSource<<ceca0dace23d18bd6045c4105b940030>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -18,12 +18,12 @@ final class FunctionDeclaration
 
   private ?OldAttributeSpecification $_attribute_spec;
   private FunctionDeclarationHeader $_declaration_header;
-  private Node $_body;
+  private CompoundStatement $_body;
 
   public function __construct(
     ?OldAttributeSpecification $attribute_spec,
     FunctionDeclarationHeader $declaration_header,
-    Node $body,
+    CompoundStatement $body,
     ?__Private\SourceRef $source_ref = null,
   ) {
     $this->_attribute_spec = $attribute_spec;
@@ -64,7 +64,7 @@ final class FunctionDeclaration
       $file,
       $offset,
       $source,
-      'Node',
+      'CompoundStatement',
     );
     $body = $body as nonnull;
     $offset += $body->getWidth();
@@ -113,7 +113,7 @@ final class FunctionDeclaration
     return new static(
       $attribute_spec as ?OldAttributeSpecification,
       $declaration_header as FunctionDeclarationHeader,
-      $body as Node,
+      $body as CompoundStatement,
     );
   }
 
@@ -184,7 +184,7 @@ final class FunctionDeclaration
     return $this->_body;
   }
 
-  public function withBody(Node $value): this {
+  public function withBody(CompoundStatement $value): this {
     if ($value === $this->_body) {
       return $this;
     }
@@ -197,16 +197,16 @@ final class FunctionDeclaration
   }
 
   /**
-   * @return CompoundStatement | SemicolonToken
+   * @return CompoundStatement
    */
-  public function getBody(): Node {
-    return $this->_body;
+  public function getBody(): CompoundStatement {
+    return TypeAssert\instance_of(CompoundStatement::class, $this->_body);
   }
 
   /**
-   * @return CompoundStatement | SemicolonToken
+   * @return CompoundStatement
    */
-  public function getBodyx(): Node {
+  public function getBodyx(): CompoundStatement {
     return $this->getBody();
   }
 }

--- a/codegen/syntax/LambdaSignature.hack
+++ b/codegen/syntax/LambdaSignature.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<78fcbd02a02de796f774ca5978b1a075>>
+ * @generated SignedSource<<b06835941dda372887312edf013c5109>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -430,15 +430,16 @@ final class LambdaSignature extends Node implements ILambdaSignature {
   }
 
   /**
-   * @return GenericTypeSpecifier | KeysetTypeSpecifier | null |
-   * SimpleTypeSpecifier
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier | KeysetTypeSpecifier
+   * | null | SimpleTypeSpecifier
    */
   public function getType(): ?ITypeSpecifier {
     return $this->_type;
   }
 
   /**
-   * @return GenericTypeSpecifier | KeysetTypeSpecifier | SimpleTypeSpecifier
+   * @return ClosureTypeSpecifier | GenericTypeSpecifier | KeysetTypeSpecifier
+   * | SimpleTypeSpecifier
    */
   public function getTypex(): ITypeSpecifier {
     return TypeAssert\not_null($this->getType());

--- a/codegen/syntax/NamespaceBody.hack
+++ b/codegen/syntax/NamespaceBody.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1d547ad6a05a605bef9d128fe93797bd>>
+ * @generated SignedSource<<7237a6fcfb9ca940aecfdfdcfbaf63b1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -162,8 +162,9 @@ final class NamespaceBody extends Node implements INamespaceBody {
   /**
    * @return NodeList<AliasDeclaration> | NodeList<Node> |
    * NodeList<IHasAttributeSpec> | NodeList<ClassishDeclaration> |
-   * NodeList<ConstDeclaration> | NodeList<EnumDeclaration> |
-   * NodeList<FunctionDeclaration> | NodeList<NamespaceGroupUseDeclaration> |
+   * NodeList<ConstDeclaration> | NodeList<EnumClassDeclaration> |
+   * NodeList<EnumDeclaration> | NodeList<FunctionDeclaration> |
+   * NodeList<NamespaceGroupUseDeclaration> |
    * NodeList<INamespaceUseDeclaration> | NodeList<NamespaceUseDeclaration> |
    * null
    */
@@ -174,8 +175,9 @@ final class NamespaceBody extends Node implements INamespaceBody {
   /**
    * @return NodeList<AliasDeclaration> | NodeList<Node> |
    * NodeList<IHasAttributeSpec> | NodeList<ClassishDeclaration> |
-   * NodeList<ConstDeclaration> | NodeList<EnumDeclaration> |
-   * NodeList<FunctionDeclaration> | NodeList<NamespaceGroupUseDeclaration> |
+   * NodeList<ConstDeclaration> | NodeList<EnumClassDeclaration> |
+   * NodeList<EnumDeclaration> | NodeList<FunctionDeclaration> |
+   * NodeList<NamespaceGroupUseDeclaration> |
    * NodeList<INamespaceUseDeclaration> | NodeList<NamespaceUseDeclaration>
    */
   public function getDeclarationsx(): NodeList<Node> {

--- a/codegen/syntax/PrefixUnaryExpression.hack
+++ b/codegen/syntax/PrefixUnaryExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<490f5d4ed2b009da2f7279ccede9a277>>
+ * @generated SignedSource<<213257e64112180c1196b9c24d3bb8ca>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -148,8 +148,9 @@ final class PrefixUnaryExpression
    * LambdaExpression | LiteralExpression | MemberSelectionExpression |
    * ObjectCreationExpression | ParenthesizedExpression |
    * PostfixUnaryExpression | PrefixUnaryExpression | QualifiedName |
-   * ScopeResolutionExpression | SubscriptExpression | NameToken |
-   * VariableExpression | VarrayIntrinsicExpression | VectorIntrinsicExpression
+   * ScopeResolutionExpression | ShapeExpression | SubscriptExpression |
+   * NameToken | VariableExpression | VarrayIntrinsicExpression |
+   * VectorIntrinsicExpression
    */
   public function getOperand(): IExpression {
     return TypeAssert\instance_of(IExpression::class, $this->_operand);
@@ -163,8 +164,9 @@ final class PrefixUnaryExpression
    * LambdaExpression | LiteralExpression | MemberSelectionExpression |
    * ObjectCreationExpression | ParenthesizedExpression |
    * PostfixUnaryExpression | PrefixUnaryExpression | QualifiedName |
-   * ScopeResolutionExpression | SubscriptExpression | NameToken |
-   * VariableExpression | VarrayIntrinsicExpression | VectorIntrinsicExpression
+   * ScopeResolutionExpression | ShapeExpression | SubscriptExpression |
+   * NameToken | VariableExpression | VarrayIntrinsicExpression |
+   * VectorIntrinsicExpression
    */
   public function getOperandx(): IExpression {
     return $this->getOperand();

--- a/codegen/syntax/TypeConstant.hack
+++ b/codegen/syntax/TypeConstant.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<770924548129a85f803fc6dc004d2346>>
+ * @generated SignedSource<<dbdd4d7f98772aa8aed03aca1baafb68>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -129,14 +129,16 @@ final class TypeConstant extends Node implements ITypeSpecifier {
   }
 
   /**
-   * @return NameToken | SelfToken | ThisToken | VariableToken | TypeConstant
+   * @return QualifiedName | NameToken | SelfToken | ThisToken | VariableToken
+   * | TypeConstant
    */
   public function getLeftType(): ITypeSpecifier {
     return TypeAssert\instance_of(ITypeSpecifier::class, $this->_left_type);
   }
 
   /**
-   * @return NameToken | SelfToken | ThisToken | VariableToken | TypeConstant
+   * @return QualifiedName | NameToken | SelfToken | ThisToken | VariableToken
+   * | TypeConstant
    */
   public function getLeftTypex(): ITypeSpecifier {
     return $this->getLeftType();

--- a/codegen/token_from_data.hack
+++ b/codegen/token_from_data.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<05f5357fbfec4b8addb5c5ea59c082a5>>
+ * @generated SignedSource<<9af17fe7e2491276378eaae3a7d39ac9>>
  */
 namespace Facebook\HHAST\__Private;
 use namespace Facebook\HHAST;
@@ -91,6 +91,7 @@ class TokenClassMap {
     'int' => HHAST\IntToken::class,
     'integer' => HHAST\IntegerToken::class,
     'interface' => HHAST\InterfaceToken::class,
+    'internal' => HHAST\InternalToken::class,
     'is' => HHAST\IsToken::class,
     'isset' => HHAST\IssetToken::class,
     'keyset' => HHAST\KeysetToken::class,

--- a/codegen/tokens/InternalToken.hack
+++ b/codegen/tokens/InternalToken.hack
@@ -1,0 +1,20 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * @generated SignedSource<<b24d1dfbd581615867080e95c9e51dd7>>
+ */
+namespace Facebook\HHAST;
+
+final class InternalToken extends TokenWithVariableText {
+
+  const string KIND = 'internal';
+
+  public function __construct(
+    ?NodeList<Trivia> $leading,
+    ?NodeList<Trivia> $trailing,
+    string $token_text = 'internal',
+    ?__Private\SourceRef $source_ref = null,
+  ) {
+    parent::__construct($leading, $trailing, $token_text, $source_ref);
+  }
+}

--- a/codegen/version.hack
+++ b/codegen/version.hack
@@ -1,12 +1,12 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<913ba88354a204bd6998ce44d6d1adf3>>
+ * @generated SignedSource<<9e3d81b975df42ace53faad6eb7dd146>>
  */
 namespace Facebook\HHAST;
 
-const string SCHEMA_VERSION = '2022-01-21-0001';
+const string SCHEMA_VERSION = '2022-04-06-0001';
 
-const int HHVM_VERSION_ID = 414700;
+const int HHVM_VERSION_ID = 415600;
 
-const string HHVM_VERSION = '4.147.0-dev';
+const string HHVM_VERSION = '4.156.0';

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,11 @@
     "require-dev": {
         "facebook/fbexpect": "^2.8.1",
         "facebook/hack-codegen": "^4.0",
+        "hhvm/hhvm-autoload": "^2.0.4|^3.0",
         "hhvm/hacktest": "^2.3.0"
     },
     "require": {
         "hhvm": "^4.156",
-        "hhvm/hsl": "^4.25",
-        "hhvm/hsl-experimental": "^4.58.0rc1",
-        "hhvm/hsl-io": "^0.2.0|0.3.0",
-        "hhvm/hhvm-autoload": "^2.0.4|^3.0",
         "hhvm/type-assert": "^4.2.2",
         "facebook/hh-clilib": "^2.5.0rc1",
         "facebook/difflib": "^1.0.0"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "hhvm/hacktest": "^2.3.0"
     },
     "require": {
-        "hhvm": "^4.128",
+        "hhvm": "^4.156",
         "hhvm/hsl": "^4.25",
         "hhvm/hsl-experimental": "^4.58.0rc1",
         "hhvm/hsl-io": "^0.2.0|0.3.0",

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -6,5 +6,6 @@
   "devRoots": [
     "tests/"
   ],
-  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
+  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler",
+  "useFactsIfAvailable": true
 }

--- a/src/Linters/UnusedParameterLinter.hack
+++ b/src/Linters/UnusedParameterLinter.hack
@@ -38,10 +38,9 @@ final class UnusedParameterLinter extends AutoFixingASTLinter {
 
     // If this is a parameter of a lambda function, we should be looking in the
     // lambda's body, not the enclosing function/method's body.
-    $lambda =
-      $functionish->getClosestAncestorOfDescendantOfType<LambdaExpression>(
-        $node,
-      );
+    $lambda = $functionish->getClosestAncestorOfDescendantOfType<
+      LambdaExpression,
+    >($node);
 
     if ($lambda is nonnull) {
       $body = $lambda->getBody();
@@ -55,7 +54,7 @@ final class UnusedParameterLinter extends AutoFixingASTLinter {
       );
     }
 
-    if ($body === null || $body is SemicolonToken) {
+    if ($body is null) {
       // Don't require `$_` for abstract or interface methods
       return null;
     }

--- a/src/Linters/UnusedVariableLinter.hack
+++ b/src/Linters/UnusedVariableLinter.hack
@@ -152,7 +152,7 @@ final class UnusedVariableLinter extends AutoFixingASTLinter {
       }
     }
 
-    return tuple($params, $body as CompoundStatement);
+    return tuple($params, $body);
   }
 
   private function getLambdaParts(

--- a/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
+++ b/src/Migrations/AddXHPChildrenDeclarationMethodMigration.hack
@@ -398,7 +398,6 @@ final class AddXHPChildrenDeclarationMethodMigration
         ]),
       ),
       $generics,
-      null,
       new LeftParenToken(null, null),
       C\is_empty($arguments)
         ? null

--- a/src/Migrations/TopLevelRequiresMigration.hack
+++ b/src/Migrations/TopLevelRequiresMigration.hack
@@ -58,11 +58,6 @@ final class TopLevelRequiresMigration extends BaseMigration {
 
     // Figure out leading whitespace
     $body = $entrypoint->getBody();
-    if (!$body is CompoundStatement) {
-      // Invalid, but e.g. `<<__EntryPoint>> function foo(): void;`
-      return $script;
-    }
-
     $leading = $body->getStatements()?->toVec() ?? vec[]
       |> C\first($$)
       |> $$?->getFirstTokenx()?->getLeadingWhitespace()

--- a/src/__Private/CodegenCLI.hack
+++ b/src/__Private/CodegenCLI.hack
@@ -67,7 +67,7 @@ final class CodegenCLI extends CLIBase {
       (new CodegenRelations($hhvm, $schema))->generate();
     }
 
-    $relationships = INFERRED_RELATIONSHIPS;
+    $relationships = CodegenRelations::getInferredRelationships();
     foreach ($generators as $generator) {
       (new $generator($schema, $relationships))->generate();
     }

--- a/src/__Private/is_compatible_schema_version.hack
+++ b/src/__Private/is_compatible_schema_version.hack
@@ -21,35 +21,18 @@ use const Facebook\HHAST\SCHEMA_VERSION;
  */
 function is_compatible_schema_version(string $other_version): bool {
   invariant(
-    SCHEMA_VERSION === '2022-01-21-0001',
+    SCHEMA_VERSION === '2022-04-06-0001',
     '%s needs updating',
     __FILE__,
   );
-  if ($other_version === '2022-01-21-0001') {
-    // adds module syntax
+  if ($other_version === '2022-04-06-0001') {
+    // an exact match, compatible.
     return true;
   }
-  if ($other_version === '2022-01-18-0001') {
-    // adds `like` for `xhp_enum`
-    return true;
-  }
-  if ($other_version === '2021-12-08-0001') {
-    // adds `attribute_spec` for `const`
-    // removes record types (never supported)
-    return true;
-  }
-  if ($other_version === '2021-09-13-0001') {
-    // adds upcast token and expression
-    // removes inference of record types (never supported)
-    return true;
-  }
-  if ($other_version === '2021-08-12-0001') {
-    // - Adds `newctx` token
-    // - Infers usage of `readonly` token
-    return true;
-  }
-  if ($other_version === '2021-08-09-0002') {
-    return true;
-  }
+
+  // Older versions of FunctionCallExpression allowed ?EnumClassLabelExpression $enum_class_label.
+  // This is the `$obj->get#Versions()` syntax.
+  // The current version of hhast would not properly parse this.
+  // Best to fail loudly, rather than parsing this as `$obj->get()`.
   return false;
 }

--- a/tests/NamespacePrivateLinterTest.hack
+++ b/tests/NamespacePrivateLinterTest.hack
@@ -20,7 +20,7 @@ final class NamespacePrivateLinterTest extends TestCase {
   <<__Override>>
   public function getCleanExamples(): vec<(string)> {
     return vec[
-      tuple('<?hh function test();'),
+      tuple('<?hh function test() {}'),
     ];
   }
 }


### PR DESCRIPTION
This version of hhast supports hhvm 4.156.
The `$obj->get#Version()` syntax was removed from hhvm.
We therefore can't parse older code correctly, since it might
use this enum label call syntax.
Fixes crash when using ext_watchman.
Watchman does not like usage of a constant that was just codegenned.