### PR TITLE
Random bug fixes

### DIFF
--- a/codegen/inferred_relationships.hack
+++ b/codegen/inferred_relationships.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c7a8a2efe3d4b0f86439bc3bcd9775fa>>
+ * @generated SignedSource<<0cb6442b34479c8ca9d81ac0cc1ec48a>>
  */
 namespace Facebook\HHAST\__Private;
 
@@ -923,6 +923,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<dictionary_intrinsic_expression>|list_item<literal>>',
     'list<list_item<enum_class_label>>',
     'list<list_item<function_call_expression>>',
+    'list<list_item<function_call_expression>|list_item<lambda_expression>>',
     'list<list_item<function_call_expression>|list_item<literal>>',
     'list<list_item<function_call_expression>|list_item<literal>|list_item<prefix_unary_expression>>',
     'list<list_item<function_call_expression>|list_item<member_selection_expression>>',
@@ -2392,9 +2393,11 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'parenthesized_expression',
     'postfix_unary_expression',
     'prefix_unary_expression',
+    'qualified_name',
     'scope_resolution_expression',
     'shape_expression',
     'subscript_expression',
+    'token:name',
     'variable',
     'varray_intrinsic_expression',
     'vector_intrinsic_expression',

--- a/codegen/syntax/LambdaExpression.hack
+++ b/codegen/syntax/LambdaExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<29ed3005c47a47905b1ba5ef2bed0d62>>
+ * @generated SignedSource<<a97f9b1e5597a401181b2f7ed611e62d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -319,9 +319,10 @@ final class LambdaExpression
    * FunctionCallExpression | IsExpression | KeysetIntrinsicExpression |
    * LambdaExpression | LiteralExpression | MemberSelectionExpression |
    * NullableAsExpression | ObjectCreationExpression | ParenthesizedExpression
-   * | PostfixUnaryExpression | PrefixUnaryExpression |
+   * | PostfixUnaryExpression | PrefixUnaryExpression | QualifiedName |
    * ScopeResolutionExpression | ShapeExpression | SubscriptExpression |
-   * VariableExpression | VarrayIntrinsicExpression | VectorIntrinsicExpression
+   * NameToken | VariableExpression | VarrayIntrinsicExpression |
+   * VectorIntrinsicExpression
    */
   public function getBody(): ILambdaBody {
     return TypeAssert\instance_of(ILambdaBody::class, $this->_body);
@@ -334,9 +335,10 @@ final class LambdaExpression
    * FunctionCallExpression | IsExpression | KeysetIntrinsicExpression |
    * LambdaExpression | LiteralExpression | MemberSelectionExpression |
    * NullableAsExpression | ObjectCreationExpression | ParenthesizedExpression
-   * | PostfixUnaryExpression | PrefixUnaryExpression |
+   * | PostfixUnaryExpression | PrefixUnaryExpression | QualifiedName |
    * ScopeResolutionExpression | ShapeExpression | SubscriptExpression |
-   * VariableExpression | VarrayIntrinsicExpression | VectorIntrinsicExpression
+   * NameToken | VariableExpression | VarrayIntrinsicExpression |
+   * VectorIntrinsicExpression
    */
   public function getBodyx(): ILambdaBody {
     return $this->getBody();

--- a/codegen/syntax/QualifiedName.hack
+++ b/codegen/syntax/QualifiedName.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4579cd1ceb9bff63b706f9dc72f3fd3c>>
+ * @generated SignedSource<<0c30f737bac86560c28df9d343ad933d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -12,7 +12,10 @@ use namespace HH\Lib\Dict;
 <<__ConsistentConstruct>>
 final class QualifiedName
   extends Node
-  implements INameishNode, __Private\IWrappableWithSimpleTypeSpecifier {
+  implements
+    ILambdaBody,
+    INameishNode,
+    __Private\IWrappableWithSimpleTypeSpecifier {
 
   const string SYNTAX_KIND = 'qualified_name';
 

--- a/codegen/tokens/NameToken.hack
+++ b/codegen/tokens/NameToken.hack
@@ -1,13 +1,16 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5f91cc9b0eb7b319df6d8118854d35af>>
+ * @generated SignedSource<<69e54ae78c68fbded1ebb524ac6284c4>>
  */
 namespace Facebook\HHAST;
 
 final class NameToken
   extends TokenWithVariableText
-  implements INameishNode, __Private\IWrappableWithSimpleTypeSpecifier {
+  implements
+    ILambdaBody,
+    INameishNode,
+    __Private\IWrappableWithSimpleTypeSpecifier {
 
   const string KIND = 'name';
 

--- a/src/Linters/NoEmptyStatementsLinter.hack
+++ b/src/Linters/NoEmptyStatementsLinter.hack
@@ -131,7 +131,7 @@ final class NoEmptyStatementsLinter extends AutoFixingASTLinter {
   /**
    * Returns whether the given token is an assignment operator.
    *
-   * This list is all the types returned from ExpressionStatement::getOperator
+   * This list is all the types returned from BinaryExpression::getOperator
    * that include "Equal" and are not comparison operators (==, >=, etc.);
    */
   private function isAssignmentOperator(Token $op): bool {
@@ -140,9 +140,7 @@ final class NoEmptyStatementsLinter extends AutoFixingASTLinter {
       $op is CaratEqualToken ||
       $op is DotEqualToken ||
       $op is EqualToken ||
-      $op is GreaterThanEqualToken ||
       $op is GreaterThanGreaterThanEqualToken ||
-      $op is LessThanEqualToken ||
       $op is LessThanLessThanEqualToken ||
       $op is MinusEqualToken ||
       $op is PercentEqualToken ||

--- a/src/Linters/UnusedUseClauseLinter.hack
+++ b/src/Linters/UnusedUseClauseLinter.hack
@@ -55,8 +55,8 @@ final class UnusedUseClauseLinter extends AutoFixingASTLinter {
           $as = $name->getText();
         } else {
           invariant($name is QualifiedName, 'Unhandled name type');
-          $as = $name->getParts()->getChildrenOfItemsOfType(NameToken::class)
-            |> (C\lastx($$) as nonnull)->getText();
+          $as = $name->getParts()->getChildrenOfItemsByType<NameToken>()
+            |> C\lastx($$)->getText();
         }
       }
       if ($kind is NamespaceToken) {

--- a/src/Linters/UseStatementWIthoutKindLinter.hack
+++ b/src/Linters/UseStatementWIthoutKindLinter.hack
@@ -71,10 +71,8 @@ final class UseStatementWithoutKindLinter extends AutoFixingASTLinter {
     // We need to look at the full file to figure out if this should be a
     // `use type`, or `use namespace`
     $used = $this->getUnresolvedReferencedNames();
-    $used_as_ns = C\any(
-      $names,
-      $name ==> C\contains($used['namespaces'], $name),
-    );
+    $used_as_ns =
+      C\any($names, $name ==> C\contains($used['namespaces'], $name));
     $used_as_type = C\any($names, $name ==> C\contains($used['types'], $name));
 
     $leading = $node->getClauses()->getFirstTokenx()->getLeadingWhitespace();
@@ -92,8 +90,7 @@ final class UseStatementWithoutKindLinter extends AutoFixingASTLinter {
   }
 
   <<__Memoize>>
-  private function getUnresolvedReferencedNames(
-  ): shape(
+  private function getUnresolvedReferencedNames(): shape(
     'namespaces' => keyset<string>,
     'types' => keyset<string>,
     'functions' => keyset<string>,

--- a/src/Linters/UseStatementWIthoutKindLinter.hack
+++ b/src/Linters/UseStatementWIthoutKindLinter.hack
@@ -55,10 +55,8 @@ final class UseStatementWithoutKindLinter extends AutoFixingASTLinter {
         }
         $name = $clause->getName();
         if ($name is QualifiedName) {
-          return (
-            C\lastx(
-              $name->getParts()->getChildrenOfItemsOfType(NameToken::class),
-            ) as nonnull
+          return C\lastx(
+            $name->getParts()->getChildrenOfItemsByType<NameToken>(),
           )->getText();
         }
         invariant(

--- a/src/Migrations/HSLMigration.hack
+++ b/src/Migrations/HSLMigration.hack
@@ -523,7 +523,7 @@ final class HSLMigration extends BaseMigration {
         }
         $found_prefix = true;
         foreach ($parts as $i => $token) {
-          if ($token?->getText() === $search[$i]) {
+          if ($token->getText() === $search[$i]) {
             continue;
           }
           $found_prefix = false;
@@ -569,7 +569,7 @@ final class HSLMigration extends BaseMigration {
             }
 
             foreach ($parts as $i => $token) {
-              if ($i < 2 && $token?->getText() !== $search[$i]) {
+              if ($i < 2 && $token->getText() !== $search[$i]) {
                 break;
               }
 

--- a/src/Migrations/HSLMigration.hack
+++ b/src/Migrations/HSLMigration.hack
@@ -576,7 +576,7 @@ final class HSLMigration extends BaseMigration {
               if ($i === 2) {
                 // we found an HH\Lib\* use statement, add the node and suffix
                 $nodes[] = $decl;
-                $ns = HslNamespace::coerce($token?->getText());
+                $ns = HslNamespace::coerce($token->getText());
                 if ($ns !== null) {
                   $suffixes[] = $ns;
                 }

--- a/src/__Private/codegen/CodegenBase.hack
+++ b/src/__Private/codegen/CodegenBase.hack
@@ -217,6 +217,9 @@ abstract class CodegenBase {
       HHAST\ILambdaBody::class => keyset[
         HHAST\IExpression::class,
         HHAST\CompoundStatement::class,
+        // Constants are not wrapped in a name expression on the RHS of `==>`.
+        HHAST\NameToken::class,
+        HHAST\QualifiedName::class,
       ],
       HHAST\ILambdaSignature::class => keyset[
         HHAST\VariableExpression::class,
@@ -239,8 +242,6 @@ abstract class CodegenBase {
         HHAST\ParameterDeclaration::class,
         HHAST\PropertyDeclaration::class,
         HHAST\LambdaExpression::class,
-        // HHAST\Php7AnonymousFunction::class : not valid in hack. No attributes
-        // if not hack
       ],
       HHAST\INameishNode::class => keyset[
         HHAST\NameToken::class,

--- a/src/__Private/codegen/CodegenRelations.hack
+++ b/src/__Private/codegen/CodegenRelations.hack
@@ -60,7 +60,7 @@ final class CodegenRelations extends CodegenBase {
 
     $relationships = new Ref(dict[]);
     $queue = new Async\Semaphore(
-      /* limit = */ 32,
+      \cpu_get_count(),
       async $file ==> {
         try {
           $links = await $this->getRelationsInFileAsync($file);

--- a/src/__Private/codegen/data/LambdaBody.SyntaxExample.hack
+++ b/src/__Private/codegen/data/LambdaBody.SyntaxExample.hack
@@ -9,7 +9,7 @@
 namespace Facebook\HHAST\__Private\SyntaxExamples;
 
 function lambda_body(): void {
-  () ==> Qualified\CONSTANT;
-  () ==> CONSTANT;
-  () ==> 1 + CONSTANT;
+  $_ = () ==> Qualified\CONSTANT;
+  $_ = () ==> CONSTANT;
+  $_ = () ==> 1 + CONSTANT;
 }

--- a/src/__Private/codegen/data/LambdaBody.SyntaxExample.hack
+++ b/src/__Private/codegen/data/LambdaBody.SyntaxExample.hack
@@ -1,0 +1,15 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+namespace Facebook\HHAST\__Private\SyntaxExamples;
+
+function lambda_body(): void {
+  () ==> Qualified\CONSTANT;
+  () ==> CONSTANT;
+  () ==> 1 + CONSTANT;
+}

--- a/src/nodes/NodeList.hack
+++ b/src/nodes/NodeList.hack
@@ -51,8 +51,9 @@ final class NodeList<+Titem as Node> extends Node {
     return $this->_children;
   }
 
-  public function getChildrenOfItems<T as ?Node>(
-  ): vec<T> where Titem as ListItem<T> {
+  public function getChildrenOfItems<T as ?Node>(): vec<T>
+  where
+    Titem as ListItem<T> {
     return Vec\map($this->getChildren(), $child ==> $child->getItem());
   }
 
@@ -140,7 +141,7 @@ final class NodeList<+Titem as Node> extends Node {
         'source' => $source,
         'offset' => $offset,
         'width' => $current_position - $offset,
-      )
+      ),
     );
   }
 
@@ -204,9 +205,8 @@ final class NodeList<+Titem as Node> extends Node {
     if (!C\contains($this->_children, $old)) {
       return $this;
     }
-    return new NodeList(
-      Vec\map($this->_children, $c ==> $c === $old ? $new : $c),
-    );
+    return
+      new NodeList(Vec\map($this->_children, $c ==> $c === $old ? $new : $c));
   }
 
   public function insertBefore<Tchild super Titem as Node>(
@@ -252,9 +252,9 @@ final class NodeList<+Titem as Node> extends Node {
     return new NodeList($new);
   }
 
-  public function withoutItemWithChild<Tinner as Node>(
-    Tinner $inner,
-  ): this where Titem as ListItem<Tinner> {
+  public function withoutItemWithChild<Tinner as Node>(Tinner $inner): this
+  where
+    Titem as ListItem<Tinner> {
     $new = Vec\filter($this->_children, $c ==> $c->getItem() !== $inner);
     if ($new === $this->_children) {
       return $this;

--- a/src/nodes/NodeList.hack
+++ b/src/nodes/NodeList.hack
@@ -16,9 +16,17 @@ use type Facebook\HHAST\_Private\SoftDeprecated;
 final class NodeList<+Titem as Node> extends Node {
   const string SYNTAX_KIND = 'list';
   /**
-   * Use `NodeList::createMaybeEmptyList()` or
-   * `NodeList::createNonEmptyListNull()` instead to be explicit
-   * about desired behavior.
+   * Use `NodeList::createMaybeEmptyList(vec[])` or `null` instead of
+   * `new NodeList(vec[])` if you know the vec is always empty.
+   * A parsed Hack AST doesn't contain empty NodeLists.
+   *
+   * Side note: Places where you'd expect to find an empty NodeList:
+   * ```
+   * function no_params( ): void {}
+   * //                 ^
+   * ```
+   * The Hack parser places a "missing" node at the carat.
+   * HHAST uses `null` to represent them.
    */
   <<__Override>>
   public function __construct(

--- a/src/nodes/NodeList.hack
+++ b/src/nodes/NodeList.hack
@@ -49,11 +49,14 @@ final class NodeList<+Titem as Node> extends Node {
 
   public function getChildrenOfItemsOfType<T as ?Node>(
     classname<T> $what,
-  ): vec<T> where Titem as ListItem<T> {
+  ): vec<T> where Titem as ListItem<?Node> {
     $out = vec[];
     foreach ($this->getChildrenOfItems() as $item) {
       if (\is_a($item, $what)) {
-        $out[] = $item;
+        $out[] = \HH\FIXME\UNSAFE_CAST<?Node, T>(
+          $item,
+          'is_a($item, $what) ~= $item is T',
+        );
       }
     }
     return $out;

--- a/src/nodes/NodeList.hack
+++ b/src/nodes/NodeList.hack
@@ -10,6 +10,7 @@
 namespace Facebook\HHAST;
 
 use namespace HH\Lib\{C, Str, Vec};
+use type Facebook\HHAST\_Private\SoftDeprecated;
 
 /* HHAST_IGNORE_ALL[5624] */
 final class NodeList<+Titem as Node> extends Node {
@@ -47,6 +48,7 @@ final class NodeList<+Titem as Node> extends Node {
     return Vec\map($this->getChildren(), $child ==> $child->getItem());
   }
 
+  <<SoftDeprecated('$node->getChildrenOfItemsByType<T>()')>>
   public function getChildrenOfItemsOfType<T as ?Node>(
     classname<T> $what,
   ): vec<T> where Titem as ListItem<?Node> {
@@ -57,6 +59,17 @@ final class NodeList<+Titem as Node> extends Node {
           $item,
           'is_a($item, $what) ~= $item is T',
         );
+      }
+    }
+    return $out;
+  }
+
+  public function getChildrenOfItemsByType<<<__Enforceable>> reify T as Node>(
+  ): vec<T> where Titem as ListItem<?Node> {
+    $out = vec[];
+    foreach ($this->getChildrenOfItems() as $item) {
+      if ($item is T) {
+        $out[] = $item;
       }
     }
     return $out;

--- a/tests/NoParamsIsAMissingNodeTest.hack
+++ b/tests/NoParamsIsAMissingNodeTest.hack
@@ -9,7 +9,6 @@
 
 namespace Facebook\HHAST;
 
-use namespace HH\Lib\Str;
 use type Facebook\HackTest\HackTest;
 use function Facebook\FBExpect\expect;
 

--- a/tests/NoParamsIsAMissingNodeTest.hack
+++ b/tests/NoParamsIsAMissingNodeTest.hack
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\Str;
+use type Facebook\HackTest\HackTest;
+use function Facebook\FBExpect\expect;
+
+final class NoParamsIsAMissingNodeTest extends HackTest {
+  /**
+   * @see `NodeList::__construct()`
+   * If this test fails, don't try and fix it.
+   * Just remove the comment (and this test) if this ever starts failing.
+   */
+  public function testTheFollowingCommentStaysCorrect(): void {
+    $_error = null;
+    $json = \HH\ffp_parse_string('function no_params( ): void {}')
+      |> \json_encode_pure($$, inout $_error);
+    expect($json)->toContainSubstring(
+      '"function_parameter_list":{"kind":"missing"}',
+    );
+  }
+}

--- a/tests/NodeListGetChildrenOfItemsOfTypeTest.hack
+++ b/tests/NodeListGetChildrenOfItemsOfTypeTest.hack
@@ -28,7 +28,6 @@ final class NodeListGetChildrenOfItemsOfTypeTest extends HackTest {
     static::takesT<LiteralExpression>($literal_expression);
   }
 
-
   private static function getNodeListOfItemsOfIExpression(
   ): NodeList<ListItem<IExpression>> {
     // NodeList(123,)

--- a/tests/NodeListGetChildrenOfItemsOfTypeTest.hack
+++ b/tests/NodeListGetChildrenOfItemsOfTypeTest.hack
@@ -21,6 +21,14 @@ final class NodeListGetChildrenOfItemsOfTypeTest extends HackTest {
     static::takesT<LiteralExpression>($literal_expression);
   }
 
+  public function testReplacementRefinesTypeToo(): void {
+    $node_list = static::getNodeListOfItemsOfIExpression();
+    $literal_expression =
+      $node_list->getChildrenOfItemsByType<LiteralExpression>() |> C\firstx($$);
+    static::takesT<LiteralExpression>($literal_expression);
+  }
+
+
   private static function getNodeListOfItemsOfIExpression(
   ): NodeList<ListItem<IExpression>> {
     // NodeList(123,)

--- a/tests/NodeListGetChildrenOfItemsOfTypeTest.hack
+++ b/tests/NodeListGetChildrenOfItemsOfTypeTest.hack
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2017-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HHAST;
+
+use namespace HH\Lib\C;
+use type Facebook\HackTest\HackTest;
+
+final class NodeListGetChildrenOfItemsOfTypeTest extends HackTest {
+  public function testRefinesType(): void {
+    $node_list = static::getNodeListOfItemsOfIExpression();
+    $literal_expression =
+      $node_list->getChildrenOfItemsOfType(LiteralExpression::class)
+      |> C\firstx($$);
+    static::takesT<LiteralExpression>($literal_expression);
+  }
+
+  private static function getNodeListOfItemsOfIExpression(
+  ): NodeList<ListItem<IExpression>> {
+    // NodeList(123,)
+    return new NodeList(
+      vec[new ListItem(
+        new LiteralExpression(new DecimalLiteralToken(null, null, '123')),
+        new CommaToken(null, null),
+      )],
+    );
+  }
+
+  private static function takesT<<<__Explicit>> T>(T $_): void {}
+}

--- a/tests/examples/NoEmptyStatementsLinter/comparison_empty_statements.php.autofix.expect
+++ b/tests/examples/NoEmptyStatementsLinter/comparison_empty_statements.php.autofix.expect
@@ -1,0 +1,8 @@
+<?hh
+
+function comparison_empty_statements(): void {
+  3 < 4;
+  3 <= 4;
+  3 > 4;
+  3 >= 4;
+}

--- a/tests/examples/NoEmptyStatementsLinter/comparison_empty_statements.php.expect
+++ b/tests/examples/NoEmptyStatementsLinter/comparison_empty_statements.php.expect
@@ -5,8 +5,18 @@
         "description": "This statement includes an expression that has no effect"
     },
     {
+        "blame": "  3 <= 4;\n",
+        "blame_pretty": "  3 <= 4;\n",
+        "description": "This statement includes an expression that has no effect"
+    },
+    {
         "blame": "  3 > 4;\n",
         "blame_pretty": "  3 > 4;\n",
+        "description": "This statement includes an expression that has no effect"
+    },
+    {
+        "blame": "  3 >= 4;\n",
+        "blame_pretty": "  3 >= 4;\n",
         "description": "This statement includes an expression that has no effect"
     }
 ]

--- a/tests/examples/NoEmptyStatementsLinter/comparison_empty_statements.php.expect
+++ b/tests/examples/NoEmptyStatementsLinter/comparison_empty_statements.php.expect
@@ -1,0 +1,12 @@
+[
+    {
+        "blame": "  3 < 4;\n",
+        "blame_pretty": "  3 < 4;\n",
+        "description": "This statement includes an expression that has no effect"
+    },
+    {
+        "blame": "  3 > 4;\n",
+        "blame_pretty": "  3 > 4;\n",
+        "description": "This statement includes an expression that has no effect"
+    }
+]

--- a/tests/examples/NoEmptyStatementsLinter/comparison_empty_statements.php.in
+++ b/tests/examples/NoEmptyStatementsLinter/comparison_empty_statements.php.in
@@ -1,0 +1,8 @@
+<?hh
+
+function comparison_empty_statements(): void {
+  3 < 4;
+  3 <= 4;
+  3 > 4;
+  3 >= 4;
+}


### PR DESCRIPTION
Fixes:
 - `NoEmptyStatementsLinter`
   - False negative `3 <= 4` was not treated as an empty expression.
   - False negative `3 >= 4` was not treated as an empty expression.
   - Comment: Mentioned `ExpressionStament::getOperator()`, should have been `BinaryOperation`.
 - `NodeList::getChildrenOfItemsOfType<T>(classname<T> $classname): vec<T>`
   - `T` was not inferred to be the type of the classname argument.
   - Added `getChildrenOfItemsByType<reify T>()` to match `getChildrenByType<reify T>()`.
   - Comment mentioned `NodeList::createEmptyListOrNull()`, which doesn't exist anymore.
 - Constants may now appear as the sole expression of a lambda body.
 - Codegen no longer consumes more threads than hardware threads of the machine.

And a quick formatting of the affect files.