### PR TITLE
Don't create the PR to update the latest breaking version if the latest breaking version is not changed

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,6 +77,13 @@ jobs:
       - if: github.event_name != 'pull_request'
         run: bin/update-codegen --dont-update-ast --update-latest-breaking-version
       - if: github.event_name != 'pull_request'
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          base: HEAD
+          filters: |
+            latest-breaking-version: codegen-no-rebuild/latest_breaking_version.hack
+      - if: github.event_name != 'pull_request' && steps.filter.outputs.latest-breaking-version == 'true'
         uses: peter-evans/create-pull-request@v4
         with:
           branch: update-latest-breaking-version/${{github.ref_name}}


### PR DESCRIPTION
#462 added a github action job to create pull requests. One of the pull request created by the job is to update the latest breaking version. However the pull request is unnecessary if the latest breaking version is the current version. This PR will prevent the pull request from being created when it is unnecessary.

Note that the other PR to update schema will still be created. For example, #463 and #464 are identical, so #464 is unnecessary while #463 is good.