### PR TITLE
Consider new fields from `hh_client --json --lint` output as backward compatible

### DIFF
--- a/src/Linters/HHClientLintError.hack
+++ b/src/Linters/HHClientLintError.hack
@@ -26,6 +26,7 @@ final class HHClientLintError implements LintError {
     'bypass_changed_lines' => bool,
     'original' => string,
     'replacement' => string,
+    ...
   );
 
   public function __construct(

--- a/src/Linters/HHClientLinter.hack
+++ b/src/Linters/HHClientLinter.hack
@@ -63,6 +63,7 @@ final class HHClientLinter implements Linter {
   const type TJSONResult = shape(
     'errors' => vec<HHClientLintError::TJSONError>,
     'version' => string,
+    ...
   );
 
   private static function blameCode(


### PR DESCRIPTION
This PR should fix #500 by considering new fields from `hh_client --json --lint` output as backward compatible. If new JSON fields were added to the JSON response in the future, it would not break HHAST like what we see in https://github.com/hhvm/hhast/runs/7729252032?check_suite_focus=true .