### PR TITLE
Add UnusedPipeVariableLinter

### DIFF
--- a/src/Linters/UnusedPipeVariableLinter.hack
+++ b/src/Linters/UnusedPipeVariableLinter.hack
@@ -31,7 +31,7 @@ final class UnusedPipeVariableLinter extends ASTLinter {
             return new ASTLintError(
                 $this,
                 "Missing pipe variable in right-hand side of pipe operator",
-                $rhs,
+                $expr,
             );
         }
 

--- a/src/Linters/UnusedPipeVariableLinter.hack
+++ b/src/Linters/UnusedPipeVariableLinter.hack
@@ -16,7 +16,7 @@ final class UnusedPipeVariableLinter extends ASTLinter {
 
   <<__Override>>
   public function getLintErrorForNode(
-    Script $script,
+    Script $_script,
     BinaryExpression $expr,
   ): ?ASTLintError {
     $op = $expr->getOperator();

--- a/src/Linters/UnusedPipeVariableLinter.hack
+++ b/src/Linters/UnusedPipeVariableLinter.hack
@@ -10,31 +10,30 @@
 namespace Facebook\HHAST;
 
 final class UnusedPipeVariableLinter extends ASTLinter {
-    const type TConfig = shape();
-    const type TNode = BinaryExpression;
-    const type TContext = Script;
+  const type TConfig = shape();
+  const type TNode = BinaryExpression;
+  const type TContext = Script;
 
-    <<__Override>>
-    public function getLintErrorForNode(
-        Script $script,
-        BinaryExpression $expr,
-    ): ?ASTLintError {
-        $op = $expr->getOperator();
-        if (!$op is BarGreaterThanToken) {
-            return null;
-        }
-        $rhs = $expr->getRightOperand();
-        $pipe_var =
-            $rhs->getFirstDescendantOfType(PipeVariableExpression::class);
-
-        if ($pipe_var is null) {
-            return new ASTLintError(
-                $this,
-                "Missing pipe variable in right-hand side of pipe operator",
-                $expr,
-            );
-        }
-
-        return null;
+  <<__Override>>
+  public function getLintErrorForNode(
+    Script $script,
+    BinaryExpression $expr,
+  ): ?ASTLintError {
+    $op = $expr->getOperator();
+    if (!$op is BarGreaterThanToken) {
+      return null;
     }
+    $rhs = $expr->getRightOperand();
+    $pipe_var = $rhs->getFirstDescendantOfType(PipeVariableExpression::class);
+
+    if ($pipe_var is null) {
+      return new ASTLintError(
+        $this,
+        "Missing pipe variable in right-hand side of pipe operator",
+        $expr,
+      );
+    }
+
+    return null;
+  }
 }

--- a/src/Linters/UnusedPipeVariableLinter.hack
+++ b/src/Linters/UnusedPipeVariableLinter.hack
@@ -29,7 +29,7 @@ final class UnusedPipeVariableLinter extends ASTLinter {
     if ($pipe_var is null) {
       return new ASTLintError(
         $this,
-        "Missing pipe variable in right-hand side of pipe operator",
+        'Missing pipe variable in right-hand side of pipe operator',
         $expr,
       );
     }

--- a/src/Linters/UnusedPipeVariableLinter.hack
+++ b/src/Linters/UnusedPipeVariableLinter.hack
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class UnusedPipeVariableLinter extends ASTLinter {
+    const type TConfig = shape();
+    const type TNode = BinaryExpression;
+    const type TContext = Script;
+
+    <<__Override>>
+    public function getLintErrorForNode(
+        Script $script,
+        BinaryExpression $expr,
+    ): ?ASTLintError {
+        $op = $expr->getOperator();
+        if (!$op is BarGreaterThanToken) {
+            return null;
+        }
+        $rhs = $expr->getRightOperand();
+        $pipe_var =
+            $rhs->getFirstDescendantOfType(PipeVariableExpression::class);
+
+        if ($pipe_var is null) {
+            return new ASTLintError(
+                $this,
+                "Missing pipe variable in right-hand side of pipe operator",
+                $rhs,
+            );
+        }
+
+        return null;
+    }
+}

--- a/tests/UnusedPipeVariableLinterTest.hack
+++ b/tests/UnusedPipeVariableLinterTest.hack
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class UnusedPipeVariableLinterTest extends TestCase {
+    use LinterTestTrait;
+
+    protected function getLinter(string $file): UnusedPipeVariableLinter {
+        return UnusedPipeVariableLinter::fromPath($file);
+    }
+
+    public function getCleanExamples(): vec<(string)> {
+        return vec[
+            tuple(
+                '<?hh function foo(): string { return "abc" |> Str\uppercase($$); }',
+            ),
+        ];
+    }
+}

--- a/tests/UnusedPipeVariableLinterTest.hack
+++ b/tests/UnusedPipeVariableLinterTest.hack
@@ -10,17 +10,17 @@
 namespace Facebook\HHAST;
 
 final class UnusedPipeVariableLinterTest extends TestCase {
-    use LinterTestTrait;
+  use LinterTestTrait;
 
-    protected function getLinter(string $file): UnusedPipeVariableLinter {
-        return UnusedPipeVariableLinter::fromPath($file);
-    }
+  protected function getLinter(string $file): UnusedPipeVariableLinter {
+    return UnusedPipeVariableLinter::fromPath($file);
+  }
 
-    public function getCleanExamples(): vec<(string)> {
-        return vec[
-            tuple(
-                '<?hh function foo(): string { return "abc" |> Str\uppercase($$); }',
-            ),
-        ];
-    }
+  public function getCleanExamples(): vec<(string)> {
+    return vec[
+      tuple(
+        '<?hh function foo(): string { return "abc" |> Str\uppercase($$); }',
+      ),
+    ];
+  }
 }

--- a/tests/UnusedPipeVariableLinterTest.hack
+++ b/tests/UnusedPipeVariableLinterTest.hack
@@ -12,10 +12,12 @@ namespace Facebook\HHAST;
 final class UnusedPipeVariableLinterTest extends TestCase {
   use LinterTestTrait;
 
+  <<__Override>>
   protected function getLinter(string $file): UnusedPipeVariableLinter {
     return UnusedPipeVariableLinter::fromPath($file);
   }
 
+  <<__Override>>
   public function getCleanExamples(): vec<(string)> {
     return vec[
       tuple(

--- a/tests/examples/UnusedPipeVariableLinter/unused_pipe.php.expect
+++ b/tests/examples/UnusedPipeVariableLinter/unused_pipe.php.expect
@@ -1,0 +1,7 @@
+[
+    {
+        "blame": "serialize($html)",
+        "blame_pretty": "serialize($html)",
+        "description": "Missing pipe variable in right-hand side of pipe operator"
+    }
+]

--- a/tests/examples/UnusedPipeVariableLinter/unused_pipe.php.expect
+++ b/tests/examples/UnusedPipeVariableLinter/unused_pipe.php.expect
@@ -1,7 +1,7 @@
 [
     {
-        "blame": "serialize($html)",
-        "blame_pretty": "serialize($html)",
+        "blame": "  htmlspecialchars($html) |> serialize($html)",
+        "blame_pretty": "  htmlspecialchars($html) |> serialize($html)",
         "description": "Missing pipe variable in right-hand side of pipe operator"
     }
 ]

--- a/tests/examples/UnusedPipeVariableLinter/unused_pipe.php.in
+++ b/tests/examples/UnusedPipeVariableLinter/unused_pipe.php.in
@@ -1,0 +1,5 @@
+<?hh
+
+function unused_pipe(string $html): void {
+  htmlspecialchars($html) |> serialize($html);
+}


### PR DESCRIPTION
This PR introduces `UnusedPipeVariableLinter` to identify bugs where the pipe variable `$$` is missing from a pipe operation.

I recently encountered a bug in a pipe operation where the right-hand side re-used the initial variable, discarding the intended input in `$$`:

```hack
$output = htmlspecialchars($html) |> format($html);
```

Note that the docs for ["Expressions And Operators: Pipe"](https://docs.hhvm.com/hack/expressions-and-operators/pipe) say:

> The binary pipe operator, `|>`, evaluates the result of a left-hand expression and stores the result in `$$`, the pre-defined pipe variable. The right-hand expression _must_ contain at least one occurrence of `$$`.

If it's a bug that the typechecker does not produce an error for a missing `$$`, we can close this PR and file an issue in https://github.com/facebook/hhvm.