### PR TITLE
Add Github Actions to update schema

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@ src/__Private/CodegenCLI.hack export-ignore
 src/codegen/data/ export-ignore
 tests/ export-ignore
 codegen/**/* linguist-generated
+codegen-no-rebuild/**/* linguist-generated
 .hhconfig export-ignore
 .hhvmconfig.hdf export-ignore
 *.hack linguist-language=Hack

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,17 +3,31 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '42 15 * * *'
+    - cron: "42 15 * * *"
 jobs:
+  determine-latest-breaking-hhvm-version:
+    runs-on: ubuntu-latest
+    outputs:
+      latest-breaking-hhvm-version: ${{steps.determine-latest-breaking-hhvm-version.outputs.latest-breaking-hhvm-version}}
+    steps:
+      - uses: actions/checkout@v3
+      - id: determine-latest-breaking-hhvm-version
+        run: |
+          [[ \
+            "$(<codegen-no-rebuild/latest_breaking_version.hack)" \
+            =~ const\ string\ LATEST_BREAKING_HHVM_VERSION\ =\ \'([0-9]+\.[0-9]+)\. \
+          ]] && \
+          echo "::set-output name=latest-breaking-hhvm-version::${BASH_REMATCH[1]}"
   build:
+    needs: determine-latest-breaking-hhvm-version
     name: HHVM ${{matrix.hhvm}} - ${{matrix.os}}
     strategy:
       # Run tests on all OS's and HHVM versions, even if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu , macos ]
+        os: [ubuntu, macos]
         hhvm:
-          - '4.158'
+          - ${{needs.determine-latest-breaking-hhvm-version.outputs.latest-breaking-hhvm-version}}
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest
@@ -28,3 +42,45 @@ jobs:
         run: bin/hhast-lint
       - name: Check for manually modified codegen
         run: vendor/bin/hh-codegen-verify-signatures codegen/
+  update-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: hhvm/actions/hack-lint-test@master
+        with:
+          hhvm: nightly
+          skip_lint: true
+          skip_tests: true
+      - if: github.event_name == 'pull_request'
+        run: bin/update-codegen
+      - if: github.event_name == 'pull_request'
+        uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: Update schema
+      - if: github.event_name != 'pull_request'
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+          repository: facebook/hhvm
+          path: ./.var/tmp/hhvm
+      - if: github.event_name != 'pull_request'
+        run: bin/update-schema --hhvm-path=./.var/tmp/hhvm
+      - if: github.event_name != 'pull_request'
+        uses: peter-evans/create-pull-request@v4
+        with:
+          branch: update-schema/${{github.ref_name}}
+          title: Update schema
+          commit-message: Update schema
+      - if: github.event_name != 'pull_request'
+        run: git checkout -B "${{github.ref_name}}"
+      - if: github.event_name != 'pull_request'
+        run: bin/update-codegen --dont-update-ast --update-latest-breaking-version
+      - if: github.event_name != 'pull_request'
+        uses: peter-evans/create-pull-request@v4
+        with:
+          branch: update-latest-breaking-version/${{github.ref_name}}
+          title: Update schema to a backward incompatible version
+          commit-message: Update the latest breaking version
+          body: |
+            This PR updates assumes the latest schema is a breaking change.
+            Feel free to close this PR if the schema is actually backward compatible with previous schema versions.

--- a/codegen-no-rebuild/latest_breaking_version.hack
+++ b/codegen-no-rebuild/latest_breaking_version.hack
@@ -1,12 +1,12 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<130141734a032b68b09fdd50790b8f0e>>
+ * @generated SignedSource<<ddda2c0cd6fe6bf35fe16a59dbf8822d>>
  */
 namespace Facebook\HHAST;
 
-const string LATEST_BREAKING_SCHEMA_VERSION = '2022-04-25-0000';
+const string LATEST_BREAKING_SCHEMA_VERSION = '2022-05-16-0000';
 
-const int LATEST_BREAKING_HHVM_VERSION_ID = 412804;
+const int LATEST_BREAKING_HHVM_VERSION_ID = 416100;
 
-const string LATEST_BREAKING_HHVM_VERSION = '4.128.4';
+const string LATEST_BREAKING_HHVM_VERSION = '4.161.0-dev';

--- a/codegen-no-rebuild/latest_breaking_version.hack
+++ b/codegen-no-rebuild/latest_breaking_version.hack
@@ -1,0 +1,12 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * @generated SignedSource<<130141734a032b68b09fdd50790b8f0e>>
+ */
+namespace Facebook\HHAST;
+
+const string LATEST_BREAKING_SCHEMA_VERSION = '2022-04-25-0000';
+
+const int LATEST_BREAKING_HHVM_VERSION_ID = 412804;
+
+const string LATEST_BREAKING_HHVM_VERSION = '4.128.4';

--- a/codegen/inferred_relationships.hack
+++ b/codegen/inferred_relationships.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<78bb07f9c83a87574b08f94b355a4e70>>
+ * @generated SignedSource<<0d7757594cf1de2622b33f2c327b06b2>>
  */
 namespace Facebook\HHAST\__Private;
 
@@ -1339,6 +1339,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   ],
   'enum_class_declaration.enum_class_modifiers' => keyset[
     'list<token:abstract>',
+    'list<token:internal>',
     'missing',
   ],
   'enum_class_declaration.enum_class_name' => keyset[
@@ -2369,6 +2370,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'subscript_expression',
     'variable',
     'varray_intrinsic_expression',
+    'vector_intrinsic_expression',
   ],
   'lambda_expression.lambda_signature' => keyset[
     'lambda_signature',
@@ -2495,6 +2497,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'shape_type_specifier',
     'simple_type_specifier',
     'subscript_expression',
+    'token:XHP_class_name',
     'token:name',
     'token:namespace',
     'token:variable',
@@ -3027,6 +3030,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<alias_declaration|classish_declaration|const_declaration|end_of_file|function_declaration|markup_section>',
     'list<alias_declaration|classish_declaration|end_of_file|enum_class_declaration|enum_declaration|file_attribute_specification|function_declaration|markup_section>',
     'list<alias_declaration|classish_declaration|end_of_file|enum_declaration|function_declaration|markup_section>',
+    'list<alias_declaration|classish_declaration|end_of_file|file_attribute_specification|markup_section|module_declaration|module_membership_declaration>',
     'list<alias_declaration|classish_declaration|end_of_file|function_declaration|markup_section>',
     'list<alias_declaration|classish_declaration|end_of_file|function_declaration|markup_section|namespace_declaration>',
     'list<alias_declaration|classish_declaration|end_of_file|markup_section>',
@@ -3047,8 +3051,11 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<classish_declaration|end_of_file|enum_declaration|function_declaration|markup_section>',
     'list<classish_declaration|end_of_file|expression_statement|function_declaration|markup_section>',
     'list<classish_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section>',
+    'list<classish_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section|module_declaration>',
     'list<classish_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section|module_membership_declaration>',
     'list<classish_declaration|end_of_file|file_attribute_specification|markup_section>',
+    'list<classish_declaration|end_of_file|file_attribute_specification|markup_section|module_declaration>',
+    'list<classish_declaration|end_of_file|file_attribute_specification|markup_section|module_declaration|module_membership_declaration>',
     'list<classish_declaration|end_of_file|function_declaration|markup_section>',
     'list<classish_declaration|end_of_file|function_declaration|markup_section|namespace_declaration>',
     'list<classish_declaration|end_of_file|function_declaration|markup_section|namespace_declaration|namespace_use_declaration>',
@@ -3065,6 +3072,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<const_declaration|end_of_file|markup_section|namespace_declaration>',
     'list<const_declaration|end_of_file|markup_section|namespace_use_declaration>',
     'list<context_alias_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section>',
+    'list<end_of_file|enum_class_declaration|file_attribute_specification|function_declaration|markup_section|module_declaration|module_membership_declaration>',
     'list<end_of_file|enum_class_declaration|function_declaration|markup_section>',
     'list<end_of_file|enum_class_declaration|markup_section>',
     'list<end_of_file|enum_declaration|expression_statement|function_declaration|markup_section>',
@@ -3162,7 +3170,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'token:noreturn',
     'token:null',
     'token:num',
-    'token:object',
     'token:resource',
     'token:string',
     'token:this',
@@ -3307,6 +3314,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<generic_type_specifier>>',
     'list<list_item<generic_type_specifier>|list_item<simple_type_specifier>>',
     'list<list_item<simple_type_specifier>>',
+    'list<list_item<token:XHP_class_name>>',
   ],
   'trait_use.trait_use_semicolon' => keyset[
     'token:;',
@@ -3344,6 +3352,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<function_call_expression>|list_item<variable>>',
     'list<list_item<function_pointer_expression>|list_item<literal>>',
     'list<list_item<keyset_intrinsic_expression>|list_item<literal>>',
+    'list<list_item<lambda_expression>|list_item<literal>>',
     'list<list_item<lambda_expression>|list_item<object_creation_expression>>',
     'list<list_item<literal>>',
     'list<list_item<literal>|list_item<object_creation_expression>>',
@@ -3869,6 +3878,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   ],
   'vector_type_specifier.vector_type_type' => keyset[
     'classname_type_specifier',
+    'closure_type_specifier',
     'darray_type_specifier',
     'dictionary_type_specifier',
     'generic_type_specifier',

--- a/codegen/node_from_json.hack
+++ b/codegen/node_from_json.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a531605e16d61a21d115fe98b56b25d1>>
+ * @generated SignedSource<<bc51db5a16a95311293731c4762d1aeb>>
  */
 namespace Facebook\HHAST\__Private;
 use namespace Facebook\HHAST;
@@ -70,6 +70,7 @@ function node_from_json_unwrapped(
     'context_constraint' => HHAST\ContextConstraint::class,
     'contexts' => HHAST\Contexts::class,
     'continue_statement' => HHAST\ContinueStatement::class,
+    'ctx_in_refinement' => HHAST\CtxInRefinement::class,
     'darray_intrinsic_expression' => HHAST\DarrayIntrinsicExpression::class,
     'darray_type_specifier' => HHAST\DarrayTypeSpecifier::class,
     'decorated_expression' => HHAST\DecoratedExpression::class,
@@ -176,8 +177,10 @@ function node_from_json_unwrapped(
     'type_const_declaration' => HHAST\TypeConstDeclaration::class,
     'type_constant' => HHAST\TypeConstant::class,
     'type_constraint' => HHAST\TypeConstraint::class,
+    'type_in_refinement' => HHAST\TypeInRefinement::class,
     'type_parameter' => HHAST\TypeParameter::class,
     'type_parameters' => HHAST\TypeParameters::class,
+    'type_refinement' => HHAST\TypeRefinement::class,
     'union_type_specifier' => HHAST\UnionTypeSpecifier::class,
     'unset_statement' => HHAST\UnsetStatement::class,
     'upcast_expression' => HHAST\UpcastExpression::class,

--- a/codegen/schema.json
+++ b/codegen/schema.json
@@ -1,6 +1,6 @@
 { "description" :
   "@generated JSON schema of the Hack Full Fidelity Parser AST",
-  "version" : "2022-04-25-0000",
+  "version" : "2022-05-16-0000",
   "trivia" : [
     { "trivia_kind_name" : "WhiteSpace",
       "trivia_type_name" : "whitespace" },
@@ -163,8 +163,6 @@
       "token_text" : "noreturn" },
     { "token_kind" : "Num",
       "token_text" : "num" },
-    { "token_kind" : "Object",
-      "token_text" : "object" },
     { "token_kind" : "Parent",
       "token_text" : "parent" },
     { "token_kind" : "Print",
@@ -231,6 +229,8 @@
       "token_text" : "vec" },
     { "token_kind" : "Void",
       "token_text" : "void" },
+    { "token_kind" : "With",
+      "token_text" : "with" },
     { "token_kind" : "Where",
       "token_text" : "where" },
     { "token_kind" : "While",
@@ -1884,6 +1884,41 @@
         { "field_name" : "call_convention" },
         { "field_name" : "readonly" },
         { "field_name" : "type" }
+      ] },
+    { "kind_name" : "TypeRefinement",
+      "type_name" : "type_refinement",
+      "description" : "type_refinement",
+      "prefix" : "type_refinement",
+      "fields" : [
+        { "field_name" : "type" },
+        { "field_name" : "keyword" },
+        { "field_name" : "left_brace" },
+        { "field_name" : "members" },
+        { "field_name" : "right_brace" }
+      ] },
+    { "kind_name" : "TypeInRefinement",
+      "type_name" : "type_in_refinement",
+      "description" : "type_in_refinement",
+      "prefix" : "type_in_refinement",
+      "fields" : [
+        { "field_name" : "keyword" },
+        { "field_name" : "name" },
+        { "field_name" : "type_parameters" },
+        { "field_name" : "constraints" },
+        { "field_name" : "equal" },
+        { "field_name" : "type" }
+      ] },
+    { "kind_name" : "CtxInRefinement",
+      "type_name" : "ctx_in_refinement",
+      "description" : "ctx_in_refinement",
+      "prefix" : "ctx_in_refinement",
+      "fields" : [
+        { "field_name" : "keyword" },
+        { "field_name" : "name" },
+        { "field_name" : "type_parameters" },
+        { "field_name" : "constraints" },
+        { "field_name" : "equal" },
+        { "field_name" : "ctx_list" }
       ] },
     { "kind_name" : "ClassnameTypeSpecifier",
       "type_name" : "classname_type_specifier",

--- a/codegen/syntax/CtxInRefinement.hack
+++ b/codegen/syntax/CtxInRefinement.hack
@@ -1,0 +1,388 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * @generated SignedSource<<971da060047eba588612a0499b1f9ff3>>
+ */
+namespace Facebook\HHAST;
+use namespace Facebook\TypeAssert;
+use namespace HH\Lib\Dict;
+/* HHAST_IGNORE_ALL[5607] 5607 is ignored because of false positives when comparing a generic to a typed value */
+/* HHAST_IGNORE_ALL[5624] HHAST_IGNORE_ALL[5639] 5624 and 5639 are ignored because they insist on using co(tra)variant generics. Could this break external consumers? */
+
+<<__ConsistentConstruct>>
+final class CtxInRefinement extends Node {
+
+  const string SYNTAX_KIND = 'ctx_in_refinement';
+
+  private ?Node $_keyword;
+  private ?Node $_name;
+  private ?Node $_type_parameters;
+  private ?Node $_constraints;
+  private ?Node $_equal;
+  private ?Node $_ctx_list;
+
+  public function __construct(
+    ?Node $keyword,
+    ?Node $name,
+    ?Node $type_parameters,
+    ?Node $constraints,
+    ?Node $equal,
+    ?Node $ctx_list,
+    ?__Private\SourceRef $source_ref = null,
+  ) {
+    $this->_keyword = $keyword;
+    $this->_name = $name;
+    $this->_type_parameters = $type_parameters;
+    $this->_constraints = $constraints;
+    $this->_equal = $equal;
+    $this->_ctx_list = $ctx_list;
+    parent::__construct($source_ref);
+  }
+
+  <<__Override>>
+  public static function fromJSON(
+    dict<arraykey, mixed> $json,
+    string $file,
+    int $initial_offset,
+    string $source,
+    string $_type_hint,
+  ): this {
+    $offset = $initial_offset;
+    $keyword = Node::fromJSON(
+      ($json['ctx_in_refinement_keyword'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $keyword?->getWidth() ?? 0;
+    $name = Node::fromJSON(
+      ($json['ctx_in_refinement_name'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $name?->getWidth() ?? 0;
+    $type_parameters = Node::fromJSON(
+      ($json['ctx_in_refinement_type_parameters'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $type_parameters?->getWidth() ?? 0;
+    $constraints = Node::fromJSON(
+      ($json['ctx_in_refinement_constraints'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $constraints?->getWidth() ?? 0;
+    $equal = Node::fromJSON(
+      ($json['ctx_in_refinement_equal'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $equal?->getWidth() ?? 0;
+    $ctx_list = Node::fromJSON(
+      ($json['ctx_in_refinement_ctx_list'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $ctx_list?->getWidth() ?? 0;
+    $source_ref = shape(
+      'file' => $file,
+      'source' => $source,
+      'offset' => $initial_offset,
+      'width' => $offset - $initial_offset,
+    );
+    return new static(
+      /* HH_IGNORE_ERROR[4110] */ $keyword,
+      /* HH_IGNORE_ERROR[4110] */ $name,
+      /* HH_IGNORE_ERROR[4110] */ $type_parameters,
+      /* HH_IGNORE_ERROR[4110] */ $constraints,
+      /* HH_IGNORE_ERROR[4110] */ $equal,
+      /* HH_IGNORE_ERROR[4110] */ $ctx_list,
+      $source_ref,
+    );
+  }
+
+  <<__Override>>
+  public function getChildren(): dict<string, Node> {
+    return dict[
+      'keyword' => $this->_keyword,
+      'name' => $this->_name,
+      'type_parameters' => $this->_type_parameters,
+      'constraints' => $this->_constraints,
+      'equal' => $this->_equal,
+      'ctx_list' => $this->_ctx_list,
+    ]
+      |> Dict\filter_nulls($$);
+  }
+
+  <<__Override>>
+  public function rewriteChildren<Tret as ?Node>(
+    (function(Node, vec<Node>): Tret) $rewriter,
+    vec<Node> $parents = vec[],
+  ): this {
+    $parents[] = $this;
+    $keyword =
+      $this->_keyword === null ? null : $rewriter($this->_keyword, $parents);
+    $name = $this->_name === null ? null : $rewriter($this->_name, $parents);
+    $type_parameters = $this->_type_parameters === null
+      ? null
+      : $rewriter($this->_type_parameters, $parents);
+    $constraints = $this->_constraints === null
+      ? null
+      : $rewriter($this->_constraints, $parents);
+    $equal = $this->_equal === null ? null : $rewriter($this->_equal, $parents);
+    $ctx_list =
+      $this->_ctx_list === null ? null : $rewriter($this->_ctx_list, $parents);
+    if (
+      $keyword === $this->_keyword &&
+      $name === $this->_name &&
+      $type_parameters === $this->_type_parameters &&
+      $constraints === $this->_constraints &&
+      $equal === $this->_equal &&
+      $ctx_list === $this->_ctx_list
+    ) {
+      return $this;
+    }
+    return new static(
+      $keyword as ?Node,
+      $name as ?Node,
+      $type_parameters as ?Node,
+      $constraints as ?Node,
+      $equal as ?Node,
+      $ctx_list as ?Node,
+    );
+  }
+
+  public function getKeywordUNTYPED(): ?Node {
+    return $this->_keyword;
+  }
+
+  public function withKeyword(?Node $value): this {
+    if ($value === $this->_keyword) {
+      return $this;
+    }
+    return new static(
+      $value,
+      $this->_name,
+      $this->_type_parameters,
+      $this->_constraints,
+      $this->_equal,
+      $this->_ctx_list,
+    );
+  }
+
+  public function hasKeyword(): bool {
+    return $this->_keyword !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getKeyword(): ?Node {
+    return $this->_keyword;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getKeywordx(): Node {
+    return TypeAssert\not_null($this->getKeyword());
+  }
+
+  public function getNameUNTYPED(): ?Node {
+    return $this->_name;
+  }
+
+  public function withName(?Node $value): this {
+    if ($value === $this->_name) {
+      return $this;
+    }
+    return new static(
+      $this->_keyword,
+      $value,
+      $this->_type_parameters,
+      $this->_constraints,
+      $this->_equal,
+      $this->_ctx_list,
+    );
+  }
+
+  public function hasName(): bool {
+    return $this->_name !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getName(): ?Node {
+    return $this->_name;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getNamex(): Node {
+    return TypeAssert\not_null($this->getName());
+  }
+
+  public function getTypeParametersUNTYPED(): ?Node {
+    return $this->_type_parameters;
+  }
+
+  public function withTypeParameters(?Node $value): this {
+    if ($value === $this->_type_parameters) {
+      return $this;
+    }
+    return new static(
+      $this->_keyword,
+      $this->_name,
+      $value,
+      $this->_constraints,
+      $this->_equal,
+      $this->_ctx_list,
+    );
+  }
+
+  public function hasTypeParameters(): bool {
+    return $this->_type_parameters !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getTypeParameters(): ?Node {
+    return $this->_type_parameters;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getTypeParametersx(): Node {
+    return TypeAssert\not_null($this->getTypeParameters());
+  }
+
+  public function getConstraintsUNTYPED(): ?Node {
+    return $this->_constraints;
+  }
+
+  public function withConstraints(?Node $value): this {
+    if ($value === $this->_constraints) {
+      return $this;
+    }
+    return new static(
+      $this->_keyword,
+      $this->_name,
+      $this->_type_parameters,
+      $value,
+      $this->_equal,
+      $this->_ctx_list,
+    );
+  }
+
+  public function hasConstraints(): bool {
+    return $this->_constraints !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getConstraints(): ?Node {
+    return $this->_constraints;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getConstraintsx(): Node {
+    return TypeAssert\not_null($this->getConstraints());
+  }
+
+  public function getEqualUNTYPED(): ?Node {
+    return $this->_equal;
+  }
+
+  public function withEqual(?Node $value): this {
+    if ($value === $this->_equal) {
+      return $this;
+    }
+    return new static(
+      $this->_keyword,
+      $this->_name,
+      $this->_type_parameters,
+      $this->_constraints,
+      $value,
+      $this->_ctx_list,
+    );
+  }
+
+  public function hasEqual(): bool {
+    return $this->_equal !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getEqual(): ?Node {
+    return $this->_equal;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getEqualx(): Node {
+    return TypeAssert\not_null($this->getEqual());
+  }
+
+  public function getCtxListUNTYPED(): ?Node {
+    return $this->_ctx_list;
+  }
+
+  public function withCtxList(?Node $value): this {
+    if ($value === $this->_ctx_list) {
+      return $this;
+    }
+    return new static(
+      $this->_keyword,
+      $this->_name,
+      $this->_type_parameters,
+      $this->_constraints,
+      $this->_equal,
+      $value,
+    );
+  }
+
+  public function hasCtxList(): bool {
+    return $this->_ctx_list !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getCtxList(): ?Node {
+    return $this->_ctx_list;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getCtxListx(): Node {
+    return TypeAssert\not_null($this->getCtxList());
+  }
+}

--- a/codegen/syntax/EnumClassDeclaration.hack
+++ b/codegen/syntax/EnumClassDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a7c30d2187e8388b7cf01c673e566e82>>
+ * @generated SignedSource<<edbc1ea3ce44dd5cc5ee916f44164090>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -15,7 +15,7 @@ final class EnumClassDeclaration extends Node {
   const string SYNTAX_KIND = 'enum_class_declaration';
 
   private ?OldAttributeSpecification $_attribute_spec;
-  private ?NodeList<AbstractToken> $_modifiers;
+  private ?NodeList<Token> $_modifiers;
   private EnumToken $_enum_keyword;
   private ClassToken $_class_keyword;
   private NameToken $_name;
@@ -29,7 +29,7 @@ final class EnumClassDeclaration extends Node {
 
   public function __construct(
     ?OldAttributeSpecification $attribute_spec,
-    ?NodeList<AbstractToken> $modifiers,
+    ?NodeList<Token> $modifiers,
     EnumToken $enum_keyword,
     ClassToken $class_keyword,
     NameToken $name,
@@ -81,7 +81,7 @@ final class EnumClassDeclaration extends Node {
       $file,
       $offset,
       $source,
-      'NodeList<AbstractToken>',
+      'NodeList<Token>',
     );
     $offset += $modifiers?->getWidth() ?? 0;
     $enum_keyword = Node::fromJSON(
@@ -258,7 +258,7 @@ final class EnumClassDeclaration extends Node {
     }
     return new static(
       $attribute_spec as ?OldAttributeSpecification,
-      /* HH_FIXME[4110] ?NodeList<AbstractToken> may not be enforceable */ $modifiers,
+      /* HH_FIXME[4110] ?NodeList<Token> may not be enforceable */ $modifiers,
       $enum_keyword as EnumToken,
       $class_keyword as ClassToken,
       $name as NameToken,
@@ -318,7 +318,7 @@ final class EnumClassDeclaration extends Node {
     return $this->_modifiers;
   }
 
-  public function withModifiers(?NodeList<AbstractToken> $value): this {
+  public function withModifiers(?NodeList<Token> $value): this {
     if ($value === $this->_modifiers) {
       return $this;
     }
@@ -343,16 +343,16 @@ final class EnumClassDeclaration extends Node {
   }
 
   /**
-   * @return NodeList<AbstractToken> | null
+   * @return NodeList<AbstractToken> | NodeList<InternalToken> | null
    */
-  public function getModifiers(): ?NodeList<AbstractToken> {
+  public function getModifiers(): ?NodeList<Token> {
     return $this->_modifiers;
   }
 
   /**
-   * @return NodeList<AbstractToken>
+   * @return NodeList<AbstractToken> | NodeList<InternalToken>
    */
-  public function getModifiersx(): NodeList<AbstractToken> {
+  public function getModifiersx(): NodeList<Token> {
     return TypeAssert\not_null($this->getModifiers());
   }
 

--- a/codegen/syntax/LambdaExpression.hack
+++ b/codegen/syntax/LambdaExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<173b5f60000dcf562d8a12a994dcd1a5>>
+ * @generated SignedSource<<29ed3005c47a47905b1ba5ef2bed0d62>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -321,7 +321,7 @@ final class LambdaExpression
    * NullableAsExpression | ObjectCreationExpression | ParenthesizedExpression
    * | PostfixUnaryExpression | PrefixUnaryExpression |
    * ScopeResolutionExpression | ShapeExpression | SubscriptExpression |
-   * VariableExpression | VarrayIntrinsicExpression
+   * VariableExpression | VarrayIntrinsicExpression | VectorIntrinsicExpression
    */
   public function getBody(): ILambdaBody {
     return TypeAssert\instance_of(ILambdaBody::class, $this->_body);
@@ -336,7 +336,7 @@ final class LambdaExpression
    * NullableAsExpression | ObjectCreationExpression | ParenthesizedExpression
    * | PostfixUnaryExpression | PrefixUnaryExpression |
    * ScopeResolutionExpression | ShapeExpression | SubscriptExpression |
-   * VariableExpression | VarrayIntrinsicExpression
+   * VariableExpression | VarrayIntrinsicExpression | VectorIntrinsicExpression
    */
   public function getBodyx(): ILambdaBody {
     return $this->getBody();

--- a/codegen/syntax/SimpleTypeSpecifier.hack
+++ b/codegen/syntax/SimpleTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a110b99b93d8da2a3a8ae45cb79fa11d>>
+ * @generated SignedSource<<f5e82198817cbe5ab496e965b36620ad>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -92,9 +92,9 @@ final class SimpleTypeSpecifier
   /**
    * @return QualifiedName | XHPClassNameToken | ArraykeyToken | BoolToken |
    * DarrayToken | DictToken | FloatToken | IntToken | KeysetToken | MixedToken
-   * | NameToken | NoreturnToken | NullLiteralToken | NumToken | ObjectToken |
-   * ResourceToken | StringToken | ThisToken | VarToken | VarrayToken |
-   * VecToken | VoidToken | XHPToken
+   * | NameToken | NoreturnToken | NullLiteralToken | NumToken | ResourceToken
+   * | StringToken | ThisToken | VarToken | VarrayToken | VecToken | VoidToken
+   * | XHPToken
    */
   public function getSpecifier(): Node {
     return $this->_specifier;
@@ -103,9 +103,9 @@ final class SimpleTypeSpecifier
   /**
    * @return QualifiedName | XHPClassNameToken | ArraykeyToken | BoolToken |
    * DarrayToken | DictToken | FloatToken | IntToken | KeysetToken | MixedToken
-   * | NameToken | NoreturnToken | NullLiteralToken | NumToken | ObjectToken |
-   * ResourceToken | StringToken | ThisToken | VarToken | VarrayToken |
-   * VecToken | VoidToken | XHPToken
+   * | NameToken | NoreturnToken | NullLiteralToken | NumToken | ResourceToken
+   * | StringToken | ThisToken | VarToken | VarrayToken | VecToken | VoidToken
+   * | XHPToken
    */
   public function getSpecifierx(): Node {
     return $this->getSpecifier();

--- a/codegen/syntax/TraitUse.hack
+++ b/codegen/syntax/TraitUse.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<129da117a81f97fc63c64e8921a42d2b>>
+ * @generated SignedSource<<a07a6b06d5a22e22bc88f074aceff338>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -15,12 +15,12 @@ final class TraitUse extends Node implements IClassBodyDeclaration {
   const string SYNTAX_KIND = 'trait_use';
 
   private UseToken $_keyword;
-  private NodeList<ListItem<ISimpleCreationSpecifier>> $_names;
+  private NodeList<ListItem<ITypeSpecifier>> $_names;
   private SemicolonToken $_semicolon;
 
   public function __construct(
     UseToken $keyword,
-    NodeList<ListItem<ISimpleCreationSpecifier>> $names,
+    NodeList<ListItem<ITypeSpecifier>> $names,
     SemicolonToken $semicolon,
     ?__Private\SourceRef $source_ref = null,
   ) {
@@ -53,7 +53,7 @@ final class TraitUse extends Node implements IClassBodyDeclaration {
       $file,
       $offset,
       $source,
-      'NodeList<ListItem<ISimpleCreationSpecifier>>',
+      'NodeList<ListItem<ITypeSpecifier>>',
     );
     $names = $names as nonnull;
     $offset += $names->getWidth();
@@ -108,7 +108,7 @@ final class TraitUse extends Node implements IClassBodyDeclaration {
     }
     return new static(
       $keyword as UseToken,
-      /* HH_FIXME[4110] NodeList<ListItem<ISimpleCreationSpecifier>> may not be enforceable */ $names,
+      /* HH_FIXME[4110] NodeList<ListItem<ITypeSpecifier>> may not be enforceable */ $names,
       $semicolon as SemicolonToken,
     );
   }
@@ -146,9 +146,7 @@ final class TraitUse extends Node implements IClassBodyDeclaration {
     return $this->_names;
   }
 
-  public function withNames(
-    NodeList<ListItem<ISimpleCreationSpecifier>> $value,
-  ): this {
+  public function withNames(NodeList<ListItem<ITypeSpecifier>> $value): this {
     if ($value === $this->_names) {
       return $this;
     }
@@ -162,18 +160,20 @@ final class TraitUse extends Node implements IClassBodyDeclaration {
   /**
    * @return NodeList<ListItem<GenericTypeSpecifier>> |
    * NodeList<ListItem<ISimpleCreationSpecifier>> |
-   * NodeList<ListItem<SimpleTypeSpecifier>>
+   * NodeList<ListItem<SimpleTypeSpecifier>> |
+   * NodeList<ListItem<XHPClassNameToken>>
    */
-  public function getNames(): NodeList<ListItem<ISimpleCreationSpecifier>> {
+  public function getNames(): NodeList<ListItem<ITypeSpecifier>> {
     return TypeAssert\instance_of(NodeList::class, $this->_names);
   }
 
   /**
    * @return NodeList<ListItem<GenericTypeSpecifier>> |
    * NodeList<ListItem<ISimpleCreationSpecifier>> |
-   * NodeList<ListItem<SimpleTypeSpecifier>>
+   * NodeList<ListItem<SimpleTypeSpecifier>> |
+   * NodeList<ListItem<XHPClassNameToken>>
    */
-  public function getNamesx(): NodeList<ListItem<ISimpleCreationSpecifier>> {
+  public function getNamesx(): NodeList<ListItem<ITypeSpecifier>> {
     return $this->getNames();
   }
 

--- a/codegen/syntax/TypeInRefinement.hack
+++ b/codegen/syntax/TypeInRefinement.hack
@@ -1,0 +1,387 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * @generated SignedSource<<bf73c8c5983b114b6f9e83fc985ecd64>>
+ */
+namespace Facebook\HHAST;
+use namespace Facebook\TypeAssert;
+use namespace HH\Lib\Dict;
+/* HHAST_IGNORE_ALL[5607] 5607 is ignored because of false positives when comparing a generic to a typed value */
+/* HHAST_IGNORE_ALL[5624] HHAST_IGNORE_ALL[5639] 5624 and 5639 are ignored because they insist on using co(tra)variant generics. Could this break external consumers? */
+
+<<__ConsistentConstruct>>
+final class TypeInRefinement extends Node {
+
+  const string SYNTAX_KIND = 'type_in_refinement';
+
+  private ?Node $_keyword;
+  private ?Node $_name;
+  private ?Node $_type_parameters;
+  private ?Node $_constraints;
+  private ?Node $_equal;
+  private ?Node $_type;
+
+  public function __construct(
+    ?Node $keyword,
+    ?Node $name,
+    ?Node $type_parameters,
+    ?Node $constraints,
+    ?Node $equal,
+    ?Node $type,
+    ?__Private\SourceRef $source_ref = null,
+  ) {
+    $this->_keyword = $keyword;
+    $this->_name = $name;
+    $this->_type_parameters = $type_parameters;
+    $this->_constraints = $constraints;
+    $this->_equal = $equal;
+    $this->_type = $type;
+    parent::__construct($source_ref);
+  }
+
+  <<__Override>>
+  public static function fromJSON(
+    dict<arraykey, mixed> $json,
+    string $file,
+    int $initial_offset,
+    string $source,
+    string $_type_hint,
+  ): this {
+    $offset = $initial_offset;
+    $keyword = Node::fromJSON(
+      ($json['type_in_refinement_keyword'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $keyword?->getWidth() ?? 0;
+    $name = Node::fromJSON(
+      ($json['type_in_refinement_name'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $name?->getWidth() ?? 0;
+    $type_parameters = Node::fromJSON(
+      ($json['type_in_refinement_type_parameters'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $type_parameters?->getWidth() ?? 0;
+    $constraints = Node::fromJSON(
+      ($json['type_in_refinement_constraints'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $constraints?->getWidth() ?? 0;
+    $equal = Node::fromJSON(
+      ($json['type_in_refinement_equal'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $equal?->getWidth() ?? 0;
+    $type = Node::fromJSON(
+      ($json['type_in_refinement_type'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $type?->getWidth() ?? 0;
+    $source_ref = shape(
+      'file' => $file,
+      'source' => $source,
+      'offset' => $initial_offset,
+      'width' => $offset - $initial_offset,
+    );
+    return new static(
+      /* HH_IGNORE_ERROR[4110] */ $keyword,
+      /* HH_IGNORE_ERROR[4110] */ $name,
+      /* HH_IGNORE_ERROR[4110] */ $type_parameters,
+      /* HH_IGNORE_ERROR[4110] */ $constraints,
+      /* HH_IGNORE_ERROR[4110] */ $equal,
+      /* HH_IGNORE_ERROR[4110] */ $type,
+      $source_ref,
+    );
+  }
+
+  <<__Override>>
+  public function getChildren(): dict<string, Node> {
+    return dict[
+      'keyword' => $this->_keyword,
+      'name' => $this->_name,
+      'type_parameters' => $this->_type_parameters,
+      'constraints' => $this->_constraints,
+      'equal' => $this->_equal,
+      'type' => $this->_type,
+    ]
+      |> Dict\filter_nulls($$);
+  }
+
+  <<__Override>>
+  public function rewriteChildren<Tret as ?Node>(
+    (function(Node, vec<Node>): Tret) $rewriter,
+    vec<Node> $parents = vec[],
+  ): this {
+    $parents[] = $this;
+    $keyword =
+      $this->_keyword === null ? null : $rewriter($this->_keyword, $parents);
+    $name = $this->_name === null ? null : $rewriter($this->_name, $parents);
+    $type_parameters = $this->_type_parameters === null
+      ? null
+      : $rewriter($this->_type_parameters, $parents);
+    $constraints = $this->_constraints === null
+      ? null
+      : $rewriter($this->_constraints, $parents);
+    $equal = $this->_equal === null ? null : $rewriter($this->_equal, $parents);
+    $type = $this->_type === null ? null : $rewriter($this->_type, $parents);
+    if (
+      $keyword === $this->_keyword &&
+      $name === $this->_name &&
+      $type_parameters === $this->_type_parameters &&
+      $constraints === $this->_constraints &&
+      $equal === $this->_equal &&
+      $type === $this->_type
+    ) {
+      return $this;
+    }
+    return new static(
+      $keyword as ?Node,
+      $name as ?Node,
+      $type_parameters as ?Node,
+      $constraints as ?Node,
+      $equal as ?Node,
+      $type as ?Node,
+    );
+  }
+
+  public function getKeywordUNTYPED(): ?Node {
+    return $this->_keyword;
+  }
+
+  public function withKeyword(?Node $value): this {
+    if ($value === $this->_keyword) {
+      return $this;
+    }
+    return new static(
+      $value,
+      $this->_name,
+      $this->_type_parameters,
+      $this->_constraints,
+      $this->_equal,
+      $this->_type,
+    );
+  }
+
+  public function hasKeyword(): bool {
+    return $this->_keyword !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getKeyword(): ?Node {
+    return $this->_keyword;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getKeywordx(): Node {
+    return TypeAssert\not_null($this->getKeyword());
+  }
+
+  public function getNameUNTYPED(): ?Node {
+    return $this->_name;
+  }
+
+  public function withName(?Node $value): this {
+    if ($value === $this->_name) {
+      return $this;
+    }
+    return new static(
+      $this->_keyword,
+      $value,
+      $this->_type_parameters,
+      $this->_constraints,
+      $this->_equal,
+      $this->_type,
+    );
+  }
+
+  public function hasName(): bool {
+    return $this->_name !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getName(): ?Node {
+    return $this->_name;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getNamex(): Node {
+    return TypeAssert\not_null($this->getName());
+  }
+
+  public function getTypeParametersUNTYPED(): ?Node {
+    return $this->_type_parameters;
+  }
+
+  public function withTypeParameters(?Node $value): this {
+    if ($value === $this->_type_parameters) {
+      return $this;
+    }
+    return new static(
+      $this->_keyword,
+      $this->_name,
+      $value,
+      $this->_constraints,
+      $this->_equal,
+      $this->_type,
+    );
+  }
+
+  public function hasTypeParameters(): bool {
+    return $this->_type_parameters !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getTypeParameters(): ?Node {
+    return $this->_type_parameters;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getTypeParametersx(): Node {
+    return TypeAssert\not_null($this->getTypeParameters());
+  }
+
+  public function getConstraintsUNTYPED(): ?Node {
+    return $this->_constraints;
+  }
+
+  public function withConstraints(?Node $value): this {
+    if ($value === $this->_constraints) {
+      return $this;
+    }
+    return new static(
+      $this->_keyword,
+      $this->_name,
+      $this->_type_parameters,
+      $value,
+      $this->_equal,
+      $this->_type,
+    );
+  }
+
+  public function hasConstraints(): bool {
+    return $this->_constraints !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getConstraints(): ?Node {
+    return $this->_constraints;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getConstraintsx(): Node {
+    return TypeAssert\not_null($this->getConstraints());
+  }
+
+  public function getEqualUNTYPED(): ?Node {
+    return $this->_equal;
+  }
+
+  public function withEqual(?Node $value): this {
+    if ($value === $this->_equal) {
+      return $this;
+    }
+    return new static(
+      $this->_keyword,
+      $this->_name,
+      $this->_type_parameters,
+      $this->_constraints,
+      $value,
+      $this->_type,
+    );
+  }
+
+  public function hasEqual(): bool {
+    return $this->_equal !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getEqual(): ?Node {
+    return $this->_equal;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getEqualx(): Node {
+    return TypeAssert\not_null($this->getEqual());
+  }
+
+  public function getTypeUNTYPED(): ?Node {
+    return $this->_type;
+  }
+
+  public function withType(?Node $value): this {
+    if ($value === $this->_type) {
+      return $this;
+    }
+    return new static(
+      $this->_keyword,
+      $this->_name,
+      $this->_type_parameters,
+      $this->_constraints,
+      $this->_equal,
+      $value,
+    );
+  }
+
+  public function hasType(): bool {
+    return $this->_type !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getType(): ?Node {
+    return $this->_type;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getTypex(): Node {
+    return TypeAssert\not_null($this->getType());
+  }
+}

--- a/codegen/syntax/TypeRefinement.hack
+++ b/codegen/syntax/TypeRefinement.hack
@@ -1,0 +1,330 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * @generated SignedSource<<0e1a92dc39647bc3121831fdcc626aca>>
+ */
+namespace Facebook\HHAST;
+use namespace Facebook\TypeAssert;
+use namespace HH\Lib\Dict;
+/* HHAST_IGNORE_ALL[5607] 5607 is ignored because of false positives when comparing a generic to a typed value */
+/* HHAST_IGNORE_ALL[5624] HHAST_IGNORE_ALL[5639] 5624 and 5639 are ignored because they insist on using co(tra)variant generics. Could this break external consumers? */
+
+<<__ConsistentConstruct>>
+final class TypeRefinement extends Node {
+
+  const string SYNTAX_KIND = 'type_refinement';
+
+  private ?Node $_type;
+  private ?Node $_keyword;
+  private ?Node $_left_brace;
+  private ?Node $_members;
+  private ?Node $_right_brace;
+
+  public function __construct(
+    ?Node $type,
+    ?Node $keyword,
+    ?Node $left_brace,
+    ?Node $members,
+    ?Node $right_brace,
+    ?__Private\SourceRef $source_ref = null,
+  ) {
+    $this->_type = $type;
+    $this->_keyword = $keyword;
+    $this->_left_brace = $left_brace;
+    $this->_members = $members;
+    $this->_right_brace = $right_brace;
+    parent::__construct($source_ref);
+  }
+
+  <<__Override>>
+  public static function fromJSON(
+    dict<arraykey, mixed> $json,
+    string $file,
+    int $initial_offset,
+    string $source,
+    string $_type_hint,
+  ): this {
+    $offset = $initial_offset;
+    $type = Node::fromJSON(
+      ($json['type_refinement_type'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $type?->getWidth() ?? 0;
+    $keyword = Node::fromJSON(
+      ($json['type_refinement_keyword'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $keyword?->getWidth() ?? 0;
+    $left_brace = Node::fromJSON(
+      ($json['type_refinement_left_brace'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $left_brace?->getWidth() ?? 0;
+    $members = Node::fromJSON(
+      ($json['type_refinement_members'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $members?->getWidth() ?? 0;
+    $right_brace = Node::fromJSON(
+      ($json['type_refinement_right_brace'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $right_brace?->getWidth() ?? 0;
+    $source_ref = shape(
+      'file' => $file,
+      'source' => $source,
+      'offset' => $initial_offset,
+      'width' => $offset - $initial_offset,
+    );
+    return new static(
+      /* HH_IGNORE_ERROR[4110] */ $type,
+      /* HH_IGNORE_ERROR[4110] */ $keyword,
+      /* HH_IGNORE_ERROR[4110] */ $left_brace,
+      /* HH_IGNORE_ERROR[4110] */ $members,
+      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $source_ref,
+    );
+  }
+
+  <<__Override>>
+  public function getChildren(): dict<string, Node> {
+    return dict[
+      'type' => $this->_type,
+      'keyword' => $this->_keyword,
+      'left_brace' => $this->_left_brace,
+      'members' => $this->_members,
+      'right_brace' => $this->_right_brace,
+    ]
+      |> Dict\filter_nulls($$);
+  }
+
+  <<__Override>>
+  public function rewriteChildren<Tret as ?Node>(
+    (function(Node, vec<Node>): Tret) $rewriter,
+    vec<Node> $parents = vec[],
+  ): this {
+    $parents[] = $this;
+    $type = $this->_type === null ? null : $rewriter($this->_type, $parents);
+    $keyword =
+      $this->_keyword === null ? null : $rewriter($this->_keyword, $parents);
+    $left_brace = $this->_left_brace === null
+      ? null
+      : $rewriter($this->_left_brace, $parents);
+    $members =
+      $this->_members === null ? null : $rewriter($this->_members, $parents);
+    $right_brace = $this->_right_brace === null
+      ? null
+      : $rewriter($this->_right_brace, $parents);
+    if (
+      $type === $this->_type &&
+      $keyword === $this->_keyword &&
+      $left_brace === $this->_left_brace &&
+      $members === $this->_members &&
+      $right_brace === $this->_right_brace
+    ) {
+      return $this;
+    }
+    return new static(
+      $type as ?Node,
+      $keyword as ?Node,
+      $left_brace as ?Node,
+      $members as ?Node,
+      $right_brace as ?Node,
+    );
+  }
+
+  public function getTypeUNTYPED(): ?Node {
+    return $this->_type;
+  }
+
+  public function withType(?Node $value): this {
+    if ($value === $this->_type) {
+      return $this;
+    }
+    return new static(
+      $value,
+      $this->_keyword,
+      $this->_left_brace,
+      $this->_members,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasType(): bool {
+    return $this->_type !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getType(): ?Node {
+    return $this->_type;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getTypex(): Node {
+    return TypeAssert\not_null($this->getType());
+  }
+
+  public function getKeywordUNTYPED(): ?Node {
+    return $this->_keyword;
+  }
+
+  public function withKeyword(?Node $value): this {
+    if ($value === $this->_keyword) {
+      return $this;
+    }
+    return new static(
+      $this->_type,
+      $value,
+      $this->_left_brace,
+      $this->_members,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasKeyword(): bool {
+    return $this->_keyword !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getKeyword(): ?Node {
+    return $this->_keyword;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getKeywordx(): Node {
+    return TypeAssert\not_null($this->getKeyword());
+  }
+
+  public function getLeftBraceUNTYPED(): ?Node {
+    return $this->_left_brace;
+  }
+
+  public function withLeftBrace(?Node $value): this {
+    if ($value === $this->_left_brace) {
+      return $this;
+    }
+    return new static(
+      $this->_type,
+      $this->_keyword,
+      $value,
+      $this->_members,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasLeftBrace(): bool {
+    return $this->_left_brace !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getLeftBrace(): ?Node {
+    return $this->_left_brace;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getLeftBracex(): Node {
+    return TypeAssert\not_null($this->getLeftBrace());
+  }
+
+  public function getMembersUNTYPED(): ?Node {
+    return $this->_members;
+  }
+
+  public function withMembers(?Node $value): this {
+    if ($value === $this->_members) {
+      return $this;
+    }
+    return new static(
+      $this->_type,
+      $this->_keyword,
+      $this->_left_brace,
+      $value,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasMembers(): bool {
+    return $this->_members !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getMembers(): ?Node {
+    return $this->_members;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getMembersx(): Node {
+    return TypeAssert\not_null($this->getMembers());
+  }
+
+  public function getRightBraceUNTYPED(): ?Node {
+    return $this->_right_brace;
+  }
+
+  public function withRightBrace(?Node $value): this {
+    if ($value === $this->_right_brace) {
+      return $this;
+    }
+    return new static(
+      $this->_type,
+      $this->_keyword,
+      $this->_left_brace,
+      $this->_members,
+      $value,
+    );
+  }
+
+  public function hasRightBrace(): bool {
+    return $this->_right_brace !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getRightBrace(): ?Node {
+    return $this->_right_brace;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getRightBracex(): Node {
+    return TypeAssert\not_null($this->getRightBrace());
+  }
+}

--- a/codegen/syntax/VectorTypeSpecifier.hack
+++ b/codegen/syntax/VectorTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<aad6cb45ee154c7d3ea7227b28b590c5>>
+ * @generated SignedSource<<5016c2894db9ddec04070aca9358f174>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -241,20 +241,22 @@ final class VectorTypeSpecifier extends Node implements ITypeSpecifier {
   }
 
   /**
-   * @return ClassnameTypeSpecifier | DarrayTypeSpecifier |
-   * DictionaryTypeSpecifier | GenericTypeSpecifier | LikeTypeSpecifier |
-   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
-   * TupleTypeSpecifier | TypeConstant | VectorTypeSpecifier
+   * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * DarrayTypeSpecifier | DictionaryTypeSpecifier | GenericTypeSpecifier |
+   * LikeTypeSpecifier | NullableTypeSpecifier | ShapeTypeSpecifier |
+   * SimpleTypeSpecifier | TupleTypeSpecifier | TypeConstant |
+   * VectorTypeSpecifier
    */
   public function getType(): ITypeSpecifier {
     return TypeAssert\instance_of(ITypeSpecifier::class, $this->_type);
   }
 
   /**
-   * @return ClassnameTypeSpecifier | DarrayTypeSpecifier |
-   * DictionaryTypeSpecifier | GenericTypeSpecifier | LikeTypeSpecifier |
-   * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
-   * TupleTypeSpecifier | TypeConstant | VectorTypeSpecifier
+   * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
+   * DarrayTypeSpecifier | DictionaryTypeSpecifier | GenericTypeSpecifier |
+   * LikeTypeSpecifier | NullableTypeSpecifier | ShapeTypeSpecifier |
+   * SimpleTypeSpecifier | TupleTypeSpecifier | TypeConstant |
+   * VectorTypeSpecifier
    */
   public function getTypex(): ITypeSpecifier {
     return $this->getType();

--- a/codegen/token_from_data.hack
+++ b/codegen/token_from_data.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ce0588f7793b5ca42614fb76a4947345>>
+ * @generated SignedSource<<4978deeca1ca80509cdf59832edc22ab>>
  */
 namespace Facebook\HHAST\__Private;
 use namespace Facebook\HHAST;
@@ -105,7 +105,6 @@ final class TokenClassMap {
     'noreturn' => HHAST\NoreturnToken::class,
     'null' => HHAST\NullLiteralToken::class,
     'num' => HHAST\NumToken::class,
-    'object' => HHAST\ObjectToken::class,
     'parent' => HHAST\ParentToken::class,
     'print' => HHAST\PrintToken::class,
     'private' => HHAST\PrivateToken::class,
@@ -142,6 +141,7 @@ final class TokenClassMap {
     'void' => HHAST\VoidToken::class,
     'where' => HHAST\WhereToken::class,
     'while' => HHAST\WhileToken::class,
+    'with' => HHAST\WithToken::class,
     'xhp' => HHAST\XHPToken::class,
     'yield' => HHAST\YieldToken::class,
     'binary_literal' => HHAST\BinaryLiteralToken::class,

--- a/codegen/tokens/WithToken.hack
+++ b/codegen/tokens/WithToken.hack
@@ -1,18 +1,18 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<90e22e44ed77a61f775b939aa4ebe2c0>>
+ * @generated SignedSource<<f477f46c5cd02a8c978d4ede2f50c97f>>
  */
 namespace Facebook\HHAST;
 
-final class ObjectToken extends TokenWithVariableText {
+final class WithToken extends TokenWithVariableText {
 
-  const string KIND = 'object';
+  const string KIND = 'with';
 
   public function __construct(
     ?NodeList<Trivia> $leading,
     ?NodeList<Trivia> $trailing,
-    string $token_text = 'object',
+    string $token_text = 'with',
     ?__Private\SourceRef $source_ref = null,
   ) {
     parent::__construct($leading, $trailing, $token_text, $source_ref);

--- a/codegen/version.hack
+++ b/codegen/version.hack
@@ -1,12 +1,12 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<16023ad2db1bf1106fdbae2cf22f9091>>
+ * @generated SignedSource<<4d464e7cf3b20fc8d1c3da4ce7387a41>>
  */
 namespace Facebook\HHAST;
 
-const string SCHEMA_VERSION = '2022-04-25-0000';
+const string SCHEMA_VERSION = '2022-05-16-0000';
 
-const int HHVM_VERSION_ID = 416000;
+const int HHVM_VERSION_ID = 416100;
 
-const string HHVM_VERSION = '4.160.0-dev';
+const string HHVM_VERSION = '4.161.0-dev';

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -1,6 +1,7 @@
 {
   "roots": [
     "codegen/",
+    "codegen-no-rebuild/",
     "src/"
   ],
   "devRoots": [

--- a/hhast-lint.json
+++ b/hhast-lint.json
@@ -1,12 +1,12 @@
 {
-  "roots": [ "src/", "codegen/", "tests/" ],
+  "roots": [ "src/", "codegen/", "codegen-no-rebuild/", "tests/" ],
   "builtinLinters": "all",
   "extraLinters": [
     "Facebook\\HHAST\\HHClientLinter"
   ],
   "overrides": [
     {
-      "patterns": [ "codegen/*", "tests/examples/*" ],
+      "patterns": [ "codegen/*", "codegen-no-rebuild/*", "tests/examples/*" ],
       "disabledLinters": [
         "Facebook\\HHAST\\UnusedUseClauseLinter",
         "Facebook\\HHAST\\LicenseHeaderLinter"

--- a/src/__Private/codegen/CodegenLastestBreakingVersion.hack
+++ b/src/__Private/codegen/CodegenLastestBreakingVersion.hack
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private;
+
+use type Facebook\HackCodegen\{CodegenFileType, HackBuilderValues};
+
+final class CodegenLastestBreakingVersion extends CodegenBase {
+
+  <<__Override>>
+  protected function getOutputDirectory(): string {
+    return __DIR__.'/../../../codegen-no-rebuild';
+  }
+
+  <<__Override>>
+  public function generate(): void {
+    $cg = $this->getCodegenFactory();
+
+    $cg
+      ->codegenFile($this->getOutputDirectory().'/latest_breaking_version.hack')
+      ->setFileType(CodegenFileType::DOT_HACK)
+      ->setNamespace('Facebook\\HHAST')
+      ->addConstant(
+        $cg->codegenConstant('LATEST_BREAKING_SCHEMA_VERSION')
+          ->setType('string')
+          ->setValue(
+            $this->getSchema()['version'],
+            HackBuilderValues::export(),
+          ),
+      )
+      ->addConstant(
+        $cg->codegenConstant('LATEST_BREAKING_HHVM_VERSION_ID')
+          ->setType('int')
+          ->setValue(\HHVM_VERSION_ID, HackBuilderValues::export()),
+      )
+      ->addConstant(
+        $cg->codegenConstant('LATEST_BREAKING_HHVM_VERSION')
+          ->setType('string')
+          ->setValue(\HHVM_VERSION, HackBuilderValues::export()),
+      )
+      ->save();
+  }
+}

--- a/src/__Private/is_compatible_schema_version.hack
+++ b/src/__Private/is_compatible_schema_version.hack
@@ -21,6 +21,12 @@ use namespace HH\Lib\Str;
  * Facebook\HHAST\SCHEMA_VERSION.
  */
 function is_compatible_schema_version(string $other_version): bool {
+  invariant(
+    Str\length($other_version) === Str\length(SCHEMA_VERSION) &&
+      Str\length($other_version) === Str\length(LATEST_BREAKING_SCHEMA_VERSION),
+    '%s needs updating or a Y10K bug occurs',
+    __FILE__,
+  );
   return Str\compare($other_version, SCHEMA_VERSION) <= 0 &&
     Str\compare($other_version, LATEST_BREAKING_SCHEMA_VERSION) >= 0;
 }

--- a/src/__Private/is_compatible_schema_version.hack
+++ b/src/__Private/is_compatible_schema_version.hack
@@ -9,7 +9,8 @@
 
 namespace Facebook\HHAST\__Private;
 
-use const Facebook\HHAST\SCHEMA_VERSION;
+use const Facebook\HHAST\{LATEST_BREAKING_SCHEMA_VERSION, SCHEMA_VERSION};
+use namespace HH\Lib\Str;
 
 /**
  * Schema versions are compatible if one is a strict superset of the other
@@ -20,17 +21,6 @@ use const Facebook\HHAST\SCHEMA_VERSION;
  * Facebook\HHAST\SCHEMA_VERSION.
  */
 function is_compatible_schema_version(string $other_version): bool {
-  invariant(
-    SCHEMA_VERSION === '2022-04-25-0000',
-    '%s needs updating',
-    __FILE__,
-  );
-  switch ($other_version) {
-    case '2022-04-25-0000': // Adding ModuleMembershipDeclaration
-    case '2022-04-20-0001': // Adding enum modifiers and alias modifiers
-    case '2022-04-13-0002': // Latest breaking change
-      return true;
-    default:
-      return false;
-  }
+  return Str\compare($other_version, SCHEMA_VERSION) <= 0 &&
+    Str\compare($other_version, LATEST_BREAKING_SCHEMA_VERSION) >= 0;
 }


### PR DESCRIPTION
## Changes in this PR

- The job `update-schema` is added to Github Actions.
  - It is executed everyday to create pull requests to update schema if it the schema changes. One for breaking change and one for backward compatible change. The maintainer can review the PRs to merge one of them. For example: https://github.com/Atry/hhast/pull/3 and https://github.com/Atry/hhast/pull/4
  - It is also executed on pull request and will add suggestions to the pull request if it detect the schema needs regeneration.
- `src/__Private/codegen/CodegenLastestBreakingVersion.hack` is a code generator to generate `codegen-no-rebuild/latest_breaking_version.hack`, which includes the version number of latest breaking change on AST.
- `src/__Private/is_compatible_schema_version.hack` is updated to use `codegen-no-rebuild/latest_breaking_version.hack` to determine whether a schema version is compatible, so we don't have to manually edit the file any more until the 100th century.
- The job `determine-latest-breaking-hhvm-version` is added to Github Actions to calculate the oldest supported HHVM version so we don't have to manually update `.github/workflows/build-and-test.yml` any more.
- The job `update-schema` is also executed when pushing a commit to any branch in either this repository or a forked repository. When a commit is pushed and the schema change is detected, the pull requests in that repository are created against that branch. For example, 4d3644ce9e3546ff7436ee8121a6128b8dc46d70 and 4bb47c4a074581cc417d1614898f5cb0cf81c694 in this PR are created by dogfooding PRs from https://github.com/Atry/hhast/pull/4 .
