### PR TITLE
Fix UnusedUseClauseLinter to handle EnumClassLabelExpression nodes

### DIFF
--- a/src/get_unresolved_referenced_names.hack
+++ b/src/get_unresolved_referenced_names.hack
@@ -98,6 +98,13 @@ function get_unresolved_referenced_names(Node $root): shape(
         $ret['namespaces'][] = C\firstx($parts);
       }
     }
+
+    if ($node is EnumClassLabelExpression) {
+      $name = $node->getQualifier() ?as NameToken;
+      if ($name !== null) {
+        $ret['types'][] = $name->getText();
+      }
+    }
   }
 
   return $ret;


### PR DESCRIPTION
Discovered this issue running on our codebase. The reference finding wasn't properly accounting for this type of node so adding it here to fix the issue we were having.