### PR TITLE
Let TypeRefinement implement ITypeSpecifier

### DIFF
--- a/codegen/inferred_relationships.hack
+++ b/codegen/inferred_relationships.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<00a5268d733469acb390705ef80ae871>>
+ * @generated SignedSource<<b90030a12d28140a33e6cba71c5bb301>>
  */
 namespace Facebook\HHAST\__Private;
 
@@ -487,7 +487,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'missing',
     'simple_type_specifier',
     'type_constant',
-    'type_refinement',
   ],
   'closure_parameter_type_specifier.closure_parameter_call_convention' =>
     keyset[
@@ -550,7 +549,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'like_type_specifier',
     'nullable_type_specifier',
     'simple_type_specifier',
-    'type_refinement',
     'vector_type_specifier',
   ],
   'collection_literal_expression.collection_literal_initializers' => keyset[
@@ -2190,7 +2188,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'token:noreturn',
     'tuple_type_specifier',
     'type_constant',
-    'type_refinement',
     'varray_type_specifier',
     'vector_type_specifier',
   ],
@@ -2538,9 +2535,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'tuple_expression',
     'tuple_type_specifier',
     'type_constant',
-    'type_in_refinement',
     'type_parameter',
-    'type_refinement',
     'variable',
     'variadic_parameter',
     'varray_intrinsic_expression',
@@ -2833,7 +2828,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'simple_type_specifier',
     'tuple_type_specifier',
     'type_constant',
-    'type_refinement',
     'varray_type_specifier',
     'vector_type_specifier',
   ],
@@ -3082,7 +3076,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<alias_declaration|classish_declaration|end_of_file|enum_declaration|function_declaration|markup_section>',
     'list<alias_declaration|classish_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section>',
     'list<alias_declaration|classish_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section|module_membership_declaration>',
-    'list<alias_declaration|classish_declaration|end_of_file|file_attribute_specification|markup_section>',
     'list<alias_declaration|classish_declaration|end_of_file|function_declaration|markup_section>',
     'list<alias_declaration|classish_declaration|end_of_file|function_declaration|markup_section|namespace_declaration>',
     'list<alias_declaration|classish_declaration|end_of_file|markup_section>',
@@ -3498,11 +3491,9 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<simple_type_specifier>>',
     'list<list_item<simple_type_specifier>|list_item<tuple_type_specifier>>',
     'list<list_item<simple_type_specifier>|list_item<type_constant>>',
-    'list<list_item<simple_type_specifier>|list_item<type_refinement>>',
     'list<list_item<simple_type_specifier>|list_item<varray_type_specifier>>',
     'list<list_item<tuple_type_specifier>>',
     'list<list_item<type_constant>>',
-    'list<list_item<type_refinement>>',
     'list<list_item<varray_type_specifier>>',
     'list<list_item<vector_type_specifier>>',
     'missing',
@@ -3582,28 +3573,8 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'shape_type_specifier',
     'simple_type_specifier',
     'type_constant',
-    'type_refinement',
     'varray_type_specifier',
     'vector_type_specifier',
-  ],
-  'type_in_refinement.type_in_refinement_constraints' => keyset[
-    'missing',
-  ],
-  'type_in_refinement.type_in_refinement_equal' => keyset[
-    'token:=',
-  ],
-  'type_in_refinement.type_in_refinement_keyword' => keyset[
-    'token:type',
-  ],
-  'type_in_refinement.type_in_refinement_name' => keyset[
-    'token:name',
-  ],
-  'type_in_refinement.type_in_refinement_type' => keyset[
-    'simple_type_specifier',
-    'type_constant',
-  ],
-  'type_in_refinement.type_in_refinement_type_parameters' => keyset[
-    'missing',
   ],
   'type_parameter.type_attribute_spec' => keyset[
     'missing',
@@ -3637,21 +3608,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   ],
   'type_parameters.type_parameters_right_angle' => keyset[
     'token:>',
-  ],
-  'type_refinement.type_refinement_keyword' => keyset[
-    'token:with',
-  ],
-  'type_refinement.type_refinement_left_brace' => keyset[
-    'token:{',
-  ],
-  'type_refinement.type_refinement_members' => keyset[
-    'list<list_item<type_in_refinement>>',
-  ],
-  'type_refinement.type_refinement_right_brace' => keyset[
-    'token:}',
-  ],
-  'type_refinement.type_refinement_type' => keyset[
-    'simple_type_specifier',
   ],
   'unset_statement.unset_keyword' => keyset[
     'token:unset',
@@ -4010,7 +3966,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'nullable_type_specifier',
     'simple_type_specifier',
     'type_constant',
-    'type_refinement',
     'vector_type_specifier',
   ],
   'while_statement.while_body' => keyset[

--- a/codegen/inferred_relationships.hack
+++ b/codegen/inferred_relationships.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b90030a12d28140a33e6cba71c5bb301>>
+ * @generated SignedSource<<b8aeea26cfca34455c594198c844cc8b>>
  */
 namespace Facebook\HHAST\__Private;
 
@@ -26,12 +26,10 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'token:type',
   ],
   'alias_declaration.alias_modifiers' => keyset[
-    'list<token:public>',
     'missing',
   ],
   'alias_declaration.alias_module_kw_opt' => keyset[
     'missing',
-    'token:module',
   ],
   'alias_declaration.alias_name' => keyset[
     'token:name',
@@ -148,6 +146,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'darray_type_specifier',
     'dictionary_type_specifier',
     'generic_type_specifier',
+    'like_type_specifier',
     'nullable_type_specifier',
     'simple_type_specifier',
     'tuple_type_specifier',
@@ -450,8 +449,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<token:abstract>',
     'list<token:abstract|token:final>',
     'list<token:final>',
-    'list<token:internal>',
-    'list<token:public>',
     'missing',
   ],
   'classish_declaration.classish_name' => keyset[
@@ -487,6 +484,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'missing',
     'simple_type_specifier',
     'type_constant',
+    'type_refinement',
   ],
   'closure_parameter_type_specifier.closure_parameter_call_convention' =>
     keyset[
@@ -549,6 +547,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'like_type_specifier',
     'nullable_type_specifier',
     'simple_type_specifier',
+    'type_refinement',
     'vector_type_specifier',
   ],
   'collection_literal_expression.collection_literal_initializers' => keyset[
@@ -1357,8 +1356,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   ],
   'enum_class_declaration.enum_class_modifiers' => keyset[
     'list<token:abstract>',
-    'list<token:internal>',
-    'list<token:public>',
     'missing',
   ],
   'enum_class_declaration.enum_class_name' => keyset[
@@ -1414,7 +1411,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'token:{',
   ],
   'enum_declaration.enum_modifiers' => keyset[
-    'list<token:public>',
     'missing',
   ],
   'enum_declaration.enum_name' => keyset[
@@ -2143,8 +2139,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<token:final|token:public>',
     'list<token:final|token:public|token:static>',
     'list<token:final|token:static>',
-    'list<token:internal>',
-    'list<token:internal|token:static>',
     'list<token:private>',
     'list<token:private|token:static>',
     'list<token:protected>',
@@ -2188,6 +2182,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'token:noreturn',
     'tuple_type_specifier',
     'type_constant',
+    'type_refinement',
     'varray_type_specifier',
     'vector_type_specifier',
   ],
@@ -2535,7 +2530,9 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'tuple_expression',
     'tuple_type_specifier',
     'type_constant',
+    'type_in_refinement',
     'type_parameter',
+    'type_refinement',
     'variable',
     'variadic_parameter',
     'varray_intrinsic_expression',
@@ -2601,7 +2598,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'token:;',
   ],
   'module_declaration.module_declaration_attribute_spec' => keyset[
-    'missing',
     'old_attribute_specification',
   ],
   'module_declaration.module_declaration_exports' => keyset[
@@ -2828,6 +2824,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'simple_type_specifier',
     'tuple_type_specifier',
     'type_constant',
+    'type_refinement',
     'varray_type_specifier',
     'vector_type_specifier',
   ],
@@ -2934,8 +2931,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<property_declarator>>',
   ],
   'property_declaration.property_modifiers' => keyset[
-    'list<token:internal>',
-    'list<token:internal|token:static>',
     'list<token:private>',
     'list<token:private|token:static>',
     'list<token:protected>',
@@ -3072,10 +3067,9 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<alias_declaration|classish_declaration|const_declaration|end_of_file|enum_declaration|function_declaration|markup_section>',
     'list<alias_declaration|classish_declaration|const_declaration|end_of_file|function_declaration|markup_section>',
     'list<alias_declaration|classish_declaration|end_of_file|enum_class_declaration|enum_declaration|file_attribute_specification|function_declaration|markup_section>',
-    'list<alias_declaration|classish_declaration|end_of_file|enum_class_declaration|enum_declaration|file_attribute_specification|function_declaration|markup_section|module_membership_declaration>',
     'list<alias_declaration|classish_declaration|end_of_file|enum_declaration|function_declaration|markup_section>',
     'list<alias_declaration|classish_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section>',
-    'list<alias_declaration|classish_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section|module_membership_declaration>',
+    'list<alias_declaration|classish_declaration|end_of_file|file_attribute_specification|markup_section>',
     'list<alias_declaration|classish_declaration|end_of_file|function_declaration|markup_section>',
     'list<alias_declaration|classish_declaration|end_of_file|function_declaration|markup_section|namespace_declaration>',
     'list<alias_declaration|classish_declaration|end_of_file|markup_section>',
@@ -3092,10 +3086,10 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<classish_declaration|end_of_file|enum_class_declaration|expression_statement|function_declaration|markup_section>',
     'list<classish_declaration|end_of_file|enum_class_declaration|function_declaration|markup_section>',
     'list<classish_declaration|end_of_file|enum_class_declaration|markup_section>',
+    'list<classish_declaration|end_of_file|enum_declaration|file_attribute_specification|function_declaration|markup_section>',
     'list<classish_declaration|end_of_file|enum_declaration|function_declaration|markup_section>',
     'list<classish_declaration|end_of_file|expression_statement|function_declaration|markup_section>',
     'list<classish_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section>',
-    'list<classish_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section|module_declaration>',
     'list<classish_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section|module_membership_declaration>',
     'list<classish_declaration|end_of_file|file_attribute_specification|markup_section>',
     'list<classish_declaration|end_of_file|file_attribute_specification|markup_section|module_declaration>',
@@ -3115,7 +3109,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<const_declaration|end_of_file|markup_section|namespace_declaration>',
     'list<const_declaration|end_of_file|markup_section|namespace_use_declaration>',
     'list<context_alias_declaration|end_of_file|file_attribute_specification|function_declaration|markup_section>',
-    'list<end_of_file|enum_class_declaration|file_attribute_specification|function_declaration|markup_section|module_membership_declaration>',
     'list<end_of_file|enum_class_declaration|function_declaration|markup_section>',
     'list<end_of_file|enum_class_declaration|markup_section>',
     'list<end_of_file|enum_declaration|expression_statement|function_declaration|markup_section>',
@@ -3123,8 +3116,6 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<end_of_file|enum_declaration|markup_section>',
     'list<end_of_file|enum_declaration|markup_section|namespace_use_declaration>',
     'list<end_of_file|file_attribute_specification|function_declaration|markup_section>',
-    'list<end_of_file|file_attribute_specification|function_declaration|markup_section|module_declaration>',
-    'list<end_of_file|file_attribute_specification|function_declaration|markup_section|module_membership_declaration>',
     'list<end_of_file|file_attribute_specification|markup_section|module_membership_declaration|namespace_declaration>',
     'list<end_of_file|file_attribute_specification|markup_section|namespace_declaration>',
     'list<end_of_file|function_declaration>',
@@ -3491,9 +3482,11 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<simple_type_specifier>>',
     'list<list_item<simple_type_specifier>|list_item<tuple_type_specifier>>',
     'list<list_item<simple_type_specifier>|list_item<type_constant>>',
+    'list<list_item<simple_type_specifier>|list_item<type_refinement>>',
     'list<list_item<simple_type_specifier>|list_item<varray_type_specifier>>',
     'list<list_item<tuple_type_specifier>>',
     'list<list_item<type_constant>>',
+    'list<list_item<type_refinement>>',
     'list<list_item<varray_type_specifier>>',
     'list<list_item<vector_type_specifier>>',
     'missing',
@@ -3573,8 +3566,28 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'shape_type_specifier',
     'simple_type_specifier',
     'type_constant',
+    'type_refinement',
     'varray_type_specifier',
     'vector_type_specifier',
+  ],
+  'type_in_refinement.type_in_refinement_constraints' => keyset[
+    'missing',
+  ],
+  'type_in_refinement.type_in_refinement_equal' => keyset[
+    'token:=',
+  ],
+  'type_in_refinement.type_in_refinement_keyword' => keyset[
+    'token:type',
+  ],
+  'type_in_refinement.type_in_refinement_name' => keyset[
+    'token:name',
+  ],
+  'type_in_refinement.type_in_refinement_type' => keyset[
+    'simple_type_specifier',
+    'type_constant',
+  ],
+  'type_in_refinement.type_in_refinement_type_parameters' => keyset[
+    'missing',
   ],
   'type_parameter.type_attribute_spec' => keyset[
     'missing',
@@ -3608,6 +3621,21 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
   ],
   'type_parameters.type_parameters_right_angle' => keyset[
     'token:>',
+  ],
+  'type_refinement.type_refinement_keyword' => keyset[
+    'token:with',
+  ],
+  'type_refinement.type_refinement_left_brace' => keyset[
+    'token:{',
+  ],
+  'type_refinement.type_refinement_members' => keyset[
+    'list<list_item<type_in_refinement>>',
+  ],
+  'type_refinement.type_refinement_right_brace' => keyset[
+    'token:}',
+  ],
+  'type_refinement.type_refinement_type' => keyset[
+    'simple_type_specifier',
   ],
   'unset_statement.unset_keyword' => keyset[
     'token:unset',
@@ -3853,6 +3881,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<cast_expression>|list_item<literal>>',
     'list<list_item<collection_literal_expression>>',
     'list<list_item<collection_literal_expression>|list_item<darray_intrinsic_expression>|list_item<dictionary_intrinsic_expression>|list_item<varray_intrinsic_expression>|list_item<vector_intrinsic_expression>>',
+    'list<list_item<collection_literal_expression>|list_item<function_pointer_expression>|list_item<keyset_intrinsic_expression>|list_item<object_creation_expression>>',
     'list<list_item<collection_literal_expression>|list_item<literal>|list_item<varray_intrinsic_expression>|list_item<vector_intrinsic_expression>>',
     'list<list_item<conditional_expression>>',
     'list<list_item<darray_intrinsic_expression>>',
@@ -3966,6 +3995,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'nullable_type_specifier',
     'simple_type_specifier',
     'type_constant',
+    'type_refinement',
     'vector_type_specifier',
   ],
   'while_statement.while_body' => keyset[

--- a/codegen/node_from_json.hack
+++ b/codegen/node_from_json.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5cbc5ea10111cd0216a39c530f736a81>>
+ * @generated SignedSource<<ccf23dc2810992f9eadf40a0131442d6>>
  */
 namespace Facebook\HHAST\__Private;
 use namespace Facebook\HHAST;
@@ -144,6 +144,9 @@ function node_from_json_unwrapped(
     'nullable_type_specifier' => HHAST\NullableTypeSpecifier::class,
     'object_creation_expression' => HHAST\ObjectCreationExpression::class,
     'old_attribute_specification' => HHAST\OldAttributeSpecification::class,
+    'package_declaration' => HHAST\PackageDeclaration::class,
+    'package_includes' => HHAST\PackageIncludes::class,
+    'package_uses' => HHAST\PackageUses::class,
     'parameter_declaration' => HHAST\ParameterDeclaration::class,
     'parenthesized_expression' => HHAST\ParenthesizedExpression::class,
     'pipe_variable' => HHAST\PipeVariableExpression::class,

--- a/codegen/schema.json
+++ b/codegen/schema.json
@@ -1,6 +1,6 @@
 { "description" :
   "@generated JSON schema of the Hack Full Fidelity Parser AST",
-  "version" : "2022-09-09-0000",
+  "version" : "2022-09-29-0000",
   "trivia" : [
     { "trivia_kind_name" : "WhiteSpace",
       "trivia_type_name" : "whitespace" },
@@ -375,6 +375,8 @@
       "token_text" : "readonly" },
     { "token_kind" : "Internal",
       "token_text" : "internal" },
+    { "token_kind" : "Package",
+      "token_text" : "package" },
 
     { "token_kind" : "ErrorToken",
       "token_text" : null },
@@ -2140,6 +2142,39 @@
         { "field_name" : "module_keyword" },
         { "field_name" : "name" },
         { "field_name" : "semicolon" }
+      ] },
+    { "kind_name" : "PackageDeclaration",
+      "type_name" : "package_declaration",
+      "description" : "package_declaration",
+      "prefix" : "package_declaration",
+      "fields" : [
+        { "field_name" : "attribute_spec" },
+        { "field_name" : "package_keyword" },
+        { "field_name" : "name" },
+        { "field_name" : "left_brace" },
+        { "field_name" : "uses" },
+        { "field_name" : "includes" },
+        { "field_name" : "right_brace" }
+      ] },
+    { "kind_name" : "PackageUses",
+      "type_name" : "package_uses",
+      "description" : "package_uses",
+      "prefix" : "package_uses",
+      "fields" : [
+        { "field_name" : "use_keyword" },
+        { "field_name" : "left_brace" },
+        { "field_name" : "uses" },
+        { "field_name" : "right_brace" }
+      ] },
+    { "kind_name" : "PackageIncludes",
+      "type_name" : "package_includes",
+      "description" : "package_includes",
+      "prefix" : "package_includes",
+      "fields" : [
+        { "field_name" : "include_keyword" },
+        { "field_name" : "left_brace" },
+        { "field_name" : "includes" },
+        { "field_name" : "right_brace" }
       ] },
 
     { "kind_name" : "Token",

--- a/codegen/syntax/AliasDeclaration.hack
+++ b/codegen/syntax/AliasDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7be6a0ad119af7b17e53c913342e9828>>
+ * @generated SignedSource<<27b32b5ffabaaeeac88bf08eea4ad05d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -15,8 +15,8 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
   const string SYNTAX_KIND = 'alias_declaration';
 
   private ?OldAttributeSpecification $_attribute_spec;
-  private ?NodeList<PublicToken> $_modifiers;
-  private ?ModuleToken $_module_kw_opt;
+  private ?Node $_modifiers;
+  private ?Node $_module_kw_opt;
   private Token $_keyword;
   private NameToken $_name;
   private ?TypeParameters $_generic_parameter;
@@ -27,8 +27,8 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
 
   public function __construct(
     ?OldAttributeSpecification $attribute_spec,
-    ?NodeList<PublicToken> $modifiers,
-    ?ModuleToken $module_kw_opt,
+    ?Node $modifiers,
+    ?Node $module_kw_opt,
     Token $keyword,
     NameToken $name,
     ?TypeParameters $generic_parameter,
@@ -74,7 +74,7 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
-      'NodeList<PublicToken>',
+      'Node',
     );
     $offset += $modifiers?->getWidth() ?? 0;
     $module_kw_opt = Node::fromJSON(
@@ -82,7 +82,7 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
-      'ModuleToken',
+      'Node',
     );
     $offset += $module_kw_opt?->getWidth() ?? 0;
     $keyword = Node::fromJSON(
@@ -227,8 +227,8 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
     }
     return new static(
       $attribute_spec as ?OldAttributeSpecification,
-      /* HH_FIXME[4110] ?NodeList<PublicToken> may not be enforceable */ $modifiers,
-      $module_kw_opt as ?ModuleToken,
+      $modifiers as ?Node,
+      $module_kw_opt as ?Node,
       $keyword as Token,
       $name as NameToken,
       $generic_parameter as ?TypeParameters,
@@ -283,7 +283,7 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
     return $this->_modifiers;
   }
 
-  public function withModifiers(?NodeList<PublicToken> $value): this {
+  public function withModifiers(?Node $value): this {
     if ($value === $this->_modifiers) {
       return $this;
     }
@@ -306,16 +306,16 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
   }
 
   /**
-   * @return NodeList<PublicToken> | null
+   * @return null
    */
-  public function getModifiers(): ?NodeList<PublicToken> {
+  public function getModifiers(): ?Node {
     return $this->_modifiers;
   }
 
   /**
-   * @return NodeList<PublicToken>
+   * @return
    */
-  public function getModifiersx(): NodeList<PublicToken> {
+  public function getModifiersx(): Node {
     return TypeAssert\not_null($this->getModifiers());
   }
 
@@ -323,7 +323,7 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
     return $this->_module_kw_opt;
   }
 
-  public function withModuleKwOpt(?ModuleToken $value): this {
+  public function withModuleKwOpt(?Node $value): this {
     if ($value === $this->_module_kw_opt) {
       return $this;
     }
@@ -346,16 +346,16 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
   }
 
   /**
-   * @return null | ModuleToken
+   * @return null
    */
-  public function getModuleKwOpt(): ?ModuleToken {
+  public function getModuleKwOpt(): ?Node {
     return $this->_module_kw_opt;
   }
 
   /**
-   * @return ModuleToken
+   * @return
    */
-  public function getModuleKwOptx(): ModuleToken {
+  public function getModuleKwOptx(): Node {
     return TypeAssert\not_null($this->getModuleKwOpt());
   }
 

--- a/codegen/syntax/AttributizedSpecifier.hack
+++ b/codegen/syntax/AttributizedSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0292b8b73ed163d95845503bd88c184a>>
+ * @generated SignedSource<<029c9c45acb4f6a4de09537c73291050>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -142,8 +142,8 @@ final class AttributizedSpecifier extends Node implements ITypeSpecifier {
 
   /**
    * @return ClosureTypeSpecifier | DarrayTypeSpecifier |
-   * DictionaryTypeSpecifier | GenericTypeSpecifier | NullableTypeSpecifier |
-   * SimpleTypeSpecifier | TupleTypeSpecifier
+   * DictionaryTypeSpecifier | GenericTypeSpecifier | LikeTypeSpecifier |
+   * NullableTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier
    */
   public function getType(): ITypeSpecifier {
     return TypeAssert\instance_of(ITypeSpecifier::class, $this->_type);
@@ -151,8 +151,8 @@ final class AttributizedSpecifier extends Node implements ITypeSpecifier {
 
   /**
    * @return ClosureTypeSpecifier | DarrayTypeSpecifier |
-   * DictionaryTypeSpecifier | GenericTypeSpecifier | NullableTypeSpecifier |
-   * SimpleTypeSpecifier | TupleTypeSpecifier
+   * DictionaryTypeSpecifier | GenericTypeSpecifier | LikeTypeSpecifier |
+   * NullableTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier
    */
   public function getTypex(): ITypeSpecifier {
     return $this->getType();

--- a/codegen/syntax/ClassishDeclaration.hack
+++ b/codegen/syntax/ClassishDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<efaed262dbcaf1bee37262fcfc534a14>>
+ * @generated SignedSource<<0b4b3a0c25254e05f99adb00d9e667f8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -359,15 +359,14 @@ final class ClassishDeclaration
 
   /**
    * @return NodeList<AbstractToken> | NodeList<Token> | NodeList<FinalToken> |
-   * NodeList<InternalToken> | NodeList<PublicToken> | null
+   * null
    */
   public function getModifiers(): ?NodeList<Token> {
     return $this->_modifiers;
   }
 
   /**
-   * @return NodeList<AbstractToken> | NodeList<Token> | NodeList<FinalToken> |
-   * NodeList<InternalToken> | NodeList<PublicToken>
+   * @return NodeList<AbstractToken> | NodeList<Token> | NodeList<FinalToken>
    */
   public function getModifiersx(): NodeList<Token> {
     return TypeAssert\not_null($this->getModifiers());

--- a/codegen/syntax/ClassnameTypeSpecifier.hack
+++ b/codegen/syntax/ClassnameTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<28ff491307c635abc18664bf1714f96d>>
+ * @generated SignedSource<<940b4d1283c6d974b2cf6f65a60e33f5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -16,14 +16,14 @@ final class ClassnameTypeSpecifier extends Node implements ITypeSpecifier {
 
   private ClassnameToken $_keyword;
   private ?LessThanToken $_left_angle;
-  private ?Node $_type;
+  private ?ITypeSpecifier $_type;
   private ?Node $_trailing_comma;
   private ?GreaterThanToken $_right_angle;
 
   public function __construct(
     ClassnameToken $keyword,
     ?LessThanToken $left_angle,
-    ?Node $type,
+    ?ITypeSpecifier $type,
     ?Node $trailing_comma,
     ?GreaterThanToken $right_angle,
     ?__Private\SourceRef $source_ref = null,
@@ -68,7 +68,7 @@ final class ClassnameTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
-      'Node',
+      'ITypeSpecifier',
     );
     $offset += $type?->getWidth() ?? 0;
     $trailing_comma = Node::fromJSON(
@@ -146,7 +146,7 @@ final class ClassnameTypeSpecifier extends Node implements ITypeSpecifier {
     return new static(
       $keyword as ClassnameToken,
       $left_angle as ?LessThanToken,
-      $type as ?Node,
+      $type as ?ITypeSpecifier,
       $trailing_comma as ?Node,
       $right_angle as ?GreaterThanToken,
     );
@@ -226,7 +226,7 @@ final class ClassnameTypeSpecifier extends Node implements ITypeSpecifier {
     return $this->_type;
   }
 
-  public function withType(?Node $value): this {
+  public function withType(?ITypeSpecifier $value): this {
     if ($value === $this->_type) {
       return $this;
     }
@@ -244,18 +244,16 @@ final class ClassnameTypeSpecifier extends Node implements ITypeSpecifier {
   }
 
   /**
-   * @return GenericTypeSpecifier | null | SimpleTypeSpecifier | TypeConstant |
-   * TypeRefinement
+   * @return GenericTypeSpecifier | null | SimpleTypeSpecifier | TypeConstant
    */
-  public function getType(): ?Node {
+  public function getType(): ?ITypeSpecifier {
     return $this->_type;
   }
 
   /**
-   * @return GenericTypeSpecifier | SimpleTypeSpecifier | TypeConstant |
-   * TypeRefinement
+   * @return GenericTypeSpecifier | SimpleTypeSpecifier | TypeConstant
    */
-  public function getTypex(): Node {
+  public function getTypex(): ITypeSpecifier {
     return TypeAssert\not_null($this->getType());
   }
 

--- a/codegen/syntax/ClassnameTypeSpecifier.hack
+++ b/codegen/syntax/ClassnameTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<940b4d1283c6d974b2cf6f65a60e33f5>>
+ * @generated SignedSource<<d02f9691a4afe313e6478c3c20ec4dc9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -244,14 +244,16 @@ final class ClassnameTypeSpecifier extends Node implements ITypeSpecifier {
   }
 
   /**
-   * @return GenericTypeSpecifier | null | SimpleTypeSpecifier | TypeConstant
+   * @return GenericTypeSpecifier | null | SimpleTypeSpecifier | TypeConstant |
+   * TypeRefinement
    */
   public function getType(): ?ITypeSpecifier {
     return $this->_type;
   }
 
   /**
-   * @return GenericTypeSpecifier | SimpleTypeSpecifier | TypeConstant
+   * @return GenericTypeSpecifier | SimpleTypeSpecifier | TypeConstant |
+   * TypeRefinement
    */
   public function getTypex(): ITypeSpecifier {
     return TypeAssert\not_null($this->getType());

--- a/codegen/syntax/ClosureTypeSpecifier.hack
+++ b/codegen/syntax/ClosureTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9c84879ef1b8682f02bbf8aafc171109>>
+ * @generated SignedSource<<d5076bd15d3bed9d614e8a13aa1bf8e4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -662,7 +662,8 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
 
   /**
    * @return ClosureTypeSpecifier | GenericTypeSpecifier | LikeTypeSpecifier |
-   * NullableTypeSpecifier | SimpleTypeSpecifier | VectorTypeSpecifier
+   * NullableTypeSpecifier | SimpleTypeSpecifier | TypeRefinement |
+   * VectorTypeSpecifier
    */
   public function getReturnType(): ITypeSpecifier {
     return TypeAssert\instance_of(ITypeSpecifier::class, $this->_return_type);
@@ -670,7 +671,8 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
 
   /**
    * @return ClosureTypeSpecifier | GenericTypeSpecifier | LikeTypeSpecifier |
-   * NullableTypeSpecifier | SimpleTypeSpecifier | VectorTypeSpecifier
+   * NullableTypeSpecifier | SimpleTypeSpecifier | TypeRefinement |
+   * VectorTypeSpecifier
    */
   public function getReturnTypex(): ITypeSpecifier {
     return $this->getReturnType();

--- a/codegen/syntax/ClosureTypeSpecifier.hack
+++ b/codegen/syntax/ClosureTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0f788451c8a0501a9fe1150e554018bf>>
+ * @generated SignedSource<<9c84879ef1b8682f02bbf8aafc171109>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -23,7 +23,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
   private ?Contexts $_contexts;
   private ColonToken $_colon;
   private ?ReadonlyToken $_readonly_return;
-  private Node $_return_type;
+  private ITypeSpecifier $_return_type;
   private RightParenToken $_outer_right_paren;
 
   public function __construct(
@@ -36,7 +36,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
     ?Contexts $contexts,
     ColonToken $colon,
     ?ReadonlyToken $readonly_return,
-    Node $return_type,
+    ITypeSpecifier $return_type,
     RightParenToken $outer_right_paren,
     ?__Private\SourceRef $source_ref = null,
   ) {
@@ -148,7 +148,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $file,
       $offset,
       $source,
-      'Node',
+      'ITypeSpecifier',
     );
     $return_type = $return_type as nonnull;
     $offset += $return_type->getWidth();
@@ -250,7 +250,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $contexts as ?Contexts,
       $colon as ColonToken,
       $readonly_return as ?ReadonlyToken,
-      $return_type as Node,
+      $return_type as ITypeSpecifier,
       $outer_right_paren as RightParenToken,
     );
   }
@@ -637,7 +637,7 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
     return $this->_return_type;
   }
 
-  public function withReturnType(Node $value): this {
+  public function withReturnType(ITypeSpecifier $value): this {
     if ($value === $this->_return_type) {
       return $this;
     }
@@ -662,19 +662,17 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
 
   /**
    * @return ClosureTypeSpecifier | GenericTypeSpecifier | LikeTypeSpecifier |
-   * NullableTypeSpecifier | SimpleTypeSpecifier | TypeRefinement |
-   * VectorTypeSpecifier
+   * NullableTypeSpecifier | SimpleTypeSpecifier | VectorTypeSpecifier
    */
-  public function getReturnType(): Node {
-    return $this->_return_type;
+  public function getReturnType(): ITypeSpecifier {
+    return TypeAssert\instance_of(ITypeSpecifier::class, $this->_return_type);
   }
 
   /**
    * @return ClosureTypeSpecifier | GenericTypeSpecifier | LikeTypeSpecifier |
-   * NullableTypeSpecifier | SimpleTypeSpecifier | TypeRefinement |
-   * VectorTypeSpecifier
+   * NullableTypeSpecifier | SimpleTypeSpecifier | VectorTypeSpecifier
    */
-  public function getReturnTypex(): Node {
+  public function getReturnTypex(): ITypeSpecifier {
     return $this->getReturnType();
   }
 

--- a/codegen/syntax/EnumClassDeclaration.hack
+++ b/codegen/syntax/EnumClassDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<71ee494596dad01a0be73d16ce53f8f8>>
+ * @generated SignedSource<<a7c30d2187e8388b7cf01c673e566e82>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -15,7 +15,7 @@ final class EnumClassDeclaration extends Node {
   const string SYNTAX_KIND = 'enum_class_declaration';
 
   private ?OldAttributeSpecification $_attribute_spec;
-  private ?NodeList<Token> $_modifiers;
+  private ?NodeList<AbstractToken> $_modifiers;
   private EnumToken $_enum_keyword;
   private ClassToken $_class_keyword;
   private NameToken $_name;
@@ -29,7 +29,7 @@ final class EnumClassDeclaration extends Node {
 
   public function __construct(
     ?OldAttributeSpecification $attribute_spec,
-    ?NodeList<Token> $modifiers,
+    ?NodeList<AbstractToken> $modifiers,
     EnumToken $enum_keyword,
     ClassToken $class_keyword,
     NameToken $name,
@@ -81,7 +81,7 @@ final class EnumClassDeclaration extends Node {
       $file,
       $offset,
       $source,
-      'NodeList<Token>',
+      'NodeList<AbstractToken>',
     );
     $offset += $modifiers?->getWidth() ?? 0;
     $enum_keyword = Node::fromJSON(
@@ -258,7 +258,7 @@ final class EnumClassDeclaration extends Node {
     }
     return new static(
       $attribute_spec as ?OldAttributeSpecification,
-      /* HH_FIXME[4110] ?NodeList<Token> may not be enforceable */ $modifiers,
+      /* HH_FIXME[4110] ?NodeList<AbstractToken> may not be enforceable */ $modifiers,
       $enum_keyword as EnumToken,
       $class_keyword as ClassToken,
       $name as NameToken,
@@ -318,7 +318,7 @@ final class EnumClassDeclaration extends Node {
     return $this->_modifiers;
   }
 
-  public function withModifiers(?NodeList<Token> $value): this {
+  public function withModifiers(?NodeList<AbstractToken> $value): this {
     if ($value === $this->_modifiers) {
       return $this;
     }
@@ -343,18 +343,16 @@ final class EnumClassDeclaration extends Node {
   }
 
   /**
-   * @return NodeList<AbstractToken> | NodeList<InternalToken> |
-   * NodeList<PublicToken> | null
+   * @return NodeList<AbstractToken> | null
    */
-  public function getModifiers(): ?NodeList<Token> {
+  public function getModifiers(): ?NodeList<AbstractToken> {
     return $this->_modifiers;
   }
 
   /**
-   * @return NodeList<AbstractToken> | NodeList<InternalToken> |
-   * NodeList<PublicToken>
+   * @return NodeList<AbstractToken>
    */
-  public function getModifiersx(): NodeList<Token> {
+  public function getModifiersx(): NodeList<AbstractToken> {
     return TypeAssert\not_null($this->getModifiers());
   }
 

--- a/codegen/syntax/EnumDeclaration.hack
+++ b/codegen/syntax/EnumDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<194693a524b90d5d00f80feff66c9e73>>
+ * @generated SignedSource<<23c47098179517a5b778b258f67ac93d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -15,7 +15,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
   const string SYNTAX_KIND = 'enum_declaration';
 
   private ?OldAttributeSpecification $_attribute_spec;
-  private ?NodeList<PublicToken> $_modifiers;
+  private ?Node $_modifiers;
   private EnumToken $_keyword;
   private NameToken $_name;
   private ColonToken $_colon;
@@ -28,7 +28,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
 
   public function __construct(
     ?OldAttributeSpecification $attribute_spec,
-    ?NodeList<PublicToken> $modifiers,
+    ?Node $modifiers,
     EnumToken $keyword,
     NameToken $name,
     ColonToken $colon,
@@ -76,7 +76,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
       $file,
       $offset,
       $source,
-      'NodeList<PublicToken>',
+      'Node',
     );
     $offset += $modifiers?->getWidth() ?? 0;
     $keyword = Node::fromJSON(
@@ -239,7 +239,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
     }
     return new static(
       $attribute_spec as ?OldAttributeSpecification,
-      /* HH_FIXME[4110] ?NodeList<PublicToken> may not be enforceable */ $modifiers,
+      $modifiers as ?Node,
       $keyword as EnumToken,
       $name as NameToken,
       $colon as ColonToken,
@@ -297,7 +297,7 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
     return $this->_modifiers;
   }
 
-  public function withModifiers(?NodeList<PublicToken> $value): this {
+  public function withModifiers(?Node $value): this {
     if ($value === $this->_modifiers) {
       return $this;
     }
@@ -321,16 +321,16 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
   }
 
   /**
-   * @return NodeList<PublicToken> | null
+   * @return null
    */
-  public function getModifiers(): ?NodeList<PublicToken> {
+  public function getModifiers(): ?Node {
     return $this->_modifiers;
   }
 
   /**
-   * @return NodeList<PublicToken>
+   * @return
    */
-  public function getModifiersx(): NodeList<PublicToken> {
+  public function getModifiersx(): Node {
     return TypeAssert\not_null($this->getModifiers());
   }
 

--- a/codegen/syntax/FunctionDeclarationHeader.hack
+++ b/codegen/syntax/FunctionDeclarationHeader.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7b65d73e7cc67162336dad84654cc162>>
+ * @generated SignedSource<<24665462d5c5e66ed6bc35d92fc9b6b1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -24,7 +24,7 @@ final class FunctionDeclarationHeader extends Node {
   private ?Contexts $_contexts;
   private ?ColonToken $_colon;
   private ?ReadonlyToken $_readonly_return;
-  private ?Node $_type;
+  private ?ITypeSpecifier $_type;
   private ?WhereClause $_where_clause;
 
   public function __construct(
@@ -38,7 +38,7 @@ final class FunctionDeclarationHeader extends Node {
     ?Contexts $contexts,
     ?ColonToken $colon,
     ?ReadonlyToken $readonly_return,
-    ?Node $type,
+    ?ITypeSpecifier $type,
     ?WhereClause $where_clause,
     ?__Private\SourceRef $source_ref = null,
   ) {
@@ -158,7 +158,7 @@ final class FunctionDeclarationHeader extends Node {
       $file,
       $offset,
       $source,
-      'Node',
+      'ITypeSpecifier',
     );
     $offset += $type?->getWidth() ?? 0;
     $where_clause = Node::fromJSON(
@@ -268,7 +268,7 @@ final class FunctionDeclarationHeader extends Node {
       $contexts as ?Contexts,
       $colon as ?ColonToken,
       $readonly_return as ?ReadonlyToken,
-      $type as ?Node,
+      $type as ?ITypeSpecifier,
       $where_clause as ?WhereClause,
     );
   }
@@ -707,7 +707,7 @@ final class FunctionDeclarationHeader extends Node {
     return $this->_type;
   }
 
-  public function withType(?Node $value): this {
+  public function withType(?ITypeSpecifier $value): this {
     if ($value === $this->_type) {
       return $this;
     }
@@ -736,10 +736,10 @@ final class FunctionDeclarationHeader extends Node {
    * ClosureTypeSpecifier | DarrayTypeSpecifier | DictionaryTypeSpecifier |
    * GenericTypeSpecifier | KeysetTypeSpecifier | LikeTypeSpecifier | null |
    * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
-   * NoreturnToken | TupleTypeSpecifier | TypeConstant | TypeRefinement |
-   * VarrayTypeSpecifier | VectorTypeSpecifier
+   * NoreturnToken | TupleTypeSpecifier | TypeConstant | VarrayTypeSpecifier |
+   * VectorTypeSpecifier
    */
-  public function getType(): ?Node {
+  public function getType(): ?ITypeSpecifier {
     return $this->_type;
   }
 
@@ -748,10 +748,10 @@ final class FunctionDeclarationHeader extends Node {
    * ClosureTypeSpecifier | DarrayTypeSpecifier | DictionaryTypeSpecifier |
    * GenericTypeSpecifier | KeysetTypeSpecifier | LikeTypeSpecifier |
    * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
-   * NoreturnToken | TupleTypeSpecifier | TypeConstant | TypeRefinement |
-   * VarrayTypeSpecifier | VectorTypeSpecifier
+   * NoreturnToken | TupleTypeSpecifier | TypeConstant | VarrayTypeSpecifier |
+   * VectorTypeSpecifier
    */
-  public function getTypex(): Node {
+  public function getTypex(): ITypeSpecifier {
     return TypeAssert\not_null($this->getType());
   }
 

--- a/codegen/syntax/FunctionDeclarationHeader.hack
+++ b/codegen/syntax/FunctionDeclarationHeader.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<24665462d5c5e66ed6bc35d92fc9b6b1>>
+ * @generated SignedSource<<c28a0b4b049e76cdb2c90d48ac0bc1b9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -303,9 +303,9 @@ final class FunctionDeclarationHeader extends Node {
 
   /**
    * @return NodeList<AbstractToken> | NodeList<Token> | NodeList<AsyncToken> |
-   * NodeList<FinalToken> | NodeList<InternalToken> | NodeList<PrivateToken> |
-   * NodeList<ProtectedToken> | NodeList<PublicToken> | NodeList<ReadonlyToken>
-   * | NodeList<StaticToken> | null
+   * NodeList<FinalToken> | NodeList<PrivateToken> | NodeList<ProtectedToken> |
+   * NodeList<PublicToken> | NodeList<ReadonlyToken> | NodeList<StaticToken> |
+   * null
    */
   public function getModifiers(): ?NodeList<Token> {
     return $this->_modifiers;
@@ -313,9 +313,8 @@ final class FunctionDeclarationHeader extends Node {
 
   /**
    * @return NodeList<AbstractToken> | NodeList<Token> | NodeList<AsyncToken> |
-   * NodeList<FinalToken> | NodeList<InternalToken> | NodeList<PrivateToken> |
-   * NodeList<ProtectedToken> | NodeList<PublicToken> | NodeList<ReadonlyToken>
-   * | NodeList<StaticToken>
+   * NodeList<FinalToken> | NodeList<PrivateToken> | NodeList<ProtectedToken> |
+   * NodeList<PublicToken> | NodeList<ReadonlyToken> | NodeList<StaticToken>
    */
   public function getModifiersx(): NodeList<Token> {
     return TypeAssert\not_null($this->getModifiers());
@@ -736,8 +735,8 @@ final class FunctionDeclarationHeader extends Node {
    * ClosureTypeSpecifier | DarrayTypeSpecifier | DictionaryTypeSpecifier |
    * GenericTypeSpecifier | KeysetTypeSpecifier | LikeTypeSpecifier | null |
    * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
-   * NoreturnToken | TupleTypeSpecifier | TypeConstant | VarrayTypeSpecifier |
-   * VectorTypeSpecifier
+   * NoreturnToken | TupleTypeSpecifier | TypeConstant | TypeRefinement |
+   * VarrayTypeSpecifier | VectorTypeSpecifier
    */
   public function getType(): ?ITypeSpecifier {
     return $this->_type;
@@ -748,8 +747,8 @@ final class FunctionDeclarationHeader extends Node {
    * ClosureTypeSpecifier | DarrayTypeSpecifier | DictionaryTypeSpecifier |
    * GenericTypeSpecifier | KeysetTypeSpecifier | LikeTypeSpecifier |
    * NullableTypeSpecifier | ShapeTypeSpecifier | SimpleTypeSpecifier |
-   * NoreturnToken | TupleTypeSpecifier | TypeConstant | VarrayTypeSpecifier |
-   * VectorTypeSpecifier
+   * NoreturnToken | TupleTypeSpecifier | TypeConstant | TypeRefinement |
+   * VarrayTypeSpecifier | VectorTypeSpecifier
    */
   public function getTypex(): ITypeSpecifier {
     return TypeAssert\not_null($this->getType());

--- a/codegen/syntax/ModuleDeclaration.hack
+++ b/codegen/syntax/ModuleDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1d1fb415307f0976061bdb3cbad664a8>>
+ * @generated SignedSource<<04ce291c75a90778876e136f06fb298d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -14,7 +14,7 @@ final class ModuleDeclaration extends Node {
 
   const string SYNTAX_KIND = 'module_declaration';
 
-  private ?OldAttributeSpecification $_attribute_spec;
+  private OldAttributeSpecification $_attribute_spec;
   private NewToken $_new_keyword;
   private ModuleToken $_module_keyword;
   private ModuleName $_name;
@@ -24,7 +24,7 @@ final class ModuleDeclaration extends Node {
   private RightBraceToken $_right_brace;
 
   public function __construct(
-    ?OldAttributeSpecification $attribute_spec,
+    OldAttributeSpecification $attribute_spec,
     NewToken $new_keyword,
     ModuleToken $module_keyword,
     ModuleName $name,
@@ -55,14 +55,14 @@ final class ModuleDeclaration extends Node {
   ): this {
     $offset = $initial_offset;
     $attribute_spec = Node::fromJSON(
-      ($json['module_declaration_attribute_spec'] ?? dict['kind' => 'missing'])
-        as dict<_, _>,
+      ($json['module_declaration_attribute_spec']) as dict<_, _>,
       $file,
       $offset,
       $source,
       'OldAttributeSpecification',
     );
-    $offset += $attribute_spec?->getWidth() ?? 0;
+    $attribute_spec = $attribute_spec as nonnull;
+    $offset += $attribute_spec->getWidth();
     $new_keyword = Node::fromJSON(
       ($json['module_declaration_new_keyword']) as dict<_, _>,
       $file,
@@ -166,9 +166,7 @@ final class ModuleDeclaration extends Node {
     vec<Node> $parents = vec[],
   ): this {
     $parents[] = $this;
-    $attribute_spec = $this->_attribute_spec === null
-      ? null
-      : $rewriter($this->_attribute_spec, $parents);
+    $attribute_spec = $rewriter($this->_attribute_spec, $parents);
     $new_keyword = $rewriter($this->_new_keyword, $parents);
     $module_keyword = $rewriter($this->_module_keyword, $parents);
     $name = $rewriter($this->_name, $parents);
@@ -191,7 +189,7 @@ final class ModuleDeclaration extends Node {
       return $this;
     }
     return new static(
-      $attribute_spec as ?OldAttributeSpecification,
+      $attribute_spec as OldAttributeSpecification,
       $new_keyword as NewToken,
       $module_keyword as ModuleToken,
       $name as ModuleName,
@@ -206,7 +204,7 @@ final class ModuleDeclaration extends Node {
     return $this->_attribute_spec;
   }
 
-  public function withAttributeSpec(?OldAttributeSpecification $value): this {
+  public function withAttributeSpec(OldAttributeSpecification $value): this {
     if ($value === $this->_attribute_spec) {
       return $this;
     }
@@ -223,21 +221,24 @@ final class ModuleDeclaration extends Node {
   }
 
   public function hasAttributeSpec(): bool {
-    return $this->_attribute_spec !== null;
+    return true;
   }
 
   /**
-   * @return null | OldAttributeSpecification
+   * @return OldAttributeSpecification
    */
-  public function getAttributeSpec(): ?OldAttributeSpecification {
-    return $this->_attribute_spec;
+  public function getAttributeSpec(): OldAttributeSpecification {
+    return TypeAssert\instance_of(
+      OldAttributeSpecification::class,
+      $this->_attribute_spec,
+    );
   }
 
   /**
    * @return OldAttributeSpecification
    */
   public function getAttributeSpecx(): OldAttributeSpecification {
-    return TypeAssert\not_null($this->getAttributeSpec());
+    return $this->getAttributeSpec();
   }
 
   public function getNewKeywordUNTYPED(): ?Node {

--- a/codegen/syntax/PackageDeclaration.hack
+++ b/codegen/syntax/PackageDeclaration.hack
@@ -1,0 +1,453 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * @generated SignedSource<<75d2329eb34236a7ab79901cedc637f9>>
+ */
+namespace Facebook\HHAST;
+use namespace Facebook\TypeAssert;
+use namespace HH\Lib\Dict;
+/* HHAST_IGNORE_ALL[5607] 5607 is ignored because of false positives when comparing a generic to a typed value */
+/* HHAST_IGNORE_ALL[5624] HHAST_IGNORE_ALL[5639] 5624 and 5639 are ignored because they insist on using co(tra)variant generics. Could this break external consumers? */
+
+<<__ConsistentConstruct>>
+final class PackageDeclaration extends Node {
+
+  const string SYNTAX_KIND = 'package_declaration';
+
+  private ?Node $_attribute_spec;
+  private ?Node $_package_keyword;
+  private ?Node $_name;
+  private ?Node $_left_brace;
+  private ?Node $_uses;
+  private ?Node $_includes;
+  private ?Node $_right_brace;
+
+  public function __construct(
+    ?Node $attribute_spec,
+    ?Node $package_keyword,
+    ?Node $name,
+    ?Node $left_brace,
+    ?Node $uses,
+    ?Node $includes,
+    ?Node $right_brace,
+    ?__Private\SourceRef $source_ref = null,
+  ) {
+    $this->_attribute_spec = $attribute_spec;
+    $this->_package_keyword = $package_keyword;
+    $this->_name = $name;
+    $this->_left_brace = $left_brace;
+    $this->_uses = $uses;
+    $this->_includes = $includes;
+    $this->_right_brace = $right_brace;
+    parent::__construct($source_ref);
+  }
+
+  <<__Override>>
+  public static function fromJSON(
+    dict<arraykey, mixed> $json,
+    string $file,
+    int $initial_offset,
+    string $source,
+    string $_type_hint,
+  ): this {
+    $offset = $initial_offset;
+    $attribute_spec = Node::fromJSON(
+      ($json['package_declaration_attribute_spec'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $attribute_spec?->getWidth() ?? 0;
+    $package_keyword = Node::fromJSON(
+      (
+        $json['package_declaration_package_keyword'] ??
+        dict['kind' => 'missing']
+      ) as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $package_keyword?->getWidth() ?? 0;
+    $name = Node::fromJSON(
+      ($json['package_declaration_name'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $name?->getWidth() ?? 0;
+    $left_brace = Node::fromJSON(
+      ($json['package_declaration_left_brace'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $left_brace?->getWidth() ?? 0;
+    $uses = Node::fromJSON(
+      ($json['package_declaration_uses'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $uses?->getWidth() ?? 0;
+    $includes = Node::fromJSON(
+      ($json['package_declaration_includes'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $includes?->getWidth() ?? 0;
+    $right_brace = Node::fromJSON(
+      ($json['package_declaration_right_brace'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $right_brace?->getWidth() ?? 0;
+    $source_ref = shape(
+      'file' => $file,
+      'source' => $source,
+      'offset' => $initial_offset,
+      'width' => $offset - $initial_offset,
+    );
+    return new static(
+      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
+      /* HH_IGNORE_ERROR[4110] */ $package_keyword,
+      /* HH_IGNORE_ERROR[4110] */ $name,
+      /* HH_IGNORE_ERROR[4110] */ $left_brace,
+      /* HH_IGNORE_ERROR[4110] */ $uses,
+      /* HH_IGNORE_ERROR[4110] */ $includes,
+      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $source_ref,
+    );
+  }
+
+  <<__Override>>
+  public function getChildren(): dict<string, Node> {
+    return dict[
+      'attribute_spec' => $this->_attribute_spec,
+      'package_keyword' => $this->_package_keyword,
+      'name' => $this->_name,
+      'left_brace' => $this->_left_brace,
+      'uses' => $this->_uses,
+      'includes' => $this->_includes,
+      'right_brace' => $this->_right_brace,
+    ]
+      |> Dict\filter_nulls($$);
+  }
+
+  <<__Override>>
+  public function rewriteChildren<Tret as ?Node>(
+    (function(Node, vec<Node>): Tret) $rewriter,
+    vec<Node> $parents = vec[],
+  ): this {
+    $parents[] = $this;
+    $attribute_spec = $this->_attribute_spec === null
+      ? null
+      : $rewriter($this->_attribute_spec, $parents);
+    $package_keyword = $this->_package_keyword === null
+      ? null
+      : $rewriter($this->_package_keyword, $parents);
+    $name = $this->_name === null ? null : $rewriter($this->_name, $parents);
+    $left_brace = $this->_left_brace === null
+      ? null
+      : $rewriter($this->_left_brace, $parents);
+    $uses = $this->_uses === null ? null : $rewriter($this->_uses, $parents);
+    $includes =
+      $this->_includes === null ? null : $rewriter($this->_includes, $parents);
+    $right_brace = $this->_right_brace === null
+      ? null
+      : $rewriter($this->_right_brace, $parents);
+    if (
+      $attribute_spec === $this->_attribute_spec &&
+      $package_keyword === $this->_package_keyword &&
+      $name === $this->_name &&
+      $left_brace === $this->_left_brace &&
+      $uses === $this->_uses &&
+      $includes === $this->_includes &&
+      $right_brace === $this->_right_brace
+    ) {
+      return $this;
+    }
+    return new static(
+      $attribute_spec as ?Node,
+      $package_keyword as ?Node,
+      $name as ?Node,
+      $left_brace as ?Node,
+      $uses as ?Node,
+      $includes as ?Node,
+      $right_brace as ?Node,
+    );
+  }
+
+  public function getAttributeSpecUNTYPED(): ?Node {
+    return $this->_attribute_spec;
+  }
+
+  public function withAttributeSpec(?Node $value): this {
+    if ($value === $this->_attribute_spec) {
+      return $this;
+    }
+    return new static(
+      $value,
+      $this->_package_keyword,
+      $this->_name,
+      $this->_left_brace,
+      $this->_uses,
+      $this->_includes,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasAttributeSpec(): bool {
+    return $this->_attribute_spec !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getAttributeSpec(): ?Node {
+    return $this->_attribute_spec;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getAttributeSpecx(): Node {
+    return TypeAssert\not_null($this->getAttributeSpec());
+  }
+
+  public function getPackageKeywordUNTYPED(): ?Node {
+    return $this->_package_keyword;
+  }
+
+  public function withPackageKeyword(?Node $value): this {
+    if ($value === $this->_package_keyword) {
+      return $this;
+    }
+    return new static(
+      $this->_attribute_spec,
+      $value,
+      $this->_name,
+      $this->_left_brace,
+      $this->_uses,
+      $this->_includes,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasPackageKeyword(): bool {
+    return $this->_package_keyword !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getPackageKeyword(): ?Node {
+    return $this->_package_keyword;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getPackageKeywordx(): Node {
+    return TypeAssert\not_null($this->getPackageKeyword());
+  }
+
+  public function getNameUNTYPED(): ?Node {
+    return $this->_name;
+  }
+
+  public function withName(?Node $value): this {
+    if ($value === $this->_name) {
+      return $this;
+    }
+    return new static(
+      $this->_attribute_spec,
+      $this->_package_keyword,
+      $value,
+      $this->_left_brace,
+      $this->_uses,
+      $this->_includes,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasName(): bool {
+    return $this->_name !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getName(): ?Node {
+    return $this->_name;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getNamex(): Node {
+    return TypeAssert\not_null($this->getName());
+  }
+
+  public function getLeftBraceUNTYPED(): ?Node {
+    return $this->_left_brace;
+  }
+
+  public function withLeftBrace(?Node $value): this {
+    if ($value === $this->_left_brace) {
+      return $this;
+    }
+    return new static(
+      $this->_attribute_spec,
+      $this->_package_keyword,
+      $this->_name,
+      $value,
+      $this->_uses,
+      $this->_includes,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasLeftBrace(): bool {
+    return $this->_left_brace !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getLeftBrace(): ?Node {
+    return $this->_left_brace;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getLeftBracex(): Node {
+    return TypeAssert\not_null($this->getLeftBrace());
+  }
+
+  public function getUsesUNTYPED(): ?Node {
+    return $this->_uses;
+  }
+
+  public function withUses(?Node $value): this {
+    if ($value === $this->_uses) {
+      return $this;
+    }
+    return new static(
+      $this->_attribute_spec,
+      $this->_package_keyword,
+      $this->_name,
+      $this->_left_brace,
+      $value,
+      $this->_includes,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasUses(): bool {
+    return $this->_uses !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getUses(): ?Node {
+    return $this->_uses;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getUsesx(): Node {
+    return TypeAssert\not_null($this->getUses());
+  }
+
+  public function getIncludesUNTYPED(): ?Node {
+    return $this->_includes;
+  }
+
+  public function withIncludes(?Node $value): this {
+    if ($value === $this->_includes) {
+      return $this;
+    }
+    return new static(
+      $this->_attribute_spec,
+      $this->_package_keyword,
+      $this->_name,
+      $this->_left_brace,
+      $this->_uses,
+      $value,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasIncludes(): bool {
+    return $this->_includes !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getIncludes(): ?Node {
+    return $this->_includes;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getIncludesx(): Node {
+    return TypeAssert\not_null($this->getIncludes());
+  }
+
+  public function getRightBraceUNTYPED(): ?Node {
+    return $this->_right_brace;
+  }
+
+  public function withRightBrace(?Node $value): this {
+    if ($value === $this->_right_brace) {
+      return $this;
+    }
+    return new static(
+      $this->_attribute_spec,
+      $this->_package_keyword,
+      $this->_name,
+      $this->_left_brace,
+      $this->_uses,
+      $this->_includes,
+      $value,
+    );
+  }
+
+  public function hasRightBrace(): bool {
+    return $this->_right_brace !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getRightBrace(): ?Node {
+    return $this->_right_brace;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getRightBracex(): Node {
+    return TypeAssert\not_null($this->getRightBrace());
+  }
+}

--- a/codegen/syntax/PackageIncludes.hack
+++ b/codegen/syntax/PackageIncludes.hack
@@ -1,0 +1,275 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * @generated SignedSource<<8ddab217e385115c2ff9dfb4f36fa2fa>>
+ */
+namespace Facebook\HHAST;
+use namespace Facebook\TypeAssert;
+use namespace HH\Lib\Dict;
+/* HHAST_IGNORE_ALL[5607] 5607 is ignored because of false positives when comparing a generic to a typed value */
+/* HHAST_IGNORE_ALL[5624] HHAST_IGNORE_ALL[5639] 5624 and 5639 are ignored because they insist on using co(tra)variant generics. Could this break external consumers? */
+
+<<__ConsistentConstruct>>
+final class PackageIncludes extends Node {
+
+  const string SYNTAX_KIND = 'package_includes';
+
+  private ?Node $_include_keyword;
+  private ?Node $_left_brace;
+  private ?Node $_includes;
+  private ?Node $_right_brace;
+
+  public function __construct(
+    ?Node $include_keyword,
+    ?Node $left_brace,
+    ?Node $includes,
+    ?Node $right_brace,
+    ?__Private\SourceRef $source_ref = null,
+  ) {
+    $this->_include_keyword = $include_keyword;
+    $this->_left_brace = $left_brace;
+    $this->_includes = $includes;
+    $this->_right_brace = $right_brace;
+    parent::__construct($source_ref);
+  }
+
+  <<__Override>>
+  public static function fromJSON(
+    dict<arraykey, mixed> $json,
+    string $file,
+    int $initial_offset,
+    string $source,
+    string $_type_hint,
+  ): this {
+    $offset = $initial_offset;
+    $include_keyword = Node::fromJSON(
+      ($json['package_includes_include_keyword'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $include_keyword?->getWidth() ?? 0;
+    $left_brace = Node::fromJSON(
+      ($json['package_includes_left_brace'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $left_brace?->getWidth() ?? 0;
+    $includes = Node::fromJSON(
+      ($json['package_includes_includes'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $includes?->getWidth() ?? 0;
+    $right_brace = Node::fromJSON(
+      ($json['package_includes_right_brace'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $right_brace?->getWidth() ?? 0;
+    $source_ref = shape(
+      'file' => $file,
+      'source' => $source,
+      'offset' => $initial_offset,
+      'width' => $offset - $initial_offset,
+    );
+    return new static(
+      /* HH_IGNORE_ERROR[4110] */ $include_keyword,
+      /* HH_IGNORE_ERROR[4110] */ $left_brace,
+      /* HH_IGNORE_ERROR[4110] */ $includes,
+      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $source_ref,
+    );
+  }
+
+  <<__Override>>
+  public function getChildren(): dict<string, Node> {
+    return dict[
+      'include_keyword' => $this->_include_keyword,
+      'left_brace' => $this->_left_brace,
+      'includes' => $this->_includes,
+      'right_brace' => $this->_right_brace,
+    ]
+      |> Dict\filter_nulls($$);
+  }
+
+  <<__Override>>
+  public function rewriteChildren<Tret as ?Node>(
+    (function(Node, vec<Node>): Tret) $rewriter,
+    vec<Node> $parents = vec[],
+  ): this {
+    $parents[] = $this;
+    $include_keyword = $this->_include_keyword === null
+      ? null
+      : $rewriter($this->_include_keyword, $parents);
+    $left_brace = $this->_left_brace === null
+      ? null
+      : $rewriter($this->_left_brace, $parents);
+    $includes =
+      $this->_includes === null ? null : $rewriter($this->_includes, $parents);
+    $right_brace = $this->_right_brace === null
+      ? null
+      : $rewriter($this->_right_brace, $parents);
+    if (
+      $include_keyword === $this->_include_keyword &&
+      $left_brace === $this->_left_brace &&
+      $includes === $this->_includes &&
+      $right_brace === $this->_right_brace
+    ) {
+      return $this;
+    }
+    return new static(
+      $include_keyword as ?Node,
+      $left_brace as ?Node,
+      $includes as ?Node,
+      $right_brace as ?Node,
+    );
+  }
+
+  public function getIncludeKeywordUNTYPED(): ?Node {
+    return $this->_include_keyword;
+  }
+
+  public function withIncludeKeyword(?Node $value): this {
+    if ($value === $this->_include_keyword) {
+      return $this;
+    }
+    return new static(
+      $value,
+      $this->_left_brace,
+      $this->_includes,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasIncludeKeyword(): bool {
+    return $this->_include_keyword !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getIncludeKeyword(): ?Node {
+    return $this->_include_keyword;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getIncludeKeywordx(): Node {
+    return TypeAssert\not_null($this->getIncludeKeyword());
+  }
+
+  public function getLeftBraceUNTYPED(): ?Node {
+    return $this->_left_brace;
+  }
+
+  public function withLeftBrace(?Node $value): this {
+    if ($value === $this->_left_brace) {
+      return $this;
+    }
+    return new static(
+      $this->_include_keyword,
+      $value,
+      $this->_includes,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasLeftBrace(): bool {
+    return $this->_left_brace !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getLeftBrace(): ?Node {
+    return $this->_left_brace;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getLeftBracex(): Node {
+    return TypeAssert\not_null($this->getLeftBrace());
+  }
+
+  public function getIncludesUNTYPED(): ?Node {
+    return $this->_includes;
+  }
+
+  public function withIncludes(?Node $value): this {
+    if ($value === $this->_includes) {
+      return $this;
+    }
+    return new static(
+      $this->_include_keyword,
+      $this->_left_brace,
+      $value,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasIncludes(): bool {
+    return $this->_includes !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getIncludes(): ?Node {
+    return $this->_includes;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getIncludesx(): Node {
+    return TypeAssert\not_null($this->getIncludes());
+  }
+
+  public function getRightBraceUNTYPED(): ?Node {
+    return $this->_right_brace;
+  }
+
+  public function withRightBrace(?Node $value): this {
+    if ($value === $this->_right_brace) {
+      return $this;
+    }
+    return new static(
+      $this->_include_keyword,
+      $this->_left_brace,
+      $this->_includes,
+      $value,
+    );
+  }
+
+  public function hasRightBrace(): bool {
+    return $this->_right_brace !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getRightBrace(): ?Node {
+    return $this->_right_brace;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getRightBracex(): Node {
+    return TypeAssert\not_null($this->getRightBrace());
+  }
+}

--- a/codegen/syntax/PackageUses.hack
+++ b/codegen/syntax/PackageUses.hack
@@ -1,0 +1,265 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * @generated SignedSource<<0fa01f717cb62e81f530c9fdea113c0a>>
+ */
+namespace Facebook\HHAST;
+use namespace Facebook\TypeAssert;
+use namespace HH\Lib\Dict;
+/* HHAST_IGNORE_ALL[5607] 5607 is ignored because of false positives when comparing a generic to a typed value */
+/* HHAST_IGNORE_ALL[5624] HHAST_IGNORE_ALL[5639] 5624 and 5639 are ignored because they insist on using co(tra)variant generics. Could this break external consumers? */
+
+<<__ConsistentConstruct>>
+final class PackageUses extends Node {
+
+  const string SYNTAX_KIND = 'package_uses';
+
+  private ?Node $_use_keyword;
+  private ?Node $_left_brace;
+  private ?Node $_uses;
+  private ?Node $_right_brace;
+
+  public function __construct(
+    ?Node $use_keyword,
+    ?Node $left_brace,
+    ?Node $uses,
+    ?Node $right_brace,
+    ?__Private\SourceRef $source_ref = null,
+  ) {
+    $this->_use_keyword = $use_keyword;
+    $this->_left_brace = $left_brace;
+    $this->_uses = $uses;
+    $this->_right_brace = $right_brace;
+    parent::__construct($source_ref);
+  }
+
+  <<__Override>>
+  public static function fromJSON(
+    dict<arraykey, mixed> $json,
+    string $file,
+    int $initial_offset,
+    string $source,
+    string $_type_hint,
+  ): this {
+    $offset = $initial_offset;
+    $use_keyword = Node::fromJSON(
+      ($json['package_uses_use_keyword'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $use_keyword?->getWidth() ?? 0;
+    $left_brace = Node::fromJSON(
+      ($json['package_uses_left_brace'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $left_brace?->getWidth() ?? 0;
+    $uses = Node::fromJSON(
+      ($json['package_uses_uses'] ?? dict['kind' => 'missing']) as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $uses?->getWidth() ?? 0;
+    $right_brace = Node::fromJSON(
+      ($json['package_uses_right_brace'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
+      $file,
+      $offset,
+      $source,
+      'Node',
+    );
+    $offset += $right_brace?->getWidth() ?? 0;
+    $source_ref = shape(
+      'file' => $file,
+      'source' => $source,
+      'offset' => $initial_offset,
+      'width' => $offset - $initial_offset,
+    );
+    return new static(
+      /* HH_IGNORE_ERROR[4110] */ $use_keyword,
+      /* HH_IGNORE_ERROR[4110] */ $left_brace,
+      /* HH_IGNORE_ERROR[4110] */ $uses,
+      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $source_ref,
+    );
+  }
+
+  <<__Override>>
+  public function getChildren(): dict<string, Node> {
+    return dict[
+      'use_keyword' => $this->_use_keyword,
+      'left_brace' => $this->_left_brace,
+      'uses' => $this->_uses,
+      'right_brace' => $this->_right_brace,
+    ]
+      |> Dict\filter_nulls($$);
+  }
+
+  <<__Override>>
+  public function rewriteChildren<Tret as ?Node>(
+    (function(Node, vec<Node>): Tret) $rewriter,
+    vec<Node> $parents = vec[],
+  ): this {
+    $parents[] = $this;
+    $use_keyword = $this->_use_keyword === null
+      ? null
+      : $rewriter($this->_use_keyword, $parents);
+    $left_brace = $this->_left_brace === null
+      ? null
+      : $rewriter($this->_left_brace, $parents);
+    $uses = $this->_uses === null ? null : $rewriter($this->_uses, $parents);
+    $right_brace = $this->_right_brace === null
+      ? null
+      : $rewriter($this->_right_brace, $parents);
+    if (
+      $use_keyword === $this->_use_keyword &&
+      $left_brace === $this->_left_brace &&
+      $uses === $this->_uses &&
+      $right_brace === $this->_right_brace
+    ) {
+      return $this;
+    }
+    return new static(
+      $use_keyword as ?Node,
+      $left_brace as ?Node,
+      $uses as ?Node,
+      $right_brace as ?Node,
+    );
+  }
+
+  public function getUseKeywordUNTYPED(): ?Node {
+    return $this->_use_keyword;
+  }
+
+  public function withUseKeyword(?Node $value): this {
+    if ($value === $this->_use_keyword) {
+      return $this;
+    }
+    return
+      new static($value, $this->_left_brace, $this->_uses, $this->_right_brace);
+  }
+
+  public function hasUseKeyword(): bool {
+    return $this->_use_keyword !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getUseKeyword(): ?Node {
+    return $this->_use_keyword;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getUseKeywordx(): Node {
+    return TypeAssert\not_null($this->getUseKeyword());
+  }
+
+  public function getLeftBraceUNTYPED(): ?Node {
+    return $this->_left_brace;
+  }
+
+  public function withLeftBrace(?Node $value): this {
+    if ($value === $this->_left_brace) {
+      return $this;
+    }
+    return new static(
+      $this->_use_keyword,
+      $value,
+      $this->_uses,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasLeftBrace(): bool {
+    return $this->_left_brace !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getLeftBrace(): ?Node {
+    return $this->_left_brace;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getLeftBracex(): Node {
+    return TypeAssert\not_null($this->getLeftBrace());
+  }
+
+  public function getUsesUNTYPED(): ?Node {
+    return $this->_uses;
+  }
+
+  public function withUses(?Node $value): this {
+    if ($value === $this->_uses) {
+      return $this;
+    }
+    return new static(
+      $this->_use_keyword,
+      $this->_left_brace,
+      $value,
+      $this->_right_brace,
+    );
+  }
+
+  public function hasUses(): bool {
+    return $this->_uses !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getUses(): ?Node {
+    return $this->_uses;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getUsesx(): Node {
+    return TypeAssert\not_null($this->getUses());
+  }
+
+  public function getRightBraceUNTYPED(): ?Node {
+    return $this->_right_brace;
+  }
+
+  public function withRightBrace(?Node $value): this {
+    if ($value === $this->_right_brace) {
+      return $this;
+    }
+    return
+      new static($this->_use_keyword, $this->_left_brace, $this->_uses, $value);
+  }
+
+  public function hasRightBrace(): bool {
+    return $this->_right_brace !== null;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getRightBrace(): ?Node {
+    return $this->_right_brace;
+  }
+
+  /**
+   * @return unknown
+   */
+  public function getRightBracex(): Node {
+    return TypeAssert\not_null($this->getRightBrace());
+  }
+}

--- a/codegen/syntax/ParameterDeclaration.hack
+++ b/codegen/syntax/ParameterDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4a583b05a02a5a15994cf04124f6b5ce>>
+ * @generated SignedSource<<1a479503fe3a347962036a518871ea84>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -22,7 +22,7 @@ final class ParameterDeclaration
   private ?Token $_visibility;
   private ?InoutToken $_call_convention;
   private ?ReadonlyToken $_readonly;
-  private ?Node $_type;
+  private ?ITypeSpecifier $_type;
   private IExpression $_name;
   private ?SimpleInitializer $_default_value;
 
@@ -31,7 +31,7 @@ final class ParameterDeclaration
     ?Token $visibility,
     ?InoutToken $call_convention,
     ?ReadonlyToken $readonly,
-    ?Node $type,
+    ?ITypeSpecifier $type,
     IExpression $name,
     ?SimpleInitializer $default_value,
     ?__Private\SourceRef $source_ref = null,
@@ -94,7 +94,7 @@ final class ParameterDeclaration
       $file,
       $offset,
       $source,
-      'Node',
+      'ITypeSpecifier',
     );
     $offset += $type?->getWidth() ?? 0;
     $name = Node::fromJSON(
@@ -185,7 +185,7 @@ final class ParameterDeclaration
       $visibility as ?Token,
       $call_convention as ?InoutToken,
       $readonly as ?ReadonlyToken,
-      $type as ?Node,
+      $type as ?ITypeSpecifier,
       $name as IExpression,
       $default_value as ?SimpleInitializer,
     );
@@ -347,7 +347,7 @@ final class ParameterDeclaration
     return $this->_type;
   }
 
-  public function withType(?Node $value): this {
+  public function withType(?ITypeSpecifier $value): this {
     if ($value === $this->_type) {
       return $this;
     }
@@ -371,9 +371,9 @@ final class ParameterDeclaration
    * DarrayTypeSpecifier | DictionaryTypeSpecifier | GenericTypeSpecifier |
    * KeysetTypeSpecifier | LikeTypeSpecifier | null | NullableTypeSpecifier |
    * ShapeTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier |
-   * TypeConstant | TypeRefinement | VarrayTypeSpecifier | VectorTypeSpecifier
+   * TypeConstant | VarrayTypeSpecifier | VectorTypeSpecifier
    */
-  public function getType(): ?Node {
+  public function getType(): ?ITypeSpecifier {
     return $this->_type;
   }
 
@@ -382,9 +382,9 @@ final class ParameterDeclaration
    * DarrayTypeSpecifier | DictionaryTypeSpecifier | GenericTypeSpecifier |
    * KeysetTypeSpecifier | LikeTypeSpecifier | NullableTypeSpecifier |
    * ShapeTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier |
-   * TypeConstant | TypeRefinement | VarrayTypeSpecifier | VectorTypeSpecifier
+   * TypeConstant | VarrayTypeSpecifier | VectorTypeSpecifier
    */
-  public function getTypex(): Node {
+  public function getTypex(): ITypeSpecifier {
     return TypeAssert\not_null($this->getType());
   }
 

--- a/codegen/syntax/ParameterDeclaration.hack
+++ b/codegen/syntax/ParameterDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1a479503fe3a347962036a518871ea84>>
+ * @generated SignedSource<<c838f5e0d3762534b1786ea0592e45a7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -371,7 +371,7 @@ final class ParameterDeclaration
    * DarrayTypeSpecifier | DictionaryTypeSpecifier | GenericTypeSpecifier |
    * KeysetTypeSpecifier | LikeTypeSpecifier | null | NullableTypeSpecifier |
    * ShapeTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier |
-   * TypeConstant | VarrayTypeSpecifier | VectorTypeSpecifier
+   * TypeConstant | TypeRefinement | VarrayTypeSpecifier | VectorTypeSpecifier
    */
   public function getType(): ?ITypeSpecifier {
     return $this->_type;
@@ -382,7 +382,7 @@ final class ParameterDeclaration
    * DarrayTypeSpecifier | DictionaryTypeSpecifier | GenericTypeSpecifier |
    * KeysetTypeSpecifier | LikeTypeSpecifier | NullableTypeSpecifier |
    * ShapeTypeSpecifier | SimpleTypeSpecifier | TupleTypeSpecifier |
-   * TypeConstant | VarrayTypeSpecifier | VectorTypeSpecifier
+   * TypeConstant | TypeRefinement | VarrayTypeSpecifier | VectorTypeSpecifier
    */
   public function getTypex(): ITypeSpecifier {
     return TypeAssert\not_null($this->getType());

--- a/codegen/syntax/PropertyDeclaration.hack
+++ b/codegen/syntax/PropertyDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cb91e6a51e5c60784c1023c4f1a8890f>>
+ * @generated SignedSource<<cb49b3d3269aa7c3acb1b7821d587674>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -207,16 +207,16 @@ final class PropertyDeclaration
   }
 
   /**
-   * @return NodeList<InternalToken> | NodeList<Token> | NodeList<PrivateToken>
-   * | NodeList<ProtectedToken> | NodeList<PublicToken> | NodeList<StaticToken>
+   * @return NodeList<PrivateToken> | NodeList<Token> |
+   * NodeList<ProtectedToken> | NodeList<PublicToken> | NodeList<StaticToken>
    */
   public function getModifiers(): NodeList<Token> {
     return TypeAssert\instance_of(NodeList::class, $this->_modifiers);
   }
 
   /**
-   * @return NodeList<InternalToken> | NodeList<Token> | NodeList<PrivateToken>
-   * | NodeList<ProtectedToken> | NodeList<PublicToken> | NodeList<StaticToken>
+   * @return NodeList<PrivateToken> | NodeList<Token> |
+   * NodeList<ProtectedToken> | NodeList<PublicToken> | NodeList<StaticToken>
    */
   public function getModifiersx(): NodeList<Token> {
     return $this->getModifiers();

--- a/codegen/syntax/TypeArguments.hack
+++ b/codegen/syntax/TypeArguments.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8da116ce9939abde432f646389ec149e>>
+ * @generated SignedSource<<8da42f4704613d0a958b1a0834e668fe>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -172,7 +172,8 @@ final class TypeArguments extends Node {
    * NodeList<ListItem<ShapeTypeSpecifier>> |
    * NodeList<ListItem<SimpleTypeSpecifier>> |
    * NodeList<ListItem<TupleTypeSpecifier>> | NodeList<ListItem<TypeConstant>>
-   * | NodeList<ListItem<VarrayTypeSpecifier>> |
+   * | NodeList<ListItem<TypeRefinement>> |
+   * NodeList<ListItem<VarrayTypeSpecifier>> |
    * NodeList<ListItem<VectorTypeSpecifier>> | null
    */
   public function getTypes(): ?NodeList<ListItem<ITypeSpecifier>> {
@@ -194,7 +195,8 @@ final class TypeArguments extends Node {
    * NodeList<ListItem<ShapeTypeSpecifier>> |
    * NodeList<ListItem<SimpleTypeSpecifier>> |
    * NodeList<ListItem<TupleTypeSpecifier>> | NodeList<ListItem<TypeConstant>>
-   * | NodeList<ListItem<VarrayTypeSpecifier>> |
+   * | NodeList<ListItem<TypeRefinement>> |
+   * NodeList<ListItem<VarrayTypeSpecifier>> |
    * NodeList<ListItem<VectorTypeSpecifier>>
    */
   public function getTypesx(): NodeList<ListItem<ITypeSpecifier>> {

--- a/codegen/syntax/TypeArguments.hack
+++ b/codegen/syntax/TypeArguments.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<aa96c2a59bd66aa5236d3735e6923561>>
+ * @generated SignedSource<<8da116ce9939abde432f646389ec149e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -15,12 +15,12 @@ final class TypeArguments extends Node {
   const string SYNTAX_KIND = 'type_arguments';
 
   private LessThanToken $_left_angle;
-  private ?NodeList<ListItem<Node>> $_types;
+  private ?NodeList<ListItem<ITypeSpecifier>> $_types;
   private GreaterThanToken $_right_angle;
 
   public function __construct(
     LessThanToken $left_angle,
-    ?NodeList<ListItem<Node>> $types,
+    ?NodeList<ListItem<ITypeSpecifier>> $types,
     GreaterThanToken $right_angle,
     ?__Private\SourceRef $source_ref = null,
   ) {
@@ -54,7 +54,7 @@ final class TypeArguments extends Node {
       $file,
       $offset,
       $source,
-      'NodeList<ListItem<Node>>',
+      'NodeList<ListItem<ITypeSpecifier>>',
     );
     $offset += $types?->getWidth() ?? 0;
     $right_angle = Node::fromJSON(
@@ -108,7 +108,7 @@ final class TypeArguments extends Node {
     }
     return new static(
       $left_angle as LessThanToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<Node>> may not be enforceable */ $types,
+      /* HH_FIXME[4110] ?NodeList<ListItem<ITypeSpecifier>> may not be enforceable */ $types,
       $right_angle as GreaterThanToken,
     );
   }
@@ -146,7 +146,7 @@ final class TypeArguments extends Node {
     return $this->_types;
   }
 
-  public function withTypes(?NodeList<ListItem<Node>> $value): this {
+  public function withTypes(?NodeList<ListItem<ITypeSpecifier>> $value): this {
     if ($value === $this->_types) {
       return $this;
     }
@@ -170,13 +170,12 @@ final class TypeArguments extends Node {
    * NodeList<ListItem<LikeTypeSpecifier>> |
    * NodeList<ListItem<NullableTypeSpecifier>> |
    * NodeList<ListItem<ShapeTypeSpecifier>> |
-   * NodeList<ListItem<SimpleTypeSpecifier>> | NodeList<ListItem<Node>> |
+   * NodeList<ListItem<SimpleTypeSpecifier>> |
    * NodeList<ListItem<TupleTypeSpecifier>> | NodeList<ListItem<TypeConstant>>
-   * | NodeList<ListItem<TypeRefinement>> |
-   * NodeList<ListItem<VarrayTypeSpecifier>> |
+   * | NodeList<ListItem<VarrayTypeSpecifier>> |
    * NodeList<ListItem<VectorTypeSpecifier>> | null
    */
-  public function getTypes(): ?NodeList<ListItem<Node>> {
+  public function getTypes(): ?NodeList<ListItem<ITypeSpecifier>> {
     return $this->_types;
   }
 
@@ -193,13 +192,12 @@ final class TypeArguments extends Node {
    * NodeList<ListItem<LikeTypeSpecifier>> |
    * NodeList<ListItem<NullableTypeSpecifier>> |
    * NodeList<ListItem<ShapeTypeSpecifier>> |
-   * NodeList<ListItem<SimpleTypeSpecifier>> | NodeList<ListItem<Node>> |
+   * NodeList<ListItem<SimpleTypeSpecifier>> |
    * NodeList<ListItem<TupleTypeSpecifier>> | NodeList<ListItem<TypeConstant>>
-   * | NodeList<ListItem<TypeRefinement>> |
-   * NodeList<ListItem<VarrayTypeSpecifier>> |
+   * | NodeList<ListItem<VarrayTypeSpecifier>> |
    * NodeList<ListItem<VectorTypeSpecifier>>
    */
-  public function getTypesx(): NodeList<ListItem<Node>> {
+  public function getTypesx(): NodeList<ListItem<ITypeSpecifier>> {
     return TypeAssert\not_null($this->getTypes());
   }
 

--- a/codegen/syntax/TypeConstraint.hack
+++ b/codegen/syntax/TypeConstraint.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8e3130923200461713699d8467cb78a0>>
+ * @generated SignedSource<<fc46f7e9c9f70f1355b251a1a7e4d1a8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -137,7 +137,7 @@ final class TypeConstraint extends Node {
   /**
    * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
    * GenericTypeSpecifier | LikeTypeSpecifier | NullableTypeSpecifier |
-   * ShapeTypeSpecifier | SimpleTypeSpecifier | TypeConstant |
+   * ShapeTypeSpecifier | SimpleTypeSpecifier | TypeConstant | TypeRefinement |
    * VarrayTypeSpecifier | VectorTypeSpecifier
    */
   public function getType(): ITypeSpecifier {
@@ -147,7 +147,7 @@ final class TypeConstraint extends Node {
   /**
    * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
    * GenericTypeSpecifier | LikeTypeSpecifier | NullableTypeSpecifier |
-   * ShapeTypeSpecifier | SimpleTypeSpecifier | TypeConstant |
+   * ShapeTypeSpecifier | SimpleTypeSpecifier | TypeConstant | TypeRefinement |
    * VarrayTypeSpecifier | VectorTypeSpecifier
    */
   public function getTypex(): ITypeSpecifier {

--- a/codegen/syntax/TypeConstraint.hack
+++ b/codegen/syntax/TypeConstraint.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cf22926607c5b3227cf7b1ed5753dbec>>
+ * @generated SignedSource<<8e3130923200461713699d8467cb78a0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -15,11 +15,11 @@ final class TypeConstraint extends Node {
   const string SYNTAX_KIND = 'type_constraint';
 
   private Token $_keyword;
-  private Node $_type;
+  private ITypeSpecifier $_type;
 
   public function __construct(
     Token $keyword,
-    Node $type,
+    ITypeSpecifier $type,
     ?__Private\SourceRef $source_ref = null,
   ) {
     $this->_keyword = $keyword;
@@ -50,7 +50,7 @@ final class TypeConstraint extends Node {
       $file,
       $offset,
       $source,
-      'Node',
+      'ITypeSpecifier',
     );
     $type = $type as nonnull;
     $offset += $type->getWidth();
@@ -87,7 +87,7 @@ final class TypeConstraint extends Node {
     if ($keyword === $this->_keyword && $type === $this->_type) {
       return $this;
     }
-    return new static($keyword as Token, $type as Node);
+    return new static($keyword as Token, $type as ITypeSpecifier);
   }
 
   public function getKeywordUNTYPED(): ?Node {
@@ -123,7 +123,7 @@ final class TypeConstraint extends Node {
     return $this->_type;
   }
 
-  public function withType(Node $value): this {
+  public function withType(ITypeSpecifier $value): this {
     if ($value === $this->_type) {
       return $this;
     }
@@ -137,20 +137,20 @@ final class TypeConstraint extends Node {
   /**
    * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
    * GenericTypeSpecifier | LikeTypeSpecifier | NullableTypeSpecifier |
-   * ShapeTypeSpecifier | SimpleTypeSpecifier | TypeConstant | TypeRefinement |
+   * ShapeTypeSpecifier | SimpleTypeSpecifier | TypeConstant |
    * VarrayTypeSpecifier | VectorTypeSpecifier
    */
-  public function getType(): Node {
-    return $this->_type;
+  public function getType(): ITypeSpecifier {
+    return TypeAssert\instance_of(ITypeSpecifier::class, $this->_type);
   }
 
   /**
    * @return ClassnameTypeSpecifier | ClosureTypeSpecifier |
    * GenericTypeSpecifier | LikeTypeSpecifier | NullableTypeSpecifier |
-   * ShapeTypeSpecifier | SimpleTypeSpecifier | TypeConstant | TypeRefinement |
+   * ShapeTypeSpecifier | SimpleTypeSpecifier | TypeConstant |
    * VarrayTypeSpecifier | VectorTypeSpecifier
    */
-  public function getTypex(): Node {
+  public function getTypex(): ITypeSpecifier {
     return $this->getType();
   }
 }

--- a/codegen/syntax/TypeInRefinement.hack
+++ b/codegen/syntax/TypeInRefinement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b5724786f5fe26a776e89e80aa56d044>>
+ * @generated SignedSource<<bf73c8c5983b114b6f9e83fc985ecd64>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -14,20 +14,20 @@ final class TypeInRefinement extends Node {
 
   const string SYNTAX_KIND = 'type_in_refinement';
 
-  private TypeToken $_keyword;
-  private NameToken $_name;
+  private ?Node $_keyword;
+  private ?Node $_name;
   private ?Node $_type_parameters;
   private ?Node $_constraints;
-  private EqualToken $_equal;
-  private ITypeSpecifier $_type;
+  private ?Node $_equal;
+  private ?Node $_type;
 
   public function __construct(
-    TypeToken $keyword,
-    NameToken $name,
+    ?Node $keyword,
+    ?Node $name,
     ?Node $type_parameters,
     ?Node $constraints,
-    EqualToken $equal,
-    ITypeSpecifier $type,
+    ?Node $equal,
+    ?Node $type,
     ?__Private\SourceRef $source_ref = null,
   ) {
     $this->_keyword = $keyword;
@@ -49,23 +49,23 @@ final class TypeInRefinement extends Node {
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
-      ($json['type_in_refinement_keyword']) as dict<_, _>,
+      ($json['type_in_refinement_keyword'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
       $file,
       $offset,
       $source,
-      'TypeToken',
+      'Node',
     );
-    $keyword = $keyword as nonnull;
-    $offset += $keyword->getWidth();
+    $offset += $keyword?->getWidth() ?? 0;
     $name = Node::fromJSON(
-      ($json['type_in_refinement_name']) as dict<_, _>,
+      ($json['type_in_refinement_name'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
       $file,
       $offset,
       $source,
-      'NameToken',
+      'Node',
     );
-    $name = $name as nonnull;
-    $offset += $name->getWidth();
+    $offset += $name?->getWidth() ?? 0;
     $type_parameters = Node::fromJSON(
       ($json['type_in_refinement_type_parameters'] ?? dict['kind' => 'missing'])
         as dict<_, _>,
@@ -85,23 +85,23 @@ final class TypeInRefinement extends Node {
     );
     $offset += $constraints?->getWidth() ?? 0;
     $equal = Node::fromJSON(
-      ($json['type_in_refinement_equal']) as dict<_, _>,
+      ($json['type_in_refinement_equal'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
       $file,
       $offset,
       $source,
-      'EqualToken',
+      'Node',
     );
-    $equal = $equal as nonnull;
-    $offset += $equal->getWidth();
+    $offset += $equal?->getWidth() ?? 0;
     $type = Node::fromJSON(
-      ($json['type_in_refinement_type']) as dict<_, _>,
+      ($json['type_in_refinement_type'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
       $file,
       $offset,
       $source,
-      'ITypeSpecifier',
+      'Node',
     );
-    $type = $type as nonnull;
-    $offset += $type->getWidth();
+    $offset += $type?->getWidth() ?? 0;
     $source_ref = shape(
       'file' => $file,
       'source' => $source,
@@ -138,16 +138,17 @@ final class TypeInRefinement extends Node {
     vec<Node> $parents = vec[],
   ): this {
     $parents[] = $this;
-    $keyword = $rewriter($this->_keyword, $parents);
-    $name = $rewriter($this->_name, $parents);
+    $keyword =
+      $this->_keyword === null ? null : $rewriter($this->_keyword, $parents);
+    $name = $this->_name === null ? null : $rewriter($this->_name, $parents);
     $type_parameters = $this->_type_parameters === null
       ? null
       : $rewriter($this->_type_parameters, $parents);
     $constraints = $this->_constraints === null
       ? null
       : $rewriter($this->_constraints, $parents);
-    $equal = $rewriter($this->_equal, $parents);
-    $type = $rewriter($this->_type, $parents);
+    $equal = $this->_equal === null ? null : $rewriter($this->_equal, $parents);
+    $type = $this->_type === null ? null : $rewriter($this->_type, $parents);
     if (
       $keyword === $this->_keyword &&
       $name === $this->_name &&
@@ -159,12 +160,12 @@ final class TypeInRefinement extends Node {
       return $this;
     }
     return new static(
-      $keyword as TypeToken,
-      $name as NameToken,
+      $keyword as ?Node,
+      $name as ?Node,
       $type_parameters as ?Node,
       $constraints as ?Node,
-      $equal as EqualToken,
-      $type as ITypeSpecifier,
+      $equal as ?Node,
+      $type as ?Node,
     );
   }
 
@@ -172,7 +173,7 @@ final class TypeInRefinement extends Node {
     return $this->_keyword;
   }
 
-  public function withKeyword(TypeToken $value): this {
+  public function withKeyword(?Node $value): this {
     if ($value === $this->_keyword) {
       return $this;
     }
@@ -187,28 +188,28 @@ final class TypeInRefinement extends Node {
   }
 
   public function hasKeyword(): bool {
-    return true;
+    return $this->_keyword !== null;
   }
 
   /**
-   * @return TypeToken
+   * @return unknown
    */
-  public function getKeyword(): TypeToken {
-    return TypeAssert\instance_of(TypeToken::class, $this->_keyword);
+  public function getKeyword(): ?Node {
+    return $this->_keyword;
   }
 
   /**
-   * @return TypeToken
+   * @return unknown
    */
-  public function getKeywordx(): TypeToken {
-    return $this->getKeyword();
+  public function getKeywordx(): Node {
+    return TypeAssert\not_null($this->getKeyword());
   }
 
   public function getNameUNTYPED(): ?Node {
     return $this->_name;
   }
 
-  public function withName(NameToken $value): this {
+  public function withName(?Node $value): this {
     if ($value === $this->_name) {
       return $this;
     }
@@ -223,21 +224,21 @@ final class TypeInRefinement extends Node {
   }
 
   public function hasName(): bool {
-    return true;
+    return $this->_name !== null;
   }
 
   /**
-   * @return NameToken
+   * @return unknown
    */
-  public function getName(): NameToken {
-    return TypeAssert\instance_of(NameToken::class, $this->_name);
+  public function getName(): ?Node {
+    return $this->_name;
   }
 
   /**
-   * @return NameToken
+   * @return unknown
    */
-  public function getNamex(): NameToken {
-    return $this->getName();
+  public function getNamex(): Node {
+    return TypeAssert\not_null($this->getName());
   }
 
   public function getTypeParametersUNTYPED(): ?Node {
@@ -263,14 +264,14 @@ final class TypeInRefinement extends Node {
   }
 
   /**
-   * @return null
+   * @return unknown
    */
   public function getTypeParameters(): ?Node {
     return $this->_type_parameters;
   }
 
   /**
-   * @return
+   * @return unknown
    */
   public function getTypeParametersx(): Node {
     return TypeAssert\not_null($this->getTypeParameters());
@@ -299,14 +300,14 @@ final class TypeInRefinement extends Node {
   }
 
   /**
-   * @return null
+   * @return unknown
    */
   public function getConstraints(): ?Node {
     return $this->_constraints;
   }
 
   /**
-   * @return
+   * @return unknown
    */
   public function getConstraintsx(): Node {
     return TypeAssert\not_null($this->getConstraints());
@@ -316,7 +317,7 @@ final class TypeInRefinement extends Node {
     return $this->_equal;
   }
 
-  public function withEqual(EqualToken $value): this {
+  public function withEqual(?Node $value): this {
     if ($value === $this->_equal) {
       return $this;
     }
@@ -331,28 +332,28 @@ final class TypeInRefinement extends Node {
   }
 
   public function hasEqual(): bool {
-    return true;
+    return $this->_equal !== null;
   }
 
   /**
-   * @return EqualToken
+   * @return unknown
    */
-  public function getEqual(): EqualToken {
-    return TypeAssert\instance_of(EqualToken::class, $this->_equal);
+  public function getEqual(): ?Node {
+    return $this->_equal;
   }
 
   /**
-   * @return EqualToken
+   * @return unknown
    */
-  public function getEqualx(): EqualToken {
-    return $this->getEqual();
+  public function getEqualx(): Node {
+    return TypeAssert\not_null($this->getEqual());
   }
 
   public function getTypeUNTYPED(): ?Node {
     return $this->_type;
   }
 
-  public function withType(ITypeSpecifier $value): this {
+  public function withType(?Node $value): this {
     if ($value === $this->_type) {
       return $this;
     }
@@ -367,20 +368,20 @@ final class TypeInRefinement extends Node {
   }
 
   public function hasType(): bool {
-    return true;
+    return $this->_type !== null;
   }
 
   /**
-   * @return SimpleTypeSpecifier | TypeConstant
+   * @return unknown
    */
-  public function getType(): ITypeSpecifier {
-    return TypeAssert\instance_of(ITypeSpecifier::class, $this->_type);
+  public function getType(): ?Node {
+    return $this->_type;
   }
 
   /**
-   * @return SimpleTypeSpecifier | TypeConstant
+   * @return unknown
    */
-  public function getTypex(): ITypeSpecifier {
-    return $this->getType();
+  public function getTypex(): Node {
+    return TypeAssert\not_null($this->getType());
   }
 }

--- a/codegen/syntax/TypeInRefinement.hack
+++ b/codegen/syntax/TypeInRefinement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bf73c8c5983b114b6f9e83fc985ecd64>>
+ * @generated SignedSource<<b5724786f5fe26a776e89e80aa56d044>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -14,20 +14,20 @@ final class TypeInRefinement extends Node {
 
   const string SYNTAX_KIND = 'type_in_refinement';
 
-  private ?Node $_keyword;
-  private ?Node $_name;
+  private TypeToken $_keyword;
+  private NameToken $_name;
   private ?Node $_type_parameters;
   private ?Node $_constraints;
-  private ?Node $_equal;
-  private ?Node $_type;
+  private EqualToken $_equal;
+  private ITypeSpecifier $_type;
 
   public function __construct(
-    ?Node $keyword,
-    ?Node $name,
+    TypeToken $keyword,
+    NameToken $name,
     ?Node $type_parameters,
     ?Node $constraints,
-    ?Node $equal,
-    ?Node $type,
+    EqualToken $equal,
+    ITypeSpecifier $type,
     ?__Private\SourceRef $source_ref = null,
   ) {
     $this->_keyword = $keyword;
@@ -49,23 +49,23 @@ final class TypeInRefinement extends Node {
   ): this {
     $offset = $initial_offset;
     $keyword = Node::fromJSON(
-      ($json['type_in_refinement_keyword'] ?? dict['kind' => 'missing'])
-        as dict<_, _>,
+      ($json['type_in_refinement_keyword']) as dict<_, _>,
       $file,
       $offset,
       $source,
-      'Node',
+      'TypeToken',
     );
-    $offset += $keyword?->getWidth() ?? 0;
+    $keyword = $keyword as nonnull;
+    $offset += $keyword->getWidth();
     $name = Node::fromJSON(
-      ($json['type_in_refinement_name'] ?? dict['kind' => 'missing'])
-        as dict<_, _>,
+      ($json['type_in_refinement_name']) as dict<_, _>,
       $file,
       $offset,
       $source,
-      'Node',
+      'NameToken',
     );
-    $offset += $name?->getWidth() ?? 0;
+    $name = $name as nonnull;
+    $offset += $name->getWidth();
     $type_parameters = Node::fromJSON(
       ($json['type_in_refinement_type_parameters'] ?? dict['kind' => 'missing'])
         as dict<_, _>,
@@ -85,23 +85,23 @@ final class TypeInRefinement extends Node {
     );
     $offset += $constraints?->getWidth() ?? 0;
     $equal = Node::fromJSON(
-      ($json['type_in_refinement_equal'] ?? dict['kind' => 'missing'])
-        as dict<_, _>,
+      ($json['type_in_refinement_equal']) as dict<_, _>,
       $file,
       $offset,
       $source,
-      'Node',
+      'EqualToken',
     );
-    $offset += $equal?->getWidth() ?? 0;
+    $equal = $equal as nonnull;
+    $offset += $equal->getWidth();
     $type = Node::fromJSON(
-      ($json['type_in_refinement_type'] ?? dict['kind' => 'missing'])
-        as dict<_, _>,
+      ($json['type_in_refinement_type']) as dict<_, _>,
       $file,
       $offset,
       $source,
-      'Node',
+      'ITypeSpecifier',
     );
-    $offset += $type?->getWidth() ?? 0;
+    $type = $type as nonnull;
+    $offset += $type->getWidth();
     $source_ref = shape(
       'file' => $file,
       'source' => $source,
@@ -138,17 +138,16 @@ final class TypeInRefinement extends Node {
     vec<Node> $parents = vec[],
   ): this {
     $parents[] = $this;
-    $keyword =
-      $this->_keyword === null ? null : $rewriter($this->_keyword, $parents);
-    $name = $this->_name === null ? null : $rewriter($this->_name, $parents);
+    $keyword = $rewriter($this->_keyword, $parents);
+    $name = $rewriter($this->_name, $parents);
     $type_parameters = $this->_type_parameters === null
       ? null
       : $rewriter($this->_type_parameters, $parents);
     $constraints = $this->_constraints === null
       ? null
       : $rewriter($this->_constraints, $parents);
-    $equal = $this->_equal === null ? null : $rewriter($this->_equal, $parents);
-    $type = $this->_type === null ? null : $rewriter($this->_type, $parents);
+    $equal = $rewriter($this->_equal, $parents);
+    $type = $rewriter($this->_type, $parents);
     if (
       $keyword === $this->_keyword &&
       $name === $this->_name &&
@@ -160,12 +159,12 @@ final class TypeInRefinement extends Node {
       return $this;
     }
     return new static(
-      $keyword as ?Node,
-      $name as ?Node,
+      $keyword as TypeToken,
+      $name as NameToken,
       $type_parameters as ?Node,
       $constraints as ?Node,
-      $equal as ?Node,
-      $type as ?Node,
+      $equal as EqualToken,
+      $type as ITypeSpecifier,
     );
   }
 
@@ -173,7 +172,7 @@ final class TypeInRefinement extends Node {
     return $this->_keyword;
   }
 
-  public function withKeyword(?Node $value): this {
+  public function withKeyword(TypeToken $value): this {
     if ($value === $this->_keyword) {
       return $this;
     }
@@ -188,28 +187,28 @@ final class TypeInRefinement extends Node {
   }
 
   public function hasKeyword(): bool {
-    return $this->_keyword !== null;
+    return true;
   }
 
   /**
-   * @return unknown
+   * @return TypeToken
    */
-  public function getKeyword(): ?Node {
-    return $this->_keyword;
+  public function getKeyword(): TypeToken {
+    return TypeAssert\instance_of(TypeToken::class, $this->_keyword);
   }
 
   /**
-   * @return unknown
+   * @return TypeToken
    */
-  public function getKeywordx(): Node {
-    return TypeAssert\not_null($this->getKeyword());
+  public function getKeywordx(): TypeToken {
+    return $this->getKeyword();
   }
 
   public function getNameUNTYPED(): ?Node {
     return $this->_name;
   }
 
-  public function withName(?Node $value): this {
+  public function withName(NameToken $value): this {
     if ($value === $this->_name) {
       return $this;
     }
@@ -224,21 +223,21 @@ final class TypeInRefinement extends Node {
   }
 
   public function hasName(): bool {
-    return $this->_name !== null;
+    return true;
   }
 
   /**
-   * @return unknown
+   * @return NameToken
    */
-  public function getName(): ?Node {
-    return $this->_name;
+  public function getName(): NameToken {
+    return TypeAssert\instance_of(NameToken::class, $this->_name);
   }
 
   /**
-   * @return unknown
+   * @return NameToken
    */
-  public function getNamex(): Node {
-    return TypeAssert\not_null($this->getName());
+  public function getNamex(): NameToken {
+    return $this->getName();
   }
 
   public function getTypeParametersUNTYPED(): ?Node {
@@ -264,14 +263,14 @@ final class TypeInRefinement extends Node {
   }
 
   /**
-   * @return unknown
+   * @return null
    */
   public function getTypeParameters(): ?Node {
     return $this->_type_parameters;
   }
 
   /**
-   * @return unknown
+   * @return
    */
   public function getTypeParametersx(): Node {
     return TypeAssert\not_null($this->getTypeParameters());
@@ -300,14 +299,14 @@ final class TypeInRefinement extends Node {
   }
 
   /**
-   * @return unknown
+   * @return null
    */
   public function getConstraints(): ?Node {
     return $this->_constraints;
   }
 
   /**
-   * @return unknown
+   * @return
    */
   public function getConstraintsx(): Node {
     return TypeAssert\not_null($this->getConstraints());
@@ -317,7 +316,7 @@ final class TypeInRefinement extends Node {
     return $this->_equal;
   }
 
-  public function withEqual(?Node $value): this {
+  public function withEqual(EqualToken $value): this {
     if ($value === $this->_equal) {
       return $this;
     }
@@ -332,28 +331,28 @@ final class TypeInRefinement extends Node {
   }
 
   public function hasEqual(): bool {
-    return $this->_equal !== null;
+    return true;
   }
 
   /**
-   * @return unknown
+   * @return EqualToken
    */
-  public function getEqual(): ?Node {
-    return $this->_equal;
+  public function getEqual(): EqualToken {
+    return TypeAssert\instance_of(EqualToken::class, $this->_equal);
   }
 
   /**
-   * @return unknown
+   * @return EqualToken
    */
-  public function getEqualx(): Node {
-    return TypeAssert\not_null($this->getEqual());
+  public function getEqualx(): EqualToken {
+    return $this->getEqual();
   }
 
   public function getTypeUNTYPED(): ?Node {
     return $this->_type;
   }
 
-  public function withType(?Node $value): this {
+  public function withType(ITypeSpecifier $value): this {
     if ($value === $this->_type) {
       return $this;
     }
@@ -368,20 +367,20 @@ final class TypeInRefinement extends Node {
   }
 
   public function hasType(): bool {
-    return $this->_type !== null;
+    return true;
   }
 
   /**
-   * @return unknown
+   * @return SimpleTypeSpecifier | TypeConstant
    */
-  public function getType(): ?Node {
-    return $this->_type;
+  public function getType(): ITypeSpecifier {
+    return TypeAssert\instance_of(ITypeSpecifier::class, $this->_type);
   }
 
   /**
-   * @return unknown
+   * @return SimpleTypeSpecifier | TypeConstant
    */
-  public function getTypex(): Node {
-    return TypeAssert\not_null($this->getType());
+  public function getTypex(): ITypeSpecifier {
+    return $this->getType();
   }
 }

--- a/codegen/syntax/TypeRefinement.hack
+++ b/codegen/syntax/TypeRefinement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0e1a92dc39647bc3121831fdcc626aca>>
+ * @generated SignedSource<<5eda3e9569f6db8ae3b00fdfe2be6d1d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -10,22 +10,22 @@ use namespace HH\Lib\Dict;
 /* HHAST_IGNORE_ALL[5624] HHAST_IGNORE_ALL[5639] 5624 and 5639 are ignored because they insist on using co(tra)variant generics. Could this break external consumers? */
 
 <<__ConsistentConstruct>>
-final class TypeRefinement extends Node {
+final class TypeRefinement extends Node implements ITypeSpecifier {
 
   const string SYNTAX_KIND = 'type_refinement';
 
-  private ?Node $_type;
-  private ?Node $_keyword;
-  private ?Node $_left_brace;
-  private ?Node $_members;
-  private ?Node $_right_brace;
+  private SimpleTypeSpecifier $_type;
+  private WithToken $_keyword;
+  private LeftBraceToken $_left_brace;
+  private NodeList<ListItem<TypeInRefinement>> $_members;
+  private RightBraceToken $_right_brace;
 
   public function __construct(
-    ?Node $type,
-    ?Node $keyword,
-    ?Node $left_brace,
-    ?Node $members,
-    ?Node $right_brace,
+    SimpleTypeSpecifier $type,
+    WithToken $keyword,
+    LeftBraceToken $left_brace,
+    NodeList<ListItem<TypeInRefinement>> $members,
+    RightBraceToken $right_brace,
     ?__Private\SourceRef $source_ref = null,
   ) {
     $this->_type = $type;
@@ -46,50 +46,50 @@ final class TypeRefinement extends Node {
   ): this {
     $offset = $initial_offset;
     $type = Node::fromJSON(
-      ($json['type_refinement_type'] ?? dict['kind' => 'missing'])
-        as dict<_, _>,
+      ($json['type_refinement_type']) as dict<_, _>,
       $file,
       $offset,
       $source,
-      'Node',
+      'SimpleTypeSpecifier',
     );
-    $offset += $type?->getWidth() ?? 0;
+    $type = $type as nonnull;
+    $offset += $type->getWidth();
     $keyword = Node::fromJSON(
-      ($json['type_refinement_keyword'] ?? dict['kind' => 'missing'])
-        as dict<_, _>,
+      ($json['type_refinement_keyword']) as dict<_, _>,
       $file,
       $offset,
       $source,
-      'Node',
+      'WithToken',
     );
-    $offset += $keyword?->getWidth() ?? 0;
+    $keyword = $keyword as nonnull;
+    $offset += $keyword->getWidth();
     $left_brace = Node::fromJSON(
-      ($json['type_refinement_left_brace'] ?? dict['kind' => 'missing'])
-        as dict<_, _>,
+      ($json['type_refinement_left_brace']) as dict<_, _>,
       $file,
       $offset,
       $source,
-      'Node',
+      'LeftBraceToken',
     );
-    $offset += $left_brace?->getWidth() ?? 0;
+    $left_brace = $left_brace as nonnull;
+    $offset += $left_brace->getWidth();
     $members = Node::fromJSON(
-      ($json['type_refinement_members'] ?? dict['kind' => 'missing'])
-        as dict<_, _>,
+      ($json['type_refinement_members']) as dict<_, _>,
       $file,
       $offset,
       $source,
-      'Node',
+      'NodeList<ListItem<TypeInRefinement>>',
     );
-    $offset += $members?->getWidth() ?? 0;
+    $members = $members as nonnull;
+    $offset += $members->getWidth();
     $right_brace = Node::fromJSON(
-      ($json['type_refinement_right_brace'] ?? dict['kind' => 'missing'])
-        as dict<_, _>,
+      ($json['type_refinement_right_brace']) as dict<_, _>,
       $file,
       $offset,
       $source,
-      'Node',
+      'RightBraceToken',
     );
-    $offset += $right_brace?->getWidth() ?? 0;
+    $right_brace = $right_brace as nonnull;
+    $offset += $right_brace->getWidth();
     $source_ref = shape(
       'file' => $file,
       'source' => $source,
@@ -124,17 +124,11 @@ final class TypeRefinement extends Node {
     vec<Node> $parents = vec[],
   ): this {
     $parents[] = $this;
-    $type = $this->_type === null ? null : $rewriter($this->_type, $parents);
-    $keyword =
-      $this->_keyword === null ? null : $rewriter($this->_keyword, $parents);
-    $left_brace = $this->_left_brace === null
-      ? null
-      : $rewriter($this->_left_brace, $parents);
-    $members =
-      $this->_members === null ? null : $rewriter($this->_members, $parents);
-    $right_brace = $this->_right_brace === null
-      ? null
-      : $rewriter($this->_right_brace, $parents);
+    $type = $rewriter($this->_type, $parents);
+    $keyword = $rewriter($this->_keyword, $parents);
+    $left_brace = $rewriter($this->_left_brace, $parents);
+    $members = $rewriter($this->_members, $parents);
+    $right_brace = $rewriter($this->_right_brace, $parents);
     if (
       $type === $this->_type &&
       $keyword === $this->_keyword &&
@@ -145,11 +139,11 @@ final class TypeRefinement extends Node {
       return $this;
     }
     return new static(
-      $type as ?Node,
-      $keyword as ?Node,
-      $left_brace as ?Node,
-      $members as ?Node,
-      $right_brace as ?Node,
+      $type as SimpleTypeSpecifier,
+      $keyword as WithToken,
+      $left_brace as LeftBraceToken,
+      /* HH_FIXME[4110] NodeList<ListItem<TypeInRefinement>> may not be enforceable */ $members,
+      $right_brace as RightBraceToken,
     );
   }
 
@@ -157,7 +151,7 @@ final class TypeRefinement extends Node {
     return $this->_type;
   }
 
-  public function withType(?Node $value): this {
+  public function withType(SimpleTypeSpecifier $value): this {
     if ($value === $this->_type) {
       return $this;
     }
@@ -171,28 +165,28 @@ final class TypeRefinement extends Node {
   }
 
   public function hasType(): bool {
-    return $this->_type !== null;
+    return true;
   }
 
   /**
-   * @return unknown
+   * @return SimpleTypeSpecifier
    */
-  public function getType(): ?Node {
-    return $this->_type;
+  public function getType(): SimpleTypeSpecifier {
+    return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_type);
   }
 
   /**
-   * @return unknown
+   * @return SimpleTypeSpecifier
    */
-  public function getTypex(): Node {
-    return TypeAssert\not_null($this->getType());
+  public function getTypex(): SimpleTypeSpecifier {
+    return $this->getType();
   }
 
   public function getKeywordUNTYPED(): ?Node {
     return $this->_keyword;
   }
 
-  public function withKeyword(?Node $value): this {
+  public function withKeyword(WithToken $value): this {
     if ($value === $this->_keyword) {
       return $this;
     }
@@ -206,28 +200,28 @@ final class TypeRefinement extends Node {
   }
 
   public function hasKeyword(): bool {
-    return $this->_keyword !== null;
+    return true;
   }
 
   /**
-   * @return unknown
+   * @return WithToken
    */
-  public function getKeyword(): ?Node {
-    return $this->_keyword;
+  public function getKeyword(): WithToken {
+    return TypeAssert\instance_of(WithToken::class, $this->_keyword);
   }
 
   /**
-   * @return unknown
+   * @return WithToken
    */
-  public function getKeywordx(): Node {
-    return TypeAssert\not_null($this->getKeyword());
+  public function getKeywordx(): WithToken {
+    return $this->getKeyword();
   }
 
   public function getLeftBraceUNTYPED(): ?Node {
     return $this->_left_brace;
   }
 
-  public function withLeftBrace(?Node $value): this {
+  public function withLeftBrace(LeftBraceToken $value): this {
     if ($value === $this->_left_brace) {
       return $this;
     }
@@ -241,28 +235,30 @@ final class TypeRefinement extends Node {
   }
 
   public function hasLeftBrace(): bool {
-    return $this->_left_brace !== null;
+    return true;
   }
 
   /**
-   * @return unknown
+   * @return LeftBraceToken
    */
-  public function getLeftBrace(): ?Node {
-    return $this->_left_brace;
+  public function getLeftBrace(): LeftBraceToken {
+    return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
   }
 
   /**
-   * @return unknown
+   * @return LeftBraceToken
    */
-  public function getLeftBracex(): Node {
-    return TypeAssert\not_null($this->getLeftBrace());
+  public function getLeftBracex(): LeftBraceToken {
+    return $this->getLeftBrace();
   }
 
   public function getMembersUNTYPED(): ?Node {
     return $this->_members;
   }
 
-  public function withMembers(?Node $value): this {
+  public function withMembers(
+    NodeList<ListItem<TypeInRefinement>> $value,
+  ): this {
     if ($value === $this->_members) {
       return $this;
     }
@@ -276,28 +272,28 @@ final class TypeRefinement extends Node {
   }
 
   public function hasMembers(): bool {
-    return $this->_members !== null;
+    return true;
   }
 
   /**
-   * @return unknown
+   * @return NodeList<ListItem<TypeInRefinement>>
    */
-  public function getMembers(): ?Node {
-    return $this->_members;
+  public function getMembers(): NodeList<ListItem<TypeInRefinement>> {
+    return TypeAssert\instance_of(NodeList::class, $this->_members);
   }
 
   /**
-   * @return unknown
+   * @return NodeList<ListItem<TypeInRefinement>>
    */
-  public function getMembersx(): Node {
-    return TypeAssert\not_null($this->getMembers());
+  public function getMembersx(): NodeList<ListItem<TypeInRefinement>> {
+    return $this->getMembers();
   }
 
   public function getRightBraceUNTYPED(): ?Node {
     return $this->_right_brace;
   }
 
-  public function withRightBrace(?Node $value): this {
+  public function withRightBrace(RightBraceToken $value): this {
     if ($value === $this->_right_brace) {
       return $this;
     }
@@ -311,20 +307,20 @@ final class TypeRefinement extends Node {
   }
 
   public function hasRightBrace(): bool {
-    return $this->_right_brace !== null;
+    return true;
   }
 
   /**
-   * @return unknown
+   * @return RightBraceToken
    */
-  public function getRightBrace(): ?Node {
-    return $this->_right_brace;
+  public function getRightBrace(): RightBraceToken {
+    return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
   }
 
   /**
-   * @return unknown
+   * @return RightBraceToken
    */
-  public function getRightBracex(): Node {
-    return TypeAssert\not_null($this->getRightBrace());
+  public function getRightBracex(): RightBraceToken {
+    return $this->getRightBrace();
   }
 }

--- a/codegen/syntax/TypeRefinement.hack
+++ b/codegen/syntax/TypeRefinement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b215636e731f4d8b29421bb5f4e9b878>>
+ * @generated SignedSource<<0e1a92dc39647bc3121831fdcc626aca>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -14,18 +14,18 @@ final class TypeRefinement extends Node {
 
   const string SYNTAX_KIND = 'type_refinement';
 
-  private SimpleTypeSpecifier $_type;
-  private WithToken $_keyword;
-  private LeftBraceToken $_left_brace;
-  private NodeList<ListItem<TypeInRefinement>> $_members;
-  private RightBraceToken $_right_brace;
+  private ?Node $_type;
+  private ?Node $_keyword;
+  private ?Node $_left_brace;
+  private ?Node $_members;
+  private ?Node $_right_brace;
 
   public function __construct(
-    SimpleTypeSpecifier $type,
-    WithToken $keyword,
-    LeftBraceToken $left_brace,
-    NodeList<ListItem<TypeInRefinement>> $members,
-    RightBraceToken $right_brace,
+    ?Node $type,
+    ?Node $keyword,
+    ?Node $left_brace,
+    ?Node $members,
+    ?Node $right_brace,
     ?__Private\SourceRef $source_ref = null,
   ) {
     $this->_type = $type;
@@ -46,50 +46,50 @@ final class TypeRefinement extends Node {
   ): this {
     $offset = $initial_offset;
     $type = Node::fromJSON(
-      ($json['type_refinement_type']) as dict<_, _>,
+      ($json['type_refinement_type'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
       $file,
       $offset,
       $source,
-      'SimpleTypeSpecifier',
+      'Node',
     );
-    $type = $type as nonnull;
-    $offset += $type->getWidth();
+    $offset += $type?->getWidth() ?? 0;
     $keyword = Node::fromJSON(
-      ($json['type_refinement_keyword']) as dict<_, _>,
+      ($json['type_refinement_keyword'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
       $file,
       $offset,
       $source,
-      'WithToken',
+      'Node',
     );
-    $keyword = $keyword as nonnull;
-    $offset += $keyword->getWidth();
+    $offset += $keyword?->getWidth() ?? 0;
     $left_brace = Node::fromJSON(
-      ($json['type_refinement_left_brace']) as dict<_, _>,
+      ($json['type_refinement_left_brace'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
       $file,
       $offset,
       $source,
-      'LeftBraceToken',
+      'Node',
     );
-    $left_brace = $left_brace as nonnull;
-    $offset += $left_brace->getWidth();
+    $offset += $left_brace?->getWidth() ?? 0;
     $members = Node::fromJSON(
-      ($json['type_refinement_members']) as dict<_, _>,
+      ($json['type_refinement_members'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
       $file,
       $offset,
       $source,
-      'NodeList<ListItem<TypeInRefinement>>',
+      'Node',
     );
-    $members = $members as nonnull;
-    $offset += $members->getWidth();
+    $offset += $members?->getWidth() ?? 0;
     $right_brace = Node::fromJSON(
-      ($json['type_refinement_right_brace']) as dict<_, _>,
+      ($json['type_refinement_right_brace'] ?? dict['kind' => 'missing'])
+        as dict<_, _>,
       $file,
       $offset,
       $source,
-      'RightBraceToken',
+      'Node',
     );
-    $right_brace = $right_brace as nonnull;
-    $offset += $right_brace->getWidth();
+    $offset += $right_brace?->getWidth() ?? 0;
     $source_ref = shape(
       'file' => $file,
       'source' => $source,
@@ -124,11 +124,17 @@ final class TypeRefinement extends Node {
     vec<Node> $parents = vec[],
   ): this {
     $parents[] = $this;
-    $type = $rewriter($this->_type, $parents);
-    $keyword = $rewriter($this->_keyword, $parents);
-    $left_brace = $rewriter($this->_left_brace, $parents);
-    $members = $rewriter($this->_members, $parents);
-    $right_brace = $rewriter($this->_right_brace, $parents);
+    $type = $this->_type === null ? null : $rewriter($this->_type, $parents);
+    $keyword =
+      $this->_keyword === null ? null : $rewriter($this->_keyword, $parents);
+    $left_brace = $this->_left_brace === null
+      ? null
+      : $rewriter($this->_left_brace, $parents);
+    $members =
+      $this->_members === null ? null : $rewriter($this->_members, $parents);
+    $right_brace = $this->_right_brace === null
+      ? null
+      : $rewriter($this->_right_brace, $parents);
     if (
       $type === $this->_type &&
       $keyword === $this->_keyword &&
@@ -139,11 +145,11 @@ final class TypeRefinement extends Node {
       return $this;
     }
     return new static(
-      $type as SimpleTypeSpecifier,
-      $keyword as WithToken,
-      $left_brace as LeftBraceToken,
-      /* HH_FIXME[4110] NodeList<ListItem<TypeInRefinement>> may not be enforceable */ $members,
-      $right_brace as RightBraceToken,
+      $type as ?Node,
+      $keyword as ?Node,
+      $left_brace as ?Node,
+      $members as ?Node,
+      $right_brace as ?Node,
     );
   }
 
@@ -151,7 +157,7 @@ final class TypeRefinement extends Node {
     return $this->_type;
   }
 
-  public function withType(SimpleTypeSpecifier $value): this {
+  public function withType(?Node $value): this {
     if ($value === $this->_type) {
       return $this;
     }
@@ -165,28 +171,28 @@ final class TypeRefinement extends Node {
   }
 
   public function hasType(): bool {
-    return true;
+    return $this->_type !== null;
   }
 
   /**
-   * @return SimpleTypeSpecifier
+   * @return unknown
    */
-  public function getType(): SimpleTypeSpecifier {
-    return TypeAssert\instance_of(SimpleTypeSpecifier::class, $this->_type);
+  public function getType(): ?Node {
+    return $this->_type;
   }
 
   /**
-   * @return SimpleTypeSpecifier
+   * @return unknown
    */
-  public function getTypex(): SimpleTypeSpecifier {
-    return $this->getType();
+  public function getTypex(): Node {
+    return TypeAssert\not_null($this->getType());
   }
 
   public function getKeywordUNTYPED(): ?Node {
     return $this->_keyword;
   }
 
-  public function withKeyword(WithToken $value): this {
+  public function withKeyword(?Node $value): this {
     if ($value === $this->_keyword) {
       return $this;
     }
@@ -200,28 +206,28 @@ final class TypeRefinement extends Node {
   }
 
   public function hasKeyword(): bool {
-    return true;
+    return $this->_keyword !== null;
   }
 
   /**
-   * @return WithToken
+   * @return unknown
    */
-  public function getKeyword(): WithToken {
-    return TypeAssert\instance_of(WithToken::class, $this->_keyword);
+  public function getKeyword(): ?Node {
+    return $this->_keyword;
   }
 
   /**
-   * @return WithToken
+   * @return unknown
    */
-  public function getKeywordx(): WithToken {
-    return $this->getKeyword();
+  public function getKeywordx(): Node {
+    return TypeAssert\not_null($this->getKeyword());
   }
 
   public function getLeftBraceUNTYPED(): ?Node {
     return $this->_left_brace;
   }
 
-  public function withLeftBrace(LeftBraceToken $value): this {
+  public function withLeftBrace(?Node $value): this {
     if ($value === $this->_left_brace) {
       return $this;
     }
@@ -235,30 +241,28 @@ final class TypeRefinement extends Node {
   }
 
   public function hasLeftBrace(): bool {
-    return true;
+    return $this->_left_brace !== null;
   }
 
   /**
-   * @return LeftBraceToken
+   * @return unknown
    */
-  public function getLeftBrace(): LeftBraceToken {
-    return TypeAssert\instance_of(LeftBraceToken::class, $this->_left_brace);
+  public function getLeftBrace(): ?Node {
+    return $this->_left_brace;
   }
 
   /**
-   * @return LeftBraceToken
+   * @return unknown
    */
-  public function getLeftBracex(): LeftBraceToken {
-    return $this->getLeftBrace();
+  public function getLeftBracex(): Node {
+    return TypeAssert\not_null($this->getLeftBrace());
   }
 
   public function getMembersUNTYPED(): ?Node {
     return $this->_members;
   }
 
-  public function withMembers(
-    NodeList<ListItem<TypeInRefinement>> $value,
-  ): this {
+  public function withMembers(?Node $value): this {
     if ($value === $this->_members) {
       return $this;
     }
@@ -272,28 +276,28 @@ final class TypeRefinement extends Node {
   }
 
   public function hasMembers(): bool {
-    return true;
+    return $this->_members !== null;
   }
 
   /**
-   * @return NodeList<ListItem<TypeInRefinement>>
+   * @return unknown
    */
-  public function getMembers(): NodeList<ListItem<TypeInRefinement>> {
-    return TypeAssert\instance_of(NodeList::class, $this->_members);
+  public function getMembers(): ?Node {
+    return $this->_members;
   }
 
   /**
-   * @return NodeList<ListItem<TypeInRefinement>>
+   * @return unknown
    */
-  public function getMembersx(): NodeList<ListItem<TypeInRefinement>> {
-    return $this->getMembers();
+  public function getMembersx(): Node {
+    return TypeAssert\not_null($this->getMembers());
   }
 
   public function getRightBraceUNTYPED(): ?Node {
     return $this->_right_brace;
   }
 
-  public function withRightBrace(RightBraceToken $value): this {
+  public function withRightBrace(?Node $value): this {
     if ($value === $this->_right_brace) {
       return $this;
     }
@@ -307,20 +311,20 @@ final class TypeRefinement extends Node {
   }
 
   public function hasRightBrace(): bool {
-    return true;
+    return $this->_right_brace !== null;
   }
 
   /**
-   * @return RightBraceToken
+   * @return unknown
    */
-  public function getRightBrace(): RightBraceToken {
-    return TypeAssert\instance_of(RightBraceToken::class, $this->_right_brace);
+  public function getRightBrace(): ?Node {
+    return $this->_right_brace;
   }
 
   /**
-   * @return RightBraceToken
+   * @return unknown
    */
-  public function getRightBracex(): RightBraceToken {
-    return $this->getRightBrace();
+  public function getRightBracex(): Node {
+    return TypeAssert\not_null($this->getRightBrace());
   }
 }

--- a/codegen/syntax/WhereConstraint.hack
+++ b/codegen/syntax/WhereConstraint.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<82c89e9b354650c7f73cd2b9746122d3>>
+ * @generated SignedSource<<90c5e31c105e2a1bbe0b9843f1d8d824>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -191,7 +191,7 @@ final class WhereConstraint extends Node {
   /**
    * @return DictionaryTypeSpecifier | GenericTypeSpecifier |
    * NullableTypeSpecifier | SimpleTypeSpecifier | TypeConstant |
-   * VectorTypeSpecifier
+   * TypeRefinement | VectorTypeSpecifier
    */
   public function getRightType(): ITypeSpecifier {
     return TypeAssert\instance_of(ITypeSpecifier::class, $this->_right_type);
@@ -200,7 +200,7 @@ final class WhereConstraint extends Node {
   /**
    * @return DictionaryTypeSpecifier | GenericTypeSpecifier |
    * NullableTypeSpecifier | SimpleTypeSpecifier | TypeConstant |
-   * VectorTypeSpecifier
+   * TypeRefinement | VectorTypeSpecifier
    */
   public function getRightTypex(): ITypeSpecifier {
     return $this->getRightType();

--- a/codegen/syntax/WhereConstraint.hack
+++ b/codegen/syntax/WhereConstraint.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<79d420983bf86f9cea4c99090d98855e>>
+ * @generated SignedSource<<82c89e9b354650c7f73cd2b9746122d3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -16,12 +16,12 @@ final class WhereConstraint extends Node {
 
   private ITypeSpecifier $_left_type;
   private Token $_operator;
-  private Node $_right_type;
+  private ITypeSpecifier $_right_type;
 
   public function __construct(
     ITypeSpecifier $left_type,
     Token $operator,
-    Node $right_type,
+    ITypeSpecifier $right_type,
     ?__Private\SourceRef $source_ref = null,
   ) {
     $this->_left_type = $left_type;
@@ -62,7 +62,7 @@ final class WhereConstraint extends Node {
       $file,
       $offset,
       $source,
-      'Node',
+      'ITypeSpecifier',
     );
     $right_type = $right_type as nonnull;
     $offset += $right_type->getWidth();
@@ -109,7 +109,7 @@ final class WhereConstraint extends Node {
     return new static(
       $left_type as ITypeSpecifier,
       $operator as Token,
-      $right_type as Node,
+      $right_type as ITypeSpecifier,
     );
   }
 
@@ -177,7 +177,7 @@ final class WhereConstraint extends Node {
     return $this->_right_type;
   }
 
-  public function withRightType(Node $value): this {
+  public function withRightType(ITypeSpecifier $value): this {
     if ($value === $this->_right_type) {
       return $this;
     }
@@ -191,18 +191,18 @@ final class WhereConstraint extends Node {
   /**
    * @return DictionaryTypeSpecifier | GenericTypeSpecifier |
    * NullableTypeSpecifier | SimpleTypeSpecifier | TypeConstant |
-   * TypeRefinement | VectorTypeSpecifier
+   * VectorTypeSpecifier
    */
-  public function getRightType(): Node {
-    return $this->_right_type;
+  public function getRightType(): ITypeSpecifier {
+    return TypeAssert\instance_of(ITypeSpecifier::class, $this->_right_type);
   }
 
   /**
    * @return DictionaryTypeSpecifier | GenericTypeSpecifier |
    * NullableTypeSpecifier | SimpleTypeSpecifier | TypeConstant |
-   * TypeRefinement | VectorTypeSpecifier
+   * VectorTypeSpecifier
    */
-  public function getRightTypex(): Node {
+  public function getRightTypex(): ITypeSpecifier {
     return $this->getRightType();
   }
 }

--- a/codegen/token_from_data.hack
+++ b/codegen/token_from_data.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c34aebea36fef6639af9192ed0d49f80>>
+ * @generated SignedSource<<7d078c309d4c59beeb06f60355a04722>>
  */
 namespace Facebook\HHAST\__Private;
 use namespace Facebook\HHAST;
@@ -101,6 +101,7 @@ final class TokenClassMap {
     'noreturn' => HHAST\NoreturnToken::class,
     'null' => HHAST\NullLiteralToken::class,
     'num' => HHAST\NumToken::class,
+    'package' => HHAST\PackageToken::class,
     'parent' => HHAST\ParentToken::class,
     'print' => HHAST\PrintToken::class,
     'private' => HHAST\PrivateToken::class,

--- a/codegen/tokens/PackageToken.hack
+++ b/codegen/tokens/PackageToken.hack
@@ -1,0 +1,20 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * @generated SignedSource<<ae30c735e288af7b15e244d581f5c39a>>
+ */
+namespace Facebook\HHAST;
+
+final class PackageToken extends TokenWithVariableText {
+
+  const string KIND = 'package';
+
+  public function __construct(
+    ?NodeList<Trivia> $leading,
+    ?NodeList<Trivia> $trailing,
+    string $token_text = 'package',
+    ?__Private\SourceRef $source_ref = null,
+  ) {
+    parent::__construct($leading, $trailing, $token_text, $source_ref);
+  }
+}

--- a/codegen/version.hack
+++ b/codegen/version.hack
@@ -1,12 +1,12 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ccbdbf2a8fb45a2fdc592f00fcd1e900>>
+ * @generated SignedSource<<4c186254a2fdaee9fc18ca3106f56fcb>>
  */
 namespace Facebook\HHAST;
 
-const string SCHEMA_VERSION = '2022-09-09-0000';
+const string SCHEMA_VERSION = '2022-09-29-0000';
 
-const int HHVM_VERSION_ID = 417000;
+const int HHVM_VERSION_ID = 417200;
 
-const string HHVM_VERSION = '4.170.0-dev';
+const string HHVM_VERSION = '4.172.0-dev';

--- a/codegen/version.hack
+++ b/codegen/version.hack
@@ -1,12 +1,12 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<866c2e301f33e65c525d7d8de1f589e3>>
+ * @generated SignedSource<<ccbdbf2a8fb45a2fdc592f00fcd1e900>>
  */
 namespace Facebook\HHAST;
 
 const string SCHEMA_VERSION = '2022-09-09-0000';
 
-const int HHVM_VERSION_ID = 417100;
+const int HHVM_VERSION_ID = 417000;
 
-const string HHVM_VERSION = '4.171.0-dev';
+const string HHVM_VERSION = '4.170.0-dev';

--- a/src/__Private/codegen/CodegenBase.hack
+++ b/src/__Private/codegen/CodegenBase.hack
@@ -311,6 +311,7 @@ abstract class CodegenBase {
           HHAST\TypeConstant::class,
           HHAST\VariadicParameter::class,
           HHAST\XHPEnumType::class,
+          HHAST\TypeRefinement::class,
         ],
         Vec\filter(
           $this->getSchema()['AST'],

--- a/src/nodes/IHasTypeHint.hack
+++ b/src/nodes/IHasTypeHint.hack
@@ -13,7 +13,7 @@ interface IHasTypeHint {
   require extends Node;
 
   public function hasType(): bool;
-  public function getType(): ?Node;
-  public function getTypex(): Node;
+  public function getType(): ?ITypeSpecifier;
+  public function getTypex(): ITypeSpecifier;
   public function getTypeUNTYPED(): ?Node;
 }

--- a/src/nodes/IHasTypeHint.hack
+++ b/src/nodes/IHasTypeHint.hack
@@ -13,7 +13,7 @@ interface IHasTypeHint {
   require extends Node;
 
   public function hasType(): bool;
-  public function getType(): ?ITypeSpecifier;
-  public function getTypex(): ITypeSpecifier;
+  public function getType(): ?Node;
+  public function getTypex(): Node;
   public function getTypeUNTYPED(): ?Node;
 }


### PR DESCRIPTION
This PR let `TypeRefinement` implement `ITypeSpecifier` and the update schame version to `2022-09-29-0000`, fixing the CI on `main` branch. Without this PR, many places that were `ITypeSpecifier` now become `Node`, resulting compilation errors.
