### PR TITLE
Create functions to get suppressions with the errors

### DIFF
--- a/src/Linters/suppress_ast_linter_error.hack
+++ b/src/Linters/suppress_ast_linter_error.hack
@@ -9,7 +9,7 @@
 
 namespace Facebook\HHAST\SuppressASTLinter;
 
-use type Facebook\HHAST\{IStatement, Node, Script, SingleRuleLinter};
+use type Facebook\HHAST\{IStatement, Node, Script, SingleRuleLinter, Token};
 
 use namespace HH\Lib\{C, Str, Vec};
 
@@ -21,15 +21,7 @@ function is_linter_error_suppressed(
   Node $node,
   Script $root,
 ): bool {
-  $fixme = $linter->getFixmeMarker();
-  $ignore = $linter->getIgnoreSingleErrorMarker();
-
-  if (is_linter_suppressed_in_current_node($node, $fixme, $ignore)) {
-    return true;
-  }
-
-  return is_linter_suppressed_in_sibling_node($node, $root, $fixme, $ignore) ||
-    is_linter_suppressed_up_to_statement($node, $root, $fixme, $ignore);
+  return linter_error_suppression_token($linter, $node, $root) is nonnull;
 }
 
 // Check the current token's leading trivia. For example a comment on the line before
@@ -38,13 +30,7 @@ function is_linter_suppressed_in_current_node(
   string $fixme,
   string $ignore,
 ): bool {
-  $token = $node->getFirstToken();
-  if ($token === null) {
-    return false;
-  }
-
-  $leading = $token->getLeading()->getCode();
-  return Str\contains($leading, $fixme) || Str\contains($leading, $ignore);
+  return linter_suppression_token_in_current_node($node, $fixme, $ignore) is nonnull;
 }
 
 // Check sibling node as the comment might be attached there instead of on the current node
@@ -54,16 +40,12 @@ function is_linter_suppressed_in_sibling_node(
   string $fixme,
   string $ignore,
 ): bool {
-  $first_token = $node->getFirstToken();
-  if ($first_token is null) {
-    return false;
-  }
-  $token = $root->getPreviousToken($first_token);
-  if ($token === null) {
-    return false;
-  }
-  $trailing = $token->getTrailing()->getCode();
-  return Str\contains($trailing, $fixme) || Str\contains($trailing, $ignore);
+  return linter_suppression_token_in_sibling_node(
+    $node,
+    $root,
+    $fixme,
+    $ignore,
+  ) is nonnull;
 }
 
 // Walk up the parents and check the leading trivia until we hit a Statement type node.
@@ -73,8 +55,74 @@ function is_linter_suppressed_up_to_statement(
   string $fixme,
   string $ignore,
 ): bool {
+  return linter_suppression_token_up_to_statement(
+    $node,
+    $root,
+    $fixme,
+    $ignore,
+  ) is nonnull;
+}
+
+function linter_error_suppression_token(
+  SingleRuleLinter $linter,
+  Node $node,
+  Script $root,
+): ?Token {
+  $fixme = $linter->getFixmeMarker();
+  $ignore = $linter->getIgnoreSingleErrorMarker();
+
+  return linter_suppression_token_in_current_node($node, $fixme, $ignore) ??
+    linter_suppression_token_in_sibling_node($node, $root, $fixme, $ignore) ??
+    linter_suppression_token_up_to_statement($node, $root, $fixme, $ignore);
+}
+
+// Check the current token's leading trivia. For example a comment on the line before
+function linter_suppression_token_in_current_node(
+  Node $node,
+  string $fixme,
+  string $ignore,
+): ?Token {
+  $token = $node->getFirstToken();
+  if ($token === null) {
+    return null;
+  }
+
+  $leading = $token->getLeading()->getCode();
+  return Str\contains($leading, $fixme) || Str\contains($leading, $ignore)
+    ? $token
+    : null;
+}
+
+// Check sibling node as the comment might be attached there instead of on the current node
+function linter_suppression_token_in_sibling_node(
+  Node $node,
+  Script $root,
+  string $fixme,
+  string $ignore,
+): ?Token {
+  $first_token = $node->getFirstToken();
+  if ($first_token is null) {
+    return null;
+  }
+  $token = $root->getPreviousToken($first_token);
+  if ($token === null) {
+    return null;
+  }
+  $trailing = $token->getTrailing()->getCode();
+  return Str\contains($trailing, $fixme) || Str\contains($trailing, $ignore)
+    ? $token
+    : null;
+}
+
+// Walk up the parents and check the leading trivia until we hit a Statement type node.
+function linter_suppression_token_up_to_statement(
+  Node $node,
+  Script $root,
+  string $fixme,
+  string $ignore,
+): ?Token {
   if ($node is IStatement) {
-    return false;
+    return null;
   }
   $children = $root->getChildren();
   $statement = null;
@@ -93,8 +141,9 @@ function is_linter_suppressed_up_to_statement(
     }
   }
   if ($statement === null) {
-    return false;
+    return null;
   }
-  return is_linter_suppressed_in_current_node($statement, $fixme, $ignore) ||
-    is_linter_suppressed_in_sibling_node($statement, $root, $fixme, $ignore);
+
+  return linter_suppression_token_in_current_node($statement, $fixme, $ignore) ??
+    linter_suppression_token_in_sibling_node($statement, $root, $fixme, $ignore);
 }


### PR DESCRIPTION
This adds some functionality that allows us to get the errors with the suppressions. This will be useful when combined with getting all of the suppressions in a file to allow the removal of those suppressions that are not actively being used.