### PR TITLE
Skip update-schema job when it is triggered by a tag

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Check for manually modified codegen
         run: vendor/bin/hh-codegen-verify-signatures codegen/
   update-schema:
+    if: github.ref_type != 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The purpose of `update-schema` is to create pull requests, which does not make sense for a tag.