### PR TITLE
Fix some shortcomings of UnusedParameterLinter

### DIFF
--- a/src/Linters/UnusedLambdaParameterLinter.hack
+++ b/src/Linters/UnusedLambdaParameterLinter.hack
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\{C, Str};
+
+final class UnusedLambdaParameterLinter extends AutoFixingASTLinter {
+  const type TConfig = shape();
+  const type TContext = LambdaExpression;
+  const type TNode = VariableToken;
+
+  use __Private\SharedCodeForUnusedParameterLinters;
+
+  <<__Override>>
+  public function getLintErrorForNode(
+    this::TContext $lambda,
+    this::TNode $name_node,
+  ): ?ASTLintError {
+    if (
+      static::startsWithUnder($name_node) ||
+      !static::isAParameter($lambda, $name_node) ||
+      static::isUsedInBody($lambda->getBody(), $name_node)
+    ) {
+      return null;
+    }
+
+    return new ASTLintError(
+      $this,
+      'Parameter is unused',
+      $name_node,
+      () ==> static::prefixWithUnderscore($name_node),
+    );
+  }
+
+  <<__Override>>
+  public function getTitleForFix(ASTLintError $err): string {
+    $name = static::prefixWithUnderscore($err->getBlameNode() as this::TNode);
+    return Str\format('Rename to `%s`', $name->getText());
+  }
+
+  /**
+   * This linter targets VariableToken, so we get a lot of false requests.
+   * `$x ==> C\count($x)` calls us twice.
+   * Once for the parameter $x and once for `C\count($x)`s $x.
+   * We can't simply target ParameterDeclaration, since `$x ==> 0`
+   * does not introduce a paramter declaration.
+   */
+  private static function isAParameter(
+    this::TContext $lambda,
+    this::TNode $name_node,
+  ): bool {
+    $signature = $lambda->getSignature();
+    return ($signature is VariableToken && $signature === $name_node) ||
+      (
+        $signature is LambdaSignature &&
+        C\any(
+          $signature->getParameters()?->getChildrenOfItems() ?? vec[],
+          $p ==> static::extractVariableFromParam($p) === $name_node,
+        )
+      );
+  }
+}

--- a/src/__Private/LSPLib/Server.hack
+++ b/src/__Private/LSPLib/Server.hack
@@ -64,7 +64,7 @@ abstract class Server<TState as ServerState> {
 
     $was_response = await $this->tryHandleMessageTypeAsync(
       type_alias_structure(LSP\ResponseMessage::class),
-      async $x ==> {},
+      async $_ignored ==> {},
       $json,
     );
     if ($was_response) {

--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -75,6 +75,7 @@ final class LintRunConfig {
     HHAST\NoNewlineAtStartOfControlFlowBlockLinter::class,
     HHAST\MustUseOverrideAttributeLinter::class,
     HHAST\NoPHPEqualityLinter::class,
+    HHAST\UnusedLambdaParameterLinter::class,
     HHAST\UnusedParameterLinter::class,
     HHAST\UnusedVariableLinter::class,
     HHAST\UnusedUseClauseLinter::class,

--- a/src/__Private/SharedCodeForUnusedParameterLinters.hack
+++ b/src/__Private/SharedCodeForUnusedParameterLinters.hack
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST\__Private;
+
+use namespace HH\Lib\{C, Str};
+use type Facebook\HHAST\{
+  DecoratedExpression,
+  IParameter,
+  Node,
+  ParameterDeclaration,
+  VariableToken,
+  VariadicParameter,
+};
+
+trait SharedCodeForUnusedParameterLinters {
+  final private static function extractVariableFromParam(
+    IParameter $p,
+  ): ?VariableToken {
+    // This isn't the modern `function _(mixed ... $collecting_vec): void {}` style.
+    // This is the old `function `function _(...): void {}` style.
+    if ($p is VariadicParameter) {
+      return null;
+    }
+
+    invariant(
+      $p is ParameterDeclaration,
+      'A new unknown parameter type was found: %s',
+      \get_class($p),
+    );
+
+    // `public function __construct(private string $x) {}` is never unused.
+    if ($p->getVisibility() is nonnull) {
+      return null;
+    }
+
+    $var = $p->getName();
+    if ($var is DecoratedExpression) {
+      $var = $var->getExpression();
+    }
+
+    invariant(
+      $var is VariableToken,
+      'Unexpected parameter type: %s did not yield a variable token',
+      \get_class($p),
+    );
+
+    return $var;
+  }
+
+  final private static function isUsedInBody(
+    Node $body,
+    VariableToken $var,
+  ): bool {
+    $search_text = $var->getText();
+    return C\any(
+      $body->traverse(),
+      $tok ==> $tok ?as VariableToken?->getText() === $search_text,
+    );
+  }
+
+  final private static function prefixWithUnderscore(
+    VariableToken $v,
+  ): VariableToken {
+    return $v->withText('$_'.Str\strip_prefix($v->getText(), '$'));
+  }
+
+  final private static function startsWithUnder(VariableToken $v): bool {
+    $name = $v->getText();
+    return Str\starts_with($name, '$_');
+  }
+}

--- a/tests/UnusedLambdaParameterLinterTest.hack
+++ b/tests/UnusedLambdaParameterLinterTest.hack
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+final class UnusedLambdaParameterLinterTest extends TestCase {
+  use AutoFixingLinterTestTrait<ASTLintError>;
+
+  <<__Override>>
+  protected function getLinter(string $file): UnusedLambdaParameterLinter {
+    return UnusedLambdaParameterLinter::fromPath($file);
+  }
+
+  <<__Override>>
+  public function getCleanExamples(): vec<(string)> {
+    return vec[
+      tuple('<?hh function _(): void {$x ==> $x + 1;}'),
+      tuple('<?hh function _(): void {($x) ==> $x + 1;}'),
+      tuple('<?hh function _(): void {(... $xs) ==> C\count($xs);}'),
+      tuple('<?hh function _(): void {$_unused ==> 0;}'),
+      tuple('<?hh function _(): void {($_unused) ==> 0;}'),
+      tuple('<?hh function _(): void {(... $_unused) ==> 0;}'),
+      tuple('<?hh function _(): void {$x ==> $y ==> $x + $y;}'),
+      tuple('<?hh function _(): void {$x ==> $_y ==> $z ==> $x + $z;}'),
+      tuple('<?hh function _(): void {$x ==> { return $x; };}'),
+    ];
+  }
+}

--- a/tests/UnusedParameterLinterTest.hack
+++ b/tests/UnusedParameterLinterTest.hack
@@ -35,6 +35,10 @@ final class UnusedParameterLinterTest extends TestCase {
       tuple(
         '<?hh class Foo { public function __construct(private int $bar) {} }',
       ),
+      tuple(
+        // Lambda's are no longer flagged by this linter
+        '<?hh function _(): void { ($a) ==> 0; (... $a) ==> 0; $a ==> 0; }',
+      ),
     ];
   }
 }

--- a/tests/examples/UnusedLambdaParameterLinter/function_param.php.autofix.expect
+++ b/tests/examples/UnusedLambdaParameterLinter/function_param.php.autofix.expect
@@ -1,0 +1,13 @@
+<?hh
+
+function launder_lambda(
+  (function(nothing, nothing): mixed) $_any_lambda,
+): void {}
+
+function _void(): void {
+  launder_lambda(($bar, int $_baz) ==> $bar);
+  launder_lambda(($a, $b) ==> {
+    $_ = ($d1) ==> tuple($d1, $b);
+    $_ = $a ==> $a; // shadowed parameter, currently causes a false negative
+  });
+}

--- a/tests/examples/UnusedLambdaParameterLinter/function_param.php.expect
+++ b/tests/examples/UnusedLambdaParameterLinter/function_param.php.expect
@@ -1,0 +1,7 @@
+[
+    {
+        "blame": "$baz",
+        "blame_pretty": "$baz",
+        "description": "Parameter is unused"
+    }
+]

--- a/tests/examples/UnusedLambdaParameterLinter/function_param.php.in
+++ b/tests/examples/UnusedLambdaParameterLinter/function_param.php.in
@@ -1,0 +1,13 @@
+<?hh
+
+function launder_lambda(
+  (function(nothing, nothing): mixed) $_any_lambda,
+): void {}
+
+function _void(): void {
+  launder_lambda(($bar, int $baz) ==> $bar);
+  launder_lambda(($a, $b) ==> {
+    $_ = ($d1) ==> tuple($d1, $b);
+    $_ = $a ==> $a; // shadowed parameter, currently causes a false negative
+  });
+}

--- a/tests/examples/UnusedLambdaParameterLinter/old_style_variadic_parameter_no_crash.php.autofix.expect
+++ b/tests/examples/UnusedLambdaParameterLinter/old_style_variadic_parameter_no_crash.php.autofix.expect
@@ -1,0 +1,5 @@
+<?hh
+
+function _(): void {
+  $_old_pa_style_variadics = (string $_file, ...): void ==> {};
+}

--- a/tests/examples/UnusedLambdaParameterLinter/old_style_variadic_parameter_no_crash.php.expect
+++ b/tests/examples/UnusedLambdaParameterLinter/old_style_variadic_parameter_no_crash.php.expect
@@ -1,0 +1,7 @@
+[
+    {
+        "blame": "$file",
+        "blame_pretty": "$file",
+        "description": "Parameter is unused"
+    }
+]

--- a/tests/examples/UnusedLambdaParameterLinter/old_style_variadic_parameter_no_crash.php.in
+++ b/tests/examples/UnusedLambdaParameterLinter/old_style_variadic_parameter_no_crash.php.in
@@ -1,0 +1,5 @@
+<?hh
+
+function _(): void {
+  $_old_pa_style_variadics = (string $file, ...): void ==> {};
+}

--- a/tests/examples/UnusedLambdaParameterLinter/unused_variadic_param.php.autofix.expect
+++ b/tests/examples/UnusedLambdaParameterLinter/unused_variadic_param.php.autofix.expect
@@ -1,0 +1,7 @@
+<?hh
+
+function _(): void {
+  $_bad_concat = (vec<int> $one, vec<int> ...$_rest): vec<int> ==> {
+    return $one;
+  };
+}

--- a/tests/examples/UnusedLambdaParameterLinter/unused_variadic_param.php.expect
+++ b/tests/examples/UnusedLambdaParameterLinter/unused_variadic_param.php.expect
@@ -1,0 +1,7 @@
+[
+    {
+        "blame": "$rest",
+        "blame_pretty": "$rest",
+        "description": "Parameter is unused"
+    }
+]

--- a/tests/examples/UnusedLambdaParameterLinter/unused_variadic_param.php.in
+++ b/tests/examples/UnusedLambdaParameterLinter/unused_variadic_param.php.in
@@ -1,0 +1,7 @@
+<?hh
+
+function _(): void {
+  $_bad_concat = (vec<int> $one, vec<int> ...$rest): vec<int> ==> {
+    return $one;
+  };
+}

--- a/tests/examples/UnusedParameterLinter/function_param.php.autofix.expect
+++ b/tests/examples/UnusedParameterLinter/function_param.php.autofix.expect
@@ -7,8 +7,7 @@ function foo(int $bar, int $_baz) {
 function lambdas(
   int $a,
   int $b,
-  (function(int, int): int) $_c = ($_c1, $c2) ==> $c2,
 ): void {
-  $d = ($d1, $_d2) ==> tuple($d1, $b);
+  $d = ($d1) ==> tuple($d1, $b);
   $e = $a ==> $a; // shadowed parameter, currently causes a false negative
 }

--- a/tests/examples/UnusedParameterLinter/function_param.php.expect
+++ b/tests/examples/UnusedParameterLinter/function_param.php.expect
@@ -3,20 +3,5 @@
         "blame": "int $baz",
         "blame_pretty": "int $baz",
         "description": "Parameter is unused"
-    },
-    {
-        "blame": "  (function(int, int): int) $c = ($c1, $c2) ==> $c2",
-        "blame_pretty": "  (function(int, int): int) $c = ($c1, $c2) ==> $c2",
-        "description": "Parameter is unused"
-    },
-    {
-        "blame": "$c1",
-        "blame_pretty": "$c1",
-        "description": "Parameter is unused"
-    },
-    {
-        "blame": "$d2",
-        "blame_pretty": "$d2",
-        "description": "Parameter is unused"
     }
 ]

--- a/tests/examples/UnusedParameterLinter/function_param.php.in
+++ b/tests/examples/UnusedParameterLinter/function_param.php.in
@@ -7,8 +7,7 @@ function foo(int $bar, int $baz) {
 function lambdas(
   int $a,
   int $b,
-  (function(int, int): int) $c = ($c1, $c2) ==> $c2,
 ): void {
-  $d = ($d1, $d2) ==> tuple($d1, $b);
+  $d = ($d1) ==> tuple($d1, $b);
   $e = $a ==> $a; // shadowed parameter, currently causes a false negative
 }

--- a/tests/examples/UnusedParameterLinter/old_style_variadic_parameter_no_crash.php.autofix.expect
+++ b/tests/examples/UnusedParameterLinter/old_style_variadic_parameter_no_crash.php.autofix.expect
@@ -1,0 +1,5 @@
+<?hh
+
+function old_style_variadics(string $_file, ...): void {
+
+}

--- a/tests/examples/UnusedParameterLinter/old_style_variadic_parameter_no_crash.php.expect
+++ b/tests/examples/UnusedParameterLinter/old_style_variadic_parameter_no_crash.php.expect
@@ -1,0 +1,7 @@
+[
+    {
+        "blame": "string $file",
+        "blame_pretty": "string $file",
+        "description": "Parameter is unused"
+    }
+]

--- a/tests/examples/UnusedParameterLinter/old_style_variadic_parameter_no_crash.php.in
+++ b/tests/examples/UnusedParameterLinter/old_style_variadic_parameter_no_crash.php.in
@@ -1,0 +1,5 @@
+<?hh
+
+function old_style_variadics(string $file, ...): void {
+
+}

--- a/tests/examples/UnusedParameterLinter/unused_variadic_param.php.autofix.expect
+++ b/tests/examples/UnusedParameterLinter/unused_variadic_param.php.autofix.expect
@@ -1,0 +1,5 @@
+<?hh
+
+function bad_concat(vec<int> $one, vec<int> ...$_rest): vec<int> {
+  return $one;
+}

--- a/tests/examples/UnusedParameterLinter/unused_variadic_param.php.expect
+++ b/tests/examples/UnusedParameterLinter/unused_variadic_param.php.expect
@@ -1,0 +1,7 @@
+[
+    {
+        "blame": "vec<int> ...$rest",
+        "blame_pretty": "vec<int> ...$rest",
+        "description": "Parameter is unused"
+    }
+]

--- a/tests/examples/UnusedParameterLinter/unused_variadic_param.php.in
+++ b/tests/examples/UnusedParameterLinter/unused_variadic_param.php.in
@@ -1,0 +1,5 @@
+<?hh
+
+function bad_concat(vec<int> $one, vec<int> ...$rest): vec<int> {
+  return $one;
+}


### PR DESCRIPTION
 - Variadic parameters were not checked
   function _(int ... $x): void {} now emits an error for $x.
- Lambda parameters are now linted in unparenthesized params.
   $x ==> 0 now emits an error for $x.
   Same applies for (int ... $x) ==> 0.
 - Added explicit tests for old style variadics.
   The linter handled them fine, but there was no test for it.
Checking for unparenthesized lambda parameters required a new linter.
The UnusedParameterLinter checked against ParameterDeclaration.
$x ==> 0; does not introduce one, so a new TNode was required.

This PR may cause old HHAST_FIXME comments to break.
You will have to upgrade:
/\*HHAST_FIXME[UnusedParameter]\*/ ($x) ==> 0; to
/\*HHAST_FIXME[UnusedLambdaParameter]\*/ ($x) ==> 0;
I suspect this linter is rarely suppressed, since the autofix is easier.