### PR TITLE
Enable lint suppressions on the error node in addition to the linted node

### DIFF
--- a/src/Linters/ASTLinter.hack
+++ b/src/Linters/ASTLinter.hack
@@ -100,7 +100,8 @@ abstract class ASTLinter extends SingleRuleLinter {
 
       if (
         $error !== null &&
-        !SuppressASTLinter\is_linter_error_suppressed($this, $node, $ast)
+        !SuppressASTLinter\is_linter_error_suppressed($this, $node, $ast) &&
+        !SuppressASTLinter\is_linter_error_suppressed($this, $error->getBlameNode(), $ast)
       ) {
         $errors[] = $error;
       }


### PR DESCRIPTION
There is currently an assumption in HHAST that the lint node and the error node will be the same thing, but discussions with @fredemmott indicate that assumption is unneeded. This change will check for suppressions on the error node in addition to the lint node so that we can have this work in an expected way. This should ease situations where people are trying to automatically apply suppressions from the lint errors for linters where the error node and lint node are not the same.