### PR TITLE
Banish hh ignore error from codegen

### DIFF
--- a/codegen/inferred_relationships.hack
+++ b/codegen/inferred_relationships.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0cb6442b34479c8ca9d81ac0cc1ec48a>>
+ * @generated SignedSource<<c780eb55e2028ea3bc430212524bd4bc>>
  */
 namespace Facebook\HHAST\__Private;
 
@@ -3490,6 +3490,7 @@ const dict<string, keyset<string>> INFERRED_RELATIONSHIPS = dict[
     'list<list_item<simple_type_specifier>|list_item<tuple_type_specifier>>',
     'list<list_item<simple_type_specifier>|list_item<type_constant>>',
     'list<list_item<simple_type_specifier>|list_item<varray_type_specifier>>',
+    'list<list_item<simple_type_specifier>|list_item<vector_type_specifier>>',
     'list<list_item<tuple_type_specifier>>',
     'list<list_item<type_constant>>',
     'list<list_item<varray_type_specifier>>',

--- a/codegen/syntax/AliasDeclaration.hack
+++ b/codegen/syntax/AliasDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<dc09cdba2457871d60ab08ffa8b217c2>>
+ * @generated SignedSource<<9bc6058071f1c761171f262079d5a9ed>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -154,16 +154,19 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $modifiers,
-      /* HH_IGNORE_ERROR[4110] */ $module_kw_opt,
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $generic_parameter,
-      /* HH_IGNORE_ERROR[4110] */ $constraint,
-      /* HH_IGNORE_ERROR[4110] */ $equal,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $attribute_spec as ?OldAttributeSpecification,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<PublicToken>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $module_kw_opt as ?ModuleToken,
+      $keyword as Token,
+      $name as NameToken,
+      $generic_parameter as ?TypeParameters,
+      $constraint as ?TypeConstraint,
+      $equal as EqualToken,
+      $type as ITypeSpecifier,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -227,7 +230,10 @@ final class AliasDeclaration extends Node implements IHasAttributeSpec {
     }
     return new static(
       $attribute_spec as ?OldAttributeSpecification,
-      /* HH_FIXME[4110] ?NodeList<PublicToken> may not be enforceable */ $modifiers,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<PublicToken>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $module_kw_opt as ?ModuleToken,
       $keyword as Token,
       $name as NameToken,

--- a/codegen/syntax/AnonymousClass.hack
+++ b/codegen/syntax/AnonymousClass.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5488c598e4c75388e89ada9be6df2018>>
+ * @generated SignedSource<<2317dd0b0aedd9cbe976c0906cba81b1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -145,15 +145,15 @@ final class AnonymousClass extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $class_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $argument_list,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $extends_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $extends_list,
-      /* HH_IGNORE_ERROR[4110] */ $implements_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $implements_list,
-      /* HH_IGNORE_ERROR[4110] */ $body,
+      $class_keyword,
+      $left_paren,
+      $argument_list,
+      $right_paren,
+      $extends_keyword,
+      $extends_list,
+      $implements_keyword,
+      $implements_list,
+      $body,
       $source_ref,
     );
   }

--- a/codegen/syntax/AnonymousFunction.hack
+++ b/codegen/syntax/AnonymousFunction.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4de5781bcaa7e6a93cf2b796ecbe43b8>>
+ * @generated SignedSource<<6e17f0c5860853dc26ded3c41eab38ae>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -179,18 +179,24 @@ final class AnonymousFunction
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $async_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $function_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $parameters,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $ctx_list,
-      /* HH_IGNORE_ERROR[4110] */ $colon,
-      /* HH_IGNORE_ERROR[4110] */ $readonly_return,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $use,
-      /* HH_IGNORE_ERROR[4110] */ $body,
+      $attribute_spec as ?OldAttributeSpecification,
+      $async_keyword as ?AsyncToken,
+      $function_keyword as FunctionToken,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ParameterDeclaration>>,
+      >(
+        $parameters as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
+      $ctx_list,
+      $colon as ?ColonToken,
+      $readonly_return as ?ReadonlyToken,
+      $type as ?ITypeSpecifier,
+      $use as ?AnonymousFunctionUseClause,
+      $body as CompoundStatement,
       $source_ref,
     );
   }
@@ -262,7 +268,13 @@ final class AnonymousFunction
       $async_keyword as ?AsyncToken,
       $function_keyword as FunctionToken,
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<ParameterDeclaration>> may not be enforceable */ $parameters,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ParameterDeclaration>>,
+      >(
+        $parameters as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
       $ctx_list as ?Node,
       $colon as ?ColonToken,

--- a/codegen/syntax/AnonymousFunctionUseClause.hack
+++ b/codegen/syntax/AnonymousFunctionUseClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<955f117d1a8d01f011b78bdd734b0795>>
+ * @generated SignedSource<<2e726f06a92097461d26c95b2ad04cc6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,16 @@ final class AnonymousFunctionUseClause extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $variables,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
+      $keyword as UseToken,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<VariableToken>>,
+      >(
+        $variables as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
       $source_ref,
     );
   }
@@ -127,7 +133,13 @@ final class AnonymousFunctionUseClause extends Node {
     return new static(
       $keyword as UseToken,
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<VariableToken>> may not be enforceable */ $variables,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<VariableToken>>,
+      >(
+        $variables as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
     );
   }

--- a/codegen/syntax/AsExpression.hack
+++ b/codegen/syntax/AsExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<543d941329cda45a434d2534a4c3d432>>
+ * @generated SignedSource<<afdc2fac998ecfe5aedae92ce960a244>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class AsExpression extends Node implements ILambdaBody, IExpression {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_operand,
-      /* HH_IGNORE_ERROR[4110] */ $operator,
-      /* HH_IGNORE_ERROR[4110] */ $right_operand,
+      $left_operand as IExpression,
+      $operator as AsToken,
+      $right_operand as ITypeSpecifier,
       $source_ref,
     );
   }

--- a/codegen/syntax/Attribute.hack
+++ b/codegen/syntax/Attribute.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7d7292faf0ec632b2025374386c0a99f>>
+ * @generated SignedSource<<9bb2fa9544ee9459f94610f89d0157fb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -59,11 +59,7 @@ final class Attribute extends Node {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $at,
-      /* HH_IGNORE_ERROR[4110] */ $attribute_name,
-      $source_ref,
-    );
+    return new static($at, $attribute_name, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/AttributeSpecification.hack
+++ b/codegen/syntax/AttributeSpecification.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8483f16a64a5e5d65cabc95c597cb11b>>
+ * @generated SignedSource<<1b80a525f6a531292ececabd673a3aed>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -48,7 +48,7 @@ final class AttributeSpecification extends Node {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(/* HH_IGNORE_ERROR[4110] */ $attributes, $source_ref);
+    return new static($attributes, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/AttributizedSpecifier.hack
+++ b/codegen/syntax/AttributizedSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0292b8b73ed163d95845503bd88c184a>>
+ * @generated SignedSource<<e212a361252f67978a6e08bc0c6f23fc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -61,8 +61,8 @@ final class AttributizedSpecifier extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $type,
+      $attribute_spec as OldAttributeSpecification,
+      $type as ITypeSpecifier,
       $source_ref,
     );
   }

--- a/codegen/syntax/AwaitableCreationExpression.hack
+++ b/codegen/syntax/AwaitableCreationExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<67b875b609e405e368b8ab7a0037444c>>
+ * @generated SignedSource<<43b98712603c4b85612a22bb5e81ce11>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,9 +75,9 @@ abstract class AwaitableCreationExpressionGeneratedBase
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $async,
-      /* HH_IGNORE_ERROR[4110] */ $compound_statement,
+      $attribute_spec as ?OldAttributeSpecification,
+      $async as AsyncToken,
+      $compound_statement as CompoundStatement,
       $source_ref,
     );
   }

--- a/codegen/syntax/BinaryExpression.hack
+++ b/codegen/syntax/BinaryExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<38bcc98afa24fc8c24ef4e98813ff68c>>
+ * @generated SignedSource<<b2fa73def88e75f83a7cdf14926a6df9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,9 +75,9 @@ final class BinaryExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_operand,
-      /* HH_IGNORE_ERROR[4110] */ $operator,
-      /* HH_IGNORE_ERROR[4110] */ $right_operand,
+      $left_operand as IExpression,
+      $operator as Token,
+      $right_operand as IExpression,
       $source_ref,
     );
   }

--- a/codegen/syntax/BracedExpression.hack
+++ b/codegen/syntax/BracedExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<684000a6d02626999e58f7d55369c6a6>>
+ * @generated SignedSource<<2a9c72dab274c67bea3c054d06b84e29>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class BracedExpression extends Node implements ILambdaBody, IExpression {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $left_brace as LeftBraceToken,
+      $expression as IExpression,
+      $right_brace as RightBraceToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/BreakStatement.hack
+++ b/codegen/syntax/BreakStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b9f41d9fd4f1071e93cadf1aa86233b4>>
+ * @generated SignedSource<<2c00ae47596381fae7c363ae6a5c3f9a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -61,8 +61,8 @@ final class BreakStatement extends Node implements IStatement {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as BreakToken,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/CaseLabel.hack
+++ b/codegen/syntax/CaseLabel.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4b31993b99a2ba9810f46d0ef63e67b7>>
+ * @generated SignedSource<<ce02783ace5cd0b24400462579b028fc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class CaseLabel extends Node implements ISwitchLabel {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $colon,
+      $keyword as CaseToken,
+      $expression as IExpression,
+      $colon as ColonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/CastExpression.hack
+++ b/codegen/syntax/CastExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f825478e51c4be876ffc3b8ef34b4458>>
+ * @generated SignedSource<<c43b7d533630bddaf9b5d96fc808e3e6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,10 @@ final class CastExpression extends Node implements ILambdaBody, IExpression {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $operand,
+      $left_paren as LeftParenToken,
+      $type as Token,
+      $right_paren as RightParenToken,
+      $operand as IExpression,
       $source_ref,
     );
   }

--- a/codegen/syntax/CatchClause.hack
+++ b/codegen/syntax/CatchClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<32c92319f025e33ecb8b330835f0d03b>>
+ * @generated SignedSource<<b5ea87a98a19b323e1fb710b9430f4b6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -109,12 +109,12 @@ final class CatchClause extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $variable,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $body,
+      $keyword as CatchToken,
+      $left_paren as LeftParenToken,
+      $type as SimpleTypeSpecifier,
+      $variable as VariableToken,
+      $right_paren as RightParenToken,
+      $body as CompoundStatement,
       $source_ref,
     );
   }

--- a/codegen/syntax/ClassishBody.hack
+++ b/codegen/syntax/ClassishBody.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0ef87b0510915c96527a592dcda3eb55>>
+ * @generated SignedSource<<7381609bda2299d214007e0181b13c0d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,12 @@ final class ClassishBody extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $elements,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $left_brace as LeftBraceToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<IClassBodyDeclaration>>(
+        $elements as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_brace as RightBraceToken,
       $source_ref,
     );
   }
@@ -109,7 +112,10 @@ final class ClassishBody extends Node {
     }
     return new static(
       $left_brace as LeftBraceToken,
-      /* HH_FIXME[4110] ?NodeList<IClassBodyDeclaration> may not be enforceable */ $elements,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<IClassBodyDeclaration>>(
+        $elements as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_brace as RightBraceToken,
     );
   }

--- a/codegen/syntax/ClassishDeclaration.hack
+++ b/codegen/syntax/ClassishDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<efaed262dbcaf1bee37262fcfc534a14>>
+ * @generated SignedSource<<e6593e279b54c2e498af4d9ebe0d6346>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -182,18 +182,33 @@ final class ClassishDeclaration
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute,
-      /* HH_IGNORE_ERROR[4110] */ $modifiers,
-      /* HH_IGNORE_ERROR[4110] */ $xhp,
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $type_parameters,
-      /* HH_IGNORE_ERROR[4110] */ $extends_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $extends_list,
-      /* HH_IGNORE_ERROR[4110] */ $implements_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $implements_list,
-      /* HH_IGNORE_ERROR[4110] */ $where_clause,
-      /* HH_IGNORE_ERROR[4110] */ $body,
+      $attribute as ?OldAttributeSpecification,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<Token>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $xhp,
+      $keyword as Token,
+      $name as Token,
+      $type_parameters as ?TypeParameters,
+      $extends_keyword as ?ExtendsToken,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ISimpleCreationSpecifier>>,
+      >(
+        $extends_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $implements_keyword as ?ImplementsToken,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ISimpleCreationSpecifier>>,
+      >(
+        $implements_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $where_clause,
+      $body as ClassishBody,
       $source_ref,
     );
   }
@@ -269,15 +284,30 @@ final class ClassishDeclaration
     }
     return new static(
       $attribute as ?OldAttributeSpecification,
-      /* HH_FIXME[4110] ?NodeList<Token> may not be enforceable */ $modifiers,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<Token>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $xhp as ?Node,
       $keyword as Token,
       $name as Token,
       $type_parameters as ?TypeParameters,
       $extends_keyword as ?ExtendsToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<ISimpleCreationSpecifier>> may not be enforceable */ $extends_list,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ISimpleCreationSpecifier>>,
+      >(
+        $extends_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $implements_keyword as ?ImplementsToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<ISimpleCreationSpecifier>> may not be enforceable */ $implements_list,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ISimpleCreationSpecifier>>,
+      >(
+        $implements_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $where_clause as ?Node,
       $body as ClassishBody,
     );

--- a/codegen/syntax/ClassnameTypeSpecifier.hack
+++ b/codegen/syntax/ClassnameTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<940b4d1283c6d974b2cf6f65a60e33f5>>
+ * @generated SignedSource<<816cb6bbb8e37b3ee2bd9f365d5ae4d9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -96,11 +96,11 @@ final class ClassnameTypeSpecifier extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_angle,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $trailing_comma,
-      /* HH_IGNORE_ERROR[4110] */ $right_angle,
+      $keyword as ClassnameToken,
+      $left_angle as ?LessThanToken,
+      $type as ?ITypeSpecifier,
+      $trailing_comma,
+      $right_angle as ?GreaterThanToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/ClosureParameterTypeSpecifier.hack
+++ b/codegen/syntax/ClosureParameterTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<55d72fb9278f435bc783fac6b2270095>>
+ * @generated SignedSource<<c9dd1028a0c5e2e7e343fdfbc46cb2f8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,9 +75,9 @@ final class ClosureParameterTypeSpecifier
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $call_convention,
-      /* HH_IGNORE_ERROR[4110] */ $readonly,
-      /* HH_IGNORE_ERROR[4110] */ $type,
+      $call_convention as ?InoutToken,
+      $readonly,
+      $type as ITypeSpecifier,
       $source_ref,
     );
   }

--- a/codegen/syntax/ClosureTypeSpecifier.hack
+++ b/codegen/syntax/ClosureTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9c84879ef1b8682f02bbf8aafc171109>>
+ * @generated SignedSource<<9862ac186f57d4ae7f63e0a12adf8dde>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -168,17 +168,23 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $outer_left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $readonly_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $function_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $inner_left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $parameter_list,
-      /* HH_IGNORE_ERROR[4110] */ $inner_right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $contexts,
-      /* HH_IGNORE_ERROR[4110] */ $colon,
-      /* HH_IGNORE_ERROR[4110] */ $readonly_return,
-      /* HH_IGNORE_ERROR[4110] */ $return_type,
-      /* HH_IGNORE_ERROR[4110] */ $outer_right_paren,
+      $outer_left_paren as LeftParenToken,
+      $readonly_keyword as ?ReadonlyToken,
+      $function_keyword as FunctionToken,
+      $inner_left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ITypeSpecifier>>,
+      >(
+        $parameter_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $inner_right_paren as RightParenToken,
+      $contexts as ?Contexts,
+      $colon as ColonToken,
+      $readonly_return as ?ReadonlyToken,
+      $return_type as ITypeSpecifier,
+      $outer_right_paren as RightParenToken,
       $source_ref,
     );
   }
@@ -245,7 +251,13 @@ final class ClosureTypeSpecifier extends Node implements ITypeSpecifier {
       $readonly_keyword as ?ReadonlyToken,
       $function_keyword as FunctionToken,
       $inner_left_paren as LeftParenToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<ITypeSpecifier>> may not be enforceable */ $parameter_list,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ITypeSpecifier>>,
+      >(
+        $parameter_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $inner_right_paren as RightParenToken,
       $contexts as ?Contexts,
       $colon as ColonToken,

--- a/codegen/syntax/CollectionLiteralExpression.hack
+++ b/codegen/syntax/CollectionLiteralExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<786dd603c6bb60cb6ee106de52240fbb>>
+ * @generated SignedSource<<ba95e6361cdccfd4a521b772774f1300>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -87,10 +87,13 @@ final class CollectionLiteralExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $initializers,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $name as ISimpleCreationSpecifier,
+      $left_brace as LeftBraceToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<Node>>>(
+        $initializers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_brace as RightBraceToken,
       $source_ref,
     );
   }
@@ -129,7 +132,10 @@ final class CollectionLiteralExpression
     return new static(
       $name as ISimpleCreationSpecifier,
       $left_brace as LeftBraceToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<Node>> may not be enforceable */ $initializers,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<Node>>>(
+        $initializers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_brace as RightBraceToken,
     );
   }

--- a/codegen/syntax/CompoundStatement.hack
+++ b/codegen/syntax/CompoundStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<71525dfadca7504b3742e23f479aed24>>
+ * @generated SignedSource<<23864588f2709c8f4c04b109e10f7a2a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -72,9 +72,12 @@ final class CompoundStatement extends Node implements ILambdaBody, IStatement {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $statements,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $left_brace as LeftBraceToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<IStatement>>(
+        $statements as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_brace as RightBraceToken,
       $source_ref,
     );
   }
@@ -109,7 +112,10 @@ final class CompoundStatement extends Node implements ILambdaBody, IStatement {
     }
     return new static(
       $left_brace as LeftBraceToken,
-      /* HH_FIXME[4110] ?NodeList<IStatement> may not be enforceable */ $statements,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<IStatement>>(
+        $statements as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_brace as RightBraceToken,
     );
   }

--- a/codegen/syntax/ConcurrentStatement.hack
+++ b/codegen/syntax/ConcurrentStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<466a81eeed014e00ea0e4a9ca7222073>>
+ * @generated SignedSource<<134b0bab7a09d5da42b8655fb8726b15>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -61,8 +61,8 @@ final class ConcurrentStatement extends Node implements IStatement {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $statement,
+      $keyword as ConcurrentToken,
+      $statement as CompoundStatement,
       $source_ref,
     );
   }

--- a/codegen/syntax/ConditionalExpression.hack
+++ b/codegen/syntax/ConditionalExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7255f3f181caf44cfd0d0e2de1bebefb>>
+ * @generated SignedSource<<4710ec77b08b21604c81e049d24642be>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -99,11 +99,11 @@ final class ConditionalExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $test,
-      /* HH_IGNORE_ERROR[4110] */ $question,
-      /* HH_IGNORE_ERROR[4110] */ $consequence,
-      /* HH_IGNORE_ERROR[4110] */ $colon,
-      /* HH_IGNORE_ERROR[4110] */ $alternative,
+      $test as IExpression,
+      $question as QuestionToken,
+      $consequence as IExpression,
+      $colon as ColonToken,
+      $alternative as IExpression,
       $source_ref,
     );
   }

--- a/codegen/syntax/ConstDeclaration.hack
+++ b/codegen/syntax/ConstDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b75a3135f04c6c1269c2cc8e3b0636cc>>
+ * @generated SignedSource<<5e18f81b83c25278e45f05d5ada547dd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -108,12 +108,21 @@ final class ConstDeclaration extends Node implements IClassBodyDeclaration {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $modifiers,
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $type_specifier,
-      /* HH_IGNORE_ERROR[4110] */ $declarators,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $attribute_spec as ?OldAttributeSpecification,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<AbstractToken>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $keyword as ConstToken,
+      $type_specifier as ?ITypeSpecifier,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<ConstantDeclarator>>,
+      >(
+        $declarators as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -161,10 +170,19 @@ final class ConstDeclaration extends Node implements IClassBodyDeclaration {
     }
     return new static(
       $attribute_spec as ?OldAttributeSpecification,
-      /* HH_FIXME[4110] ?NodeList<AbstractToken> may not be enforceable */ $modifiers,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<AbstractToken>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $keyword as ConstToken,
       $type_specifier as ?ITypeSpecifier,
-      /* HH_FIXME[4110] NodeList<ListItem<ConstantDeclarator>> may not be enforceable */ $declarators,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<ConstantDeclarator>>,
+      >(
+        $declarators as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $semicolon as SemicolonToken,
     );
   }

--- a/codegen/syntax/ConstantDeclarator.hack
+++ b/codegen/syntax/ConstantDeclarator.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5d8e015cb516a2876d35026c3b4d677f>>
+ * @generated SignedSource<<c2538e1ae0f078e306ceb0cb1b391709>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -61,8 +61,8 @@ final class ConstantDeclarator extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $initializer,
+      $name as NameToken,
+      $initializer as ?SimpleInitializer,
       $source_ref,
     );
   }

--- a/codegen/syntax/ConstructorCall.hack
+++ b/codegen/syntax/ConstructorCall.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<d85dbea9b42c0f5b6f4269b792e3e767>>
+ * @generated SignedSource<<e75f27825b63a3cec31f0ea6655e2591>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,13 @@ final class ConstructorCall extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $argument_list,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
+      $type,
+      $left_paren as ?LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $argument_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as ?RightParenToken,
       $source_ref,
     );
   }
@@ -131,7 +134,10 @@ final class ConstructorCall extends Node {
     return new static(
       $type as Node,
       $left_paren as ?LeftParenToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<IExpression>> may not be enforceable */ $argument_list,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $argument_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as ?RightParenToken,
     );
   }

--- a/codegen/syntax/ContextAliasDeclaration.hack
+++ b/codegen/syntax/ContextAliasDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<565cc4ddff64bf69989e050ba7ffda0d>>
+ * @generated SignedSource<<72edea266dc0e1bc0dfe5e191fbd8e8f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -131,14 +131,17 @@ final class ContextAliasDeclaration extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $generic_parameter,
-      /* HH_IGNORE_ERROR[4110] */ $as_constraint,
-      /* HH_IGNORE_ERROR[4110] */ $equal,
-      /* HH_IGNORE_ERROR[4110] */ $context,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $attribute_spec,
+      $keyword as NewctxToken,
+      $name as NameToken,
+      $generic_parameter,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ContextConstraint>>(
+        $as_constraint as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $equal,
+      $context,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -194,7 +197,10 @@ final class ContextAliasDeclaration extends Node {
       $keyword as NewctxToken,
       $name as NameToken,
       $generic_parameter as ?Node,
-      /* HH_FIXME[4110] NodeList<ContextConstraint> may not be enforceable */ $as_constraint,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ContextConstraint>>(
+        $as_constraint as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $equal as ?Node,
       $context as ?Node,
       $semicolon as SemicolonToken,

--- a/codegen/syntax/ContextConstDeclaration.hack
+++ b/codegen/syntax/ContextConstDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<925ac9aeff38758f27c23870b9e37367>>
+ * @generated SignedSource<<bf031e6fe4dcf93366718f2fcb17e83c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -146,15 +146,21 @@ final class ContextConstDeclaration
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $modifiers,
-      /* HH_IGNORE_ERROR[4110] */ $const_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $ctx_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $type_parameters,
-      /* HH_IGNORE_ERROR[4110] */ $constraint,
-      /* HH_IGNORE_ERROR[4110] */ $equal,
-      /* HH_IGNORE_ERROR[4110] */ $ctx_list,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<AbstractToken>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $const_keyword as ConstToken,
+      $ctx_keyword as CtxToken,
+      $name as NameToken,
+      $type_parameters,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ContextConstraint>>(
+        $constraint as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $equal as ?EqualToken,
+      $ctx_list as ?Contexts,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -211,12 +217,18 @@ final class ContextConstDeclaration
       return $this;
     }
     return new static(
-      /* HH_FIXME[4110] ?NodeList<AbstractToken> may not be enforceable */ $modifiers,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<AbstractToken>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $const_keyword as ConstToken,
       $ctx_keyword as CtxToken,
       $name as NameToken,
       $type_parameters as ?Node,
-      /* HH_FIXME[4110] ?NodeList<ContextConstraint> may not be enforceable */ $constraint,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ContextConstraint>>(
+        $constraint as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $equal as ?EqualToken,
       $ctx_list as ?Contexts,
       $semicolon as SemicolonToken,

--- a/codegen/syntax/ContextConstraint.hack
+++ b/codegen/syntax/ContextConstraint.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b8dc33fec6bfa8193e60b1c6f580aa37>>
+ * @generated SignedSource<<3a7a455500a11f53cacd519e3652bf45>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -60,11 +60,7 @@ final class ContextConstraint extends Node {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $ctx_list,
-      $source_ref,
-    );
+    return new static($keyword as Token, $ctx_list as Contexts, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/Contexts.hack
+++ b/codegen/syntax/Contexts.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a67417c96893617d8c1cf979cae218d8>>
+ * @generated SignedSource<<c3ee12a0d48deb304278f6d5c3465dea>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -72,9 +72,12 @@ final class Contexts extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_bracket,
-      /* HH_IGNORE_ERROR[4110] */ $types,
-      /* HH_IGNORE_ERROR[4110] */ $right_bracket,
+      $left_bracket as LeftBracketToken,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ITypeSpecifier>>,
+      >($types as ?NodeList<_>, 'Open for sound approaches that are not O(n).'),
+      $right_bracket as RightBracketToken,
       $source_ref,
     );
   }
@@ -107,7 +110,10 @@ final class Contexts extends Node {
     }
     return new static(
       $left_bracket as LeftBracketToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<ITypeSpecifier>> may not be enforceable */ $types,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ITypeSpecifier>>,
+      >($types as ?NodeList<_>, 'Open for sound approaches that are not O(n).'),
       $right_bracket as RightBracketToken,
     );
   }

--- a/codegen/syntax/ContinueStatement.hack
+++ b/codegen/syntax/ContinueStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1d719f96b775abcbb01d42c7899afc26>>
+ * @generated SignedSource<<a5e3372d5bcec6abadd941b08eb50135>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -61,8 +61,8 @@ final class ContinueStatement extends Node implements IStatement {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as ContinueToken,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/CtxInRefinement.hack
+++ b/codegen/syntax/CtxInRefinement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<971da060047eba588612a0499b1f9ff3>>
+ * @generated SignedSource<<1b8256fac85477af8b84b5f34bce6029>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -109,12 +109,12 @@ final class CtxInRefinement extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $type_parameters,
-      /* HH_IGNORE_ERROR[4110] */ $constraints,
-      /* HH_IGNORE_ERROR[4110] */ $equal,
-      /* HH_IGNORE_ERROR[4110] */ $ctx_list,
+      $keyword,
+      $name,
+      $type_parameters,
+      $constraints,
+      $equal,
+      $ctx_list,
       $source_ref,
     );
   }

--- a/codegen/syntax/DarrayIntrinsicExpression.hack
+++ b/codegen/syntax/DarrayIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<588f481a1005c97bf14f05d9fee418ce>>
+ * @generated SignedSource<<76543444fbb8919c7a7e9b02c12f206b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -99,11 +99,17 @@ final class DarrayIntrinsicExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $explicit_type,
-      /* HH_IGNORE_ERROR[4110] */ $left_bracket,
-      /* HH_IGNORE_ERROR[4110] */ $members,
-      /* HH_IGNORE_ERROR[4110] */ $right_bracket,
+      $keyword as DarrayToken,
+      $explicit_type as ?TypeArguments,
+      $left_bracket as LeftBracketToken,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ElementInitializer>>,
+      >(
+        $members as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_bracket as RightBracketToken,
       $source_ref,
     );
   }
@@ -147,7 +153,13 @@ final class DarrayIntrinsicExpression
       $keyword as DarrayToken,
       $explicit_type as ?TypeArguments,
       $left_bracket as LeftBracketToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<ElementInitializer>> may not be enforceable */ $members,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ElementInitializer>>,
+      >(
+        $members as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_bracket as RightBracketToken,
     );
   }

--- a/codegen/syntax/DarrayTypeSpecifier.hack
+++ b/codegen/syntax/DarrayTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7a8e2062b7d28a4461f2a7dcf9fc863f>>
+ * @generated SignedSource<<439b473db4b2673302c4c5de126138f7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -121,13 +121,13 @@ final class DarrayTypeSpecifier extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_angle,
-      /* HH_IGNORE_ERROR[4110] */ $key,
-      /* HH_IGNORE_ERROR[4110] */ $comma,
-      /* HH_IGNORE_ERROR[4110] */ $value,
-      /* HH_IGNORE_ERROR[4110] */ $trailing_comma,
-      /* HH_IGNORE_ERROR[4110] */ $right_angle,
+      $keyword as DarrayToken,
+      $left_angle as LessThanToken,
+      $key as ITypeSpecifier,
+      $comma as CommaToken,
+      $value as ITypeSpecifier,
+      $trailing_comma,
+      $right_angle as GreaterThanToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/DecoratedExpression.hack
+++ b/codegen/syntax/DecoratedExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<06fb91fe5add4ec33b22a0175ea83cab>>
+ * @generated SignedSource<<9a5a6aef9d6a49dfc4f54243193c134b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -62,11 +62,8 @@ final class DecoratedExpression
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $decorator,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      $source_ref,
-    );
+    return
+      new static($decorator as Token, $expression as IExpression, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/DefaultLabel.hack
+++ b/codegen/syntax/DefaultLabel.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<088ddba8a29ac1d79f78ea2a5bfedd1b>>
+ * @generated SignedSource<<d2f428feccd7640d68f30f6e51f04a7d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -60,11 +60,8 @@ final class DefaultLabel extends Node implements ISwitchLabel {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $colon,
-      $source_ref,
-    );
+    return
+      new static($keyword as DefaultToken, $colon as ColonToken, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/DictionaryIntrinsicExpression.hack
+++ b/codegen/syntax/DictionaryIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<154a388f4c22ad5b744590f8fa45361c>>
+ * @generated SignedSource<<6a2094fd6b0ef7c88fb542596a374439>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -99,11 +99,17 @@ final class DictionaryIntrinsicExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $explicit_type,
-      /* HH_IGNORE_ERROR[4110] */ $left_bracket,
-      /* HH_IGNORE_ERROR[4110] */ $members,
-      /* HH_IGNORE_ERROR[4110] */ $right_bracket,
+      $keyword as DictToken,
+      $explicit_type as ?TypeArguments,
+      $left_bracket as LeftBracketToken,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ElementInitializer>>,
+      >(
+        $members as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_bracket as RightBracketToken,
       $source_ref,
     );
   }
@@ -147,7 +153,13 @@ final class DictionaryIntrinsicExpression
       $keyword as DictToken,
       $explicit_type as ?TypeArguments,
       $left_bracket as LeftBracketToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<ElementInitializer>> may not be enforceable */ $members,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ElementInitializer>>,
+      >(
+        $members as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_bracket as RightBracketToken,
     );
   }

--- a/codegen/syntax/DictionaryTypeSpecifier.hack
+++ b/codegen/syntax/DictionaryTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<be5da7ec7a88e74dd79d418e72fc91f2>>
+ * @generated SignedSource<<69c7077da9abbda7c325ce16f648442e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,13 @@ final class DictionaryTypeSpecifier extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_angle,
-      /* HH_IGNORE_ERROR[4110] */ $members,
-      /* HH_IGNORE_ERROR[4110] */ $right_angle,
+      $keyword as DictToken,
+      $left_angle as LessThanToken,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<ITypeSpecifier>>>(
+        $members as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_angle as GreaterThanToken,
       $source_ref,
     );
   }
@@ -125,7 +128,10 @@ final class DictionaryTypeSpecifier extends Node implements ITypeSpecifier {
     return new static(
       $keyword as DictToken,
       $left_angle as LessThanToken,
-      /* HH_FIXME[4110] NodeList<ListItem<ITypeSpecifier>> may not be enforceable */ $members,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<ITypeSpecifier>>>(
+        $members as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_angle as GreaterThanToken,
     );
   }

--- a/codegen/syntax/DoStatement.hack
+++ b/codegen/syntax/DoStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<3bb44d055612de73057a24db5f93ef3f>>
+ * @generated SignedSource<<87e6a9ff5c3d9623b15c48e3639d0e61>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -123,13 +123,13 @@ final class DoStatement
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $body,
-      /* HH_IGNORE_ERROR[4110] */ $while_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $condition,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as DoToken,
+      $body as IStatement,
+      $while_keyword as WhileToken,
+      $left_paren as LeftParenToken,
+      $condition as IExpression,
+      $right_paren as RightParenToken,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/ETSpliceExpression.hack
+++ b/codegen/syntax/ETSpliceExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ab3e3302ce00c54305a523896b387582>>
+ * @generated SignedSource<<dd7a60d144190f1e81e405d298bc5a70>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -86,13 +86,8 @@ final class ETSpliceExpression
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $dollar,
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
-      $source_ref,
-    );
+    return
+      new static($dollar, $left_brace, $expression, $right_brace, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/EchoStatement.hack
+++ b/codegen/syntax/EchoStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<512bea22bc4609af55ed732b9923be21>>
+ * @generated SignedSource<<11fa470bb0382baefb26e48a6990477e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,12 @@ final class EchoStatement extends Node implements IStatement {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $expressions,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as EchoToken,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<IExpression>>>(
+        $expressions as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -108,7 +111,10 @@ final class EchoStatement extends Node implements IStatement {
     }
     return new static(
       $keyword as EchoToken,
-      /* HH_FIXME[4110] NodeList<ListItem<IExpression>> may not be enforceable */ $expressions,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<IExpression>>>(
+        $expressions as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $semicolon as SemicolonToken,
     );
   }

--- a/codegen/syntax/ElementInitializer.hack
+++ b/codegen/syntax/ElementInitializer.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bdf93deb54cd07534c01acca0857afda>>
+ * @generated SignedSource<<96d085c469992b9436ca0b970b75f6b9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class ElementInitializer extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $key,
-      /* HH_IGNORE_ERROR[4110] */ $arrow,
-      /* HH_IGNORE_ERROR[4110] */ $value,
+      $key as IExpression,
+      $arrow as EqualGreaterThanToken,
+      $value as IExpression,
       $source_ref,
     );
   }

--- a/codegen/syntax/ElseClause.hack
+++ b/codegen/syntax/ElseClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b5f971d03e85781f29846db4c9c6eca4>>
+ * @generated SignedSource<<390356a2040ed125251932d900a2a7eb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -60,11 +60,8 @@ final class ElseClause extends Node implements IControlFlowStatement {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $statement,
-      $source_ref,
-    );
+    return
+      new static($keyword as ElseToken, $statement as IStatement, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/EmbeddedBracedExpression.hack
+++ b/codegen/syntax/EmbeddedBracedExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<74550a934a1712eda932b8ea69c1b3b6>>
+ * @generated SignedSource<<ec49e3aa125cc0977814a51faee6074b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -80,12 +80,7 @@ final class EmbeddedBracedExpression
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
-      $source_ref,
-    );
+    return new static($left_brace, $expression, $right_brace, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/EmbeddedMemberSelectionExpression.hack
+++ b/codegen/syntax/EmbeddedMemberSelectionExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a139d2b4d92ce303a43c3d751f5ed835>>
+ * @generated SignedSource<<2140ca235ed062243921d40c13749123>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -74,12 +74,7 @@ final class EmbeddedMemberSelectionExpression
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $object,
-      /* HH_IGNORE_ERROR[4110] */ $operator,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      $source_ref,
-    );
+    return new static($object, $operator, $name, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/EmbeddedSubscriptExpression.hack
+++ b/codegen/syntax/EmbeddedSubscriptExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fe74dbe08adc87b5586ca80815d6f55b>>
+ * @generated SignedSource<<cd100ffaf05e1e085eea56119f6c8374>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -86,13 +86,8 @@ final class EmbeddedSubscriptExpression
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $receiver,
-      /* HH_IGNORE_ERROR[4110] */ $left_bracket,
-      /* HH_IGNORE_ERROR[4110] */ $index,
-      /* HH_IGNORE_ERROR[4110] */ $right_bracket,
-      $source_ref,
-    );
+    return
+      new static($receiver, $left_bracket, $index, $right_bracket, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/EndOfFile.hack
+++ b/codegen/syntax/EndOfFile.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ee8cf185114a93a8babb028e045c0d84>>
+ * @generated SignedSource<<f225fb3e119b517cf3092e36678a382b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -48,7 +48,7 @@ final class EndOfFile extends Node {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(/* HH_IGNORE_ERROR[4110] */ $token, $source_ref);
+    return new static($token as EndOfFileToken, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/EnumClassDeclaration.hack
+++ b/codegen/syntax/EnumClassDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<71ee494596dad01a0be73d16ce53f8f8>>
+ * @generated SignedSource<<0da4cb9fdc6b9c3ed197bf9ba43a81c7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -179,18 +179,30 @@ final class EnumClassDeclaration extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $modifiers,
-      /* HH_IGNORE_ERROR[4110] */ $enum_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $class_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $colon,
-      /* HH_IGNORE_ERROR[4110] */ $base,
-      /* HH_IGNORE_ERROR[4110] */ $extends,
-      /* HH_IGNORE_ERROR[4110] */ $extends_list,
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $elements,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $attribute_spec as ?OldAttributeSpecification,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<Token>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $enum_keyword as EnumToken,
+      $class_keyword as ClassToken,
+      $name as NameToken,
+      $colon as ColonToken,
+      $base as ITypeSpecifier,
+      $extends as ?ExtendsToken,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<SimpleTypeSpecifier>>,
+      >(
+        $extends_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $left_brace as LeftBraceToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<EnumClassEnumerator>>(
+        $elements as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_brace as RightBraceToken,
       $source_ref,
     );
   }
@@ -258,16 +270,28 @@ final class EnumClassDeclaration extends Node {
     }
     return new static(
       $attribute_spec as ?OldAttributeSpecification,
-      /* HH_FIXME[4110] ?NodeList<Token> may not be enforceable */ $modifiers,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<Token>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $enum_keyword as EnumToken,
       $class_keyword as ClassToken,
       $name as NameToken,
       $colon as ColonToken,
       $base as ITypeSpecifier,
       $extends as ?ExtendsToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<SimpleTypeSpecifier>> may not be enforceable */ $extends_list,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<SimpleTypeSpecifier>>,
+      >(
+        $extends_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $left_brace as LeftBraceToken,
-      /* HH_FIXME[4110] ?NodeList<EnumClassEnumerator> may not be enforceable */ $elements,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<EnumClassEnumerator>>(
+        $elements as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_brace as RightBraceToken,
     );
   }

--- a/codegen/syntax/EnumClassEnumerator.hack
+++ b/codegen/syntax/EnumClassEnumerator.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2f6ca00a20eed650f03db2996c441559>>
+ * @generated SignedSource<<cc720539b2f5162d905f08f7443342a0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -97,11 +97,14 @@ final class EnumClassEnumerator extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $modifiers,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $initializer,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<AbstractToken>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $type as ITypeSpecifier,
+      $name as NameToken,
+      $initializer as ?SimpleInitializer,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -143,7 +146,10 @@ final class EnumClassEnumerator extends Node {
       return $this;
     }
     return new static(
-      /* HH_FIXME[4110] ?NodeList<AbstractToken> may not be enforceable */ $modifiers,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<AbstractToken>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $type as ITypeSpecifier,
       $name as NameToken,
       $initializer as ?SimpleInitializer,

--- a/codegen/syntax/EnumClassLabelExpression.hack
+++ b/codegen/syntax/EnumClassLabelExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b97d800dfcc06780cad30d16b48a1c7b>>
+ * @generated SignedSource<<17f073115ce7aebe04d017aa25aaa1e0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -74,12 +74,7 @@ final class EnumClassLabelExpression
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $qualifier,
-      /* HH_IGNORE_ERROR[4110] */ $hash,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      $source_ref,
-    );
+    return new static($qualifier, $hash, $expression, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/EnumDeclaration.hack
+++ b/codegen/syntax/EnumDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<194693a524b90d5d00f80feff66c9e73>>
+ * @generated SignedSource<<ff7b26bb028be3d865fa7f425d4f5b85>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -164,17 +164,26 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $modifiers,
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $colon,
-      /* HH_IGNORE_ERROR[4110] */ $base,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $use_clauses,
-      /* HH_IGNORE_ERROR[4110] */ $enumerators,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $attribute_spec as ?OldAttributeSpecification,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<PublicToken>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $keyword as EnumToken,
+      $name as NameToken,
+      $colon as ColonToken,
+      $base as ITypeSpecifier,
+      $type as ?TypeConstraint,
+      $left_brace as LeftBraceToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<EnumUse>>(
+        $use_clauses as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<Enumerator>>(
+        $enumerators as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_brace as RightBraceToken,
       $source_ref,
     );
   }
@@ -239,15 +248,24 @@ final class EnumDeclaration extends Node implements IHasAttributeSpec {
     }
     return new static(
       $attribute_spec as ?OldAttributeSpecification,
-      /* HH_FIXME[4110] ?NodeList<PublicToken> may not be enforceable */ $modifiers,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<PublicToken>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $keyword as EnumToken,
       $name as NameToken,
       $colon as ColonToken,
       $base as ITypeSpecifier,
       $type as ?TypeConstraint,
       $left_brace as LeftBraceToken,
-      /* HH_FIXME[4110] ?NodeList<EnumUse> may not be enforceable */ $use_clauses,
-      /* HH_FIXME[4110] ?NodeList<Enumerator> may not be enforceable */ $enumerators,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<EnumUse>>(
+        $use_clauses as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<Enumerator>>(
+        $enumerators as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_brace as RightBraceToken,
     );
   }

--- a/codegen/syntax/EnumUse.hack
+++ b/codegen/syntax/EnumUse.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<de2aaad485d903c675f556874699d829>>
+ * @generated SignedSource<<c5661c94fd35594826977acf08cf124f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,12 @@ final class EnumUse extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $names,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as UseToken,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<SimpleTypeSpecifier>>,
+      >($names as NodeList<_>, 'Open for sound approaches that are not O(n).'),
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -108,7 +111,10 @@ final class EnumUse extends Node {
     }
     return new static(
       $keyword as UseToken,
-      /* HH_FIXME[4110] NodeList<ListItem<SimpleTypeSpecifier>> may not be enforceable */ $names,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<SimpleTypeSpecifier>>,
+      >($names as NodeList<_>, 'Open for sound approaches that are not O(n).'),
       $semicolon as SemicolonToken,
     );
   }

--- a/codegen/syntax/Enumerator.hack
+++ b/codegen/syntax/Enumerator.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<91f93b6ec5f12d0c97c142e8af19d139>>
+ * @generated SignedSource<<062ba1738a53a6c9aed6a3f874622c5d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,10 @@ final class Enumerator extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $equal,
-      /* HH_IGNORE_ERROR[4110] */ $value,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $name as NameToken,
+      $equal as EqualToken,
+      $value as IExpression,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/ErrorSyntax.hack
+++ b/codegen/syntax/ErrorSyntax.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5bed80736f100a1252edf023be0d0855>>
+ * @generated SignedSource<<b86f3ac3abc529e25b55ce502585b229>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -47,7 +47,7 @@ final class ErrorSyntax extends Node {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(/* HH_IGNORE_ERROR[4110] */ $error, $source_ref);
+    return new static($error, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/EvalExpression.hack
+++ b/codegen/syntax/EvalExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1a38379e38d9ab39c1ecf1886964c5c1>>
+ * @generated SignedSource<<ee97dc81bdcf87a70f59f63f15e66a36>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,10 @@ final class EvalExpression extends Node implements ILambdaBody, IExpression {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $argument,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
+      $keyword as EvalToken,
+      $left_paren as LeftParenToken,
+      $argument as IExpression,
+      $right_paren as RightParenToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/ExpressionStatement.hack
+++ b/codegen/syntax/ExpressionStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1194a0d59cc75e69360ae0daf491bc86>>
+ * @generated SignedSource<<bcb2e3803a5f2a742265f0952b626678>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -61,8 +61,8 @@ final class ExpressionStatement extends Node implements IStatement {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $expression as ?IExpression,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/FieldInitializer.hack
+++ b/codegen/syntax/FieldInitializer.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1c2647d3c781721f3183c03c3c4dcd6c>>
+ * @generated SignedSource<<c0336819bde92f0980bd98e087f659a9>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class FieldInitializer extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $arrow,
-      /* HH_IGNORE_ERROR[4110] */ $value,
+      $name as IExpression,
+      $arrow as EqualGreaterThanToken,
+      $value as IExpression,
       $source_ref,
     );
   }

--- a/codegen/syntax/FieldSpecifier.hack
+++ b/codegen/syntax/FieldSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<29d5388bdd052b39f124825c2b08a834>>
+ * @generated SignedSource<<3718e409df5ef8c517508b3975b273a7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -84,10 +84,10 @@ final class FieldSpecifier extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $question,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $arrow,
-      /* HH_IGNORE_ERROR[4110] */ $type,
+      $question as ?QuestionToken,
+      $name as IExpression,
+      $arrow as EqualGreaterThanToken,
+      $type as ITypeSpecifier,
       $source_ref,
     );
   }

--- a/codegen/syntax/FileAttributeSpecification.hack
+++ b/codegen/syntax/FileAttributeSpecification.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fba646fa4f50bf3741f1e2af377b6121>>
+ * @generated SignedSource<<b307c109472f8944199acc5089e213d5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -97,11 +97,17 @@ final class FileAttributeSpecification extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_double_angle,
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $colon,
-      /* HH_IGNORE_ERROR[4110] */ $attributes,
-      /* HH_IGNORE_ERROR[4110] */ $right_double_angle,
+      $left_double_angle as LessThanLessThanToken,
+      $keyword as FileToken,
+      $colon as ColonToken,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<ConstructorCall>>,
+      >(
+        $attributes as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_double_angle as GreaterThanGreaterThanToken,
       $source_ref,
     );
   }
@@ -142,7 +148,13 @@ final class FileAttributeSpecification extends Node {
       $left_double_angle as LessThanLessThanToken,
       $keyword as FileToken,
       $colon as ColonToken,
-      /* HH_FIXME[4110] NodeList<ListItem<ConstructorCall>> may not be enforceable */ $attributes,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<ConstructorCall>>,
+      >(
+        $attributes as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_double_angle as GreaterThanGreaterThanToken,
     );
   }

--- a/codegen/syntax/FinallyClause.hack
+++ b/codegen/syntax/FinallyClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f5cce87b7cb736dfa694b8a5b24425aa>>
+ * @generated SignedSource<<ab9242f55d68600a5d29cb6a082e89ef>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -61,8 +61,8 @@ final class FinallyClause extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $body,
+      $keyword as FinallyToken,
+      $body as CompoundStatement,
       $source_ref,
     );
   }

--- a/codegen/syntax/ForStatement.hack
+++ b/codegen/syntax/ForStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fbe5c2fa3eba3b6ca8b27989f75c9152>>
+ * @generated SignedSource<<b118698d3297247dde2daaaa91bf61f2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -144,15 +144,21 @@ final class ForStatement
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $initializer,
-      /* HH_IGNORE_ERROR[4110] */ $first_semicolon,
-      /* HH_IGNORE_ERROR[4110] */ $control,
-      /* HH_IGNORE_ERROR[4110] */ $second_semicolon,
-      /* HH_IGNORE_ERROR[4110] */ $end_of_loop,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $body,
+      $keyword as ForToken,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $initializer as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $first_semicolon as SemicolonToken,
+      $control as ?IExpression,
+      $second_semicolon as SemicolonToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $end_of_loop as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
+      $body as IStatement,
       $source_ref,
     );
   }
@@ -209,11 +215,17 @@ final class ForStatement
     return new static(
       $keyword as ForToken,
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<IExpression>> may not be enforceable */ $initializer,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $initializer as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $first_semicolon as SemicolonToken,
       $control as ?IExpression,
       $second_semicolon as SemicolonToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<IExpression>> may not be enforceable */ $end_of_loop,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $end_of_loop as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
       $body as IStatement,
     );

--- a/codegen/syntax/ForeachStatement.hack
+++ b/codegen/syntax/ForeachStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<83d516a16e955f0c95bf335c86404860>>
+ * @generated SignedSource<<fcbb7bad5650089301bfcd4973d75529>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -157,16 +157,16 @@ final class ForeachStatement
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $collection,
-      /* HH_IGNORE_ERROR[4110] */ $await_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $as,
-      /* HH_IGNORE_ERROR[4110] */ $key,
-      /* HH_IGNORE_ERROR[4110] */ $arrow,
-      /* HH_IGNORE_ERROR[4110] */ $value,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $body,
+      $keyword as ForeachToken,
+      $left_paren as LeftParenToken,
+      $collection as IExpression,
+      $await_keyword as ?AwaitToken,
+      $as as AsToken,
+      $key as ?IExpression,
+      $arrow as ?EqualGreaterThanToken,
+      $value as IExpression,
+      $right_paren as RightParenToken,
+      $body as IStatement,
       $source_ref,
     );
   }

--- a/codegen/syntax/FunctionCallExpression.hack
+++ b/codegen/syntax/FunctionCallExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<18913689b7721adc5fd92a1d0453d818>>
+ * @generated SignedSource<<7549531c875b3917560ec97ba207360d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -99,11 +99,14 @@ final class FunctionCallExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $receiver,
-      /* HH_IGNORE_ERROR[4110] */ $type_args,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $argument_list,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
+      $receiver,
+      $type_args as ?TypeArguments,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $argument_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
       $source_ref,
     );
   }
@@ -148,7 +151,10 @@ final class FunctionCallExpression
       $receiver as Node,
       $type_args as ?TypeArguments,
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<IExpression>> may not be enforceable */ $argument_list,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $argument_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
     );
   }

--- a/codegen/syntax/FunctionCtxTypeSpecifier.hack
+++ b/codegen/syntax/FunctionCtxTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5f60bd9e49ef0ec0309ccf51a474b35a>>
+ * @generated SignedSource<<40d8aa2260fbe6c7b3835d29f170dca3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -60,11 +60,8 @@ final class FunctionCtxTypeSpecifier extends Node implements ITypeSpecifier {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $variable,
-      $source_ref,
-    );
+    return
+      new static($keyword as CtxToken, $variable as VariableToken, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/FunctionDeclaration.hack
+++ b/codegen/syntax/FunctionDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<357059e64232775c7411ada8399f0546>>
+ * @generated SignedSource<<1002045f59014e9f1f70af80457c70c8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,9 +75,9 @@ final class FunctionDeclaration
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $declaration_header,
-      /* HH_IGNORE_ERROR[4110] */ $body,
+      $attribute_spec as ?OldAttributeSpecification,
+      $declaration_header as FunctionDeclarationHeader,
+      $body,
       $source_ref,
     );
   }

--- a/codegen/syntax/FunctionDeclarationHeader.hack
+++ b/codegen/syntax/FunctionDeclarationHeader.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<24665462d5c5e66ed6bc35d92fc9b6b1>>
+ * @generated SignedSource<<d0ba6105216205f50fe149d4575a601b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -177,18 +177,24 @@ final class FunctionDeclarationHeader extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $modifiers,
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $type_parameter_list,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $parameter_list,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $contexts,
-      /* HH_IGNORE_ERROR[4110] */ $colon,
-      /* HH_IGNORE_ERROR[4110] */ $readonly_return,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $where_clause,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<Token>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $keyword as FunctionToken,
+      $name as Token,
+      $type_parameter_list as ?TypeParameters,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IParameter>>>(
+        $parameter_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
+      $contexts as ?Contexts,
+      $colon as ?ColonToken,
+      $readonly_return as ?ReadonlyToken,
+      $type as ?ITypeSpecifier,
+      $where_clause as ?WhereClause,
       $source_ref,
     );
   }
@@ -258,12 +264,18 @@ final class FunctionDeclarationHeader extends Node {
       return $this;
     }
     return new static(
-      /* HH_FIXME[4110] ?NodeList<Token> may not be enforceable */ $modifiers,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<Token>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $keyword as FunctionToken,
       $name as Token,
       $type_parameter_list as ?TypeParameters,
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<IParameter>> may not be enforceable */ $parameter_list,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IParameter>>>(
+        $parameter_list as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
       $contexts as ?Contexts,
       $colon as ?ColonToken,

--- a/codegen/syntax/FunctionPointerExpression.hack
+++ b/codegen/syntax/FunctionPointerExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0aa14f716f65104431220b291b8230af>>
+ * @generated SignedSource<<f0a3048bf3a0aba485e0b5d4748d7cc2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -63,8 +63,8 @@ final class FunctionPointerExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $receiver,
-      /* HH_IGNORE_ERROR[4110] */ $type_args,
+      $receiver as IExpression,
+      $type_args as TypeArguments,
       $source_ref,
     );
   }

--- a/codegen/syntax/GenericTypeSpecifier.hack
+++ b/codegen/syntax/GenericTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<63fce2719adbf4a5cb13e27997f551cd>>
+ * @generated SignedSource<<d617dff96df8c546bed530ac1d1dd1c3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -62,11 +62,8 @@ final class GenericTypeSpecifier
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $class_type,
-      /* HH_IGNORE_ERROR[4110] */ $argument_list,
-      $source_ref,
-    );
+    return
+      new static($class_type, $argument_list as TypeArguments, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/IfStatement.hack
+++ b/codegen/syntax/IfStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1a56fb44690438bdbb7a3b0d15660cb4>>
+ * @generated SignedSource<<7975ab6101c98a108a3af48c0c70a6b1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -110,12 +110,12 @@ final class IfStatement
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $condition,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $statement,
-      /* HH_IGNORE_ERROR[4110] */ $else_clause,
+      $keyword as IfToken,
+      $left_paren as LeftParenToken,
+      $condition as IExpression,
+      $right_paren as RightParenToken,
+      $statement as IStatement,
+      $else_clause as ?ElseClause,
       $source_ref,
     );
   }

--- a/codegen/syntax/InclusionDirective.hack
+++ b/codegen/syntax/InclusionDirective.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e0777e108bd0b42b18b984a5cec53926>>
+ * @generated SignedSource<<a73ff4a0cd9ccfb31705c511db6f5ceb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -60,11 +60,7 @@ final class InclusionDirective extends Node implements IStatement {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
-      $source_ref,
-    );
+    return new static($expression, $semicolon, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/InclusionExpression.hack
+++ b/codegen/syntax/InclusionExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<dbe336fbc82ae340fbd86d4800fbfe87>>
+ * @generated SignedSource<<db69bfe1392dd61c0d223c28a559a235>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -62,11 +62,7 @@ final class InclusionExpression
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $require,
-      /* HH_IGNORE_ERROR[4110] */ $filename,
-      $source_ref,
-    );
+    return new static($require as Token, $filename as IExpression, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/IntersectionTypeSpecifier.hack
+++ b/codegen/syntax/IntersectionTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e8f6a701d3114c6849c05e81c482ac51>>
+ * @generated SignedSource<<9d4e7f2a5d89c42e3af443b3fa6ad8fd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -71,12 +71,7 @@ final class IntersectionTypeSpecifier extends Node implements ITypeSpecifier {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $types,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      $source_ref,
-    );
+    return new static($left_paren, $types, $right_paren, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/IsExpression.hack
+++ b/codegen/syntax/IsExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<39d0ddf0080da50f0c3abdad45e5544c>>
+ * @generated SignedSource<<17181cb4a47c13c80c83a97f089530ae>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class IsExpression extends Node implements ILambdaBody, IExpression {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_operand,
-      /* HH_IGNORE_ERROR[4110] */ $operator,
-      /* HH_IGNORE_ERROR[4110] */ $right_operand,
+      $left_operand as IExpression,
+      $operator as IsToken,
+      $right_operand as ITypeSpecifier,
       $source_ref,
     );
   }

--- a/codegen/syntax/IssetExpression.hack
+++ b/codegen/syntax/IssetExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b9640ad3e1f1a8c6970b0a118b14d3ac>>
+ * @generated SignedSource<<de74dfdc120986891e9c115ee6b7953c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,13 @@ final class IssetExpression extends Node implements ILambdaBody, IExpression {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $argument_list,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
+      $keyword as IssetToken,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<IExpression>>>(
+        $argument_list as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
       $source_ref,
     );
   }
@@ -125,7 +128,10 @@ final class IssetExpression extends Node implements ILambdaBody, IExpression {
     return new static(
       $keyword as IssetToken,
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] NodeList<ListItem<IExpression>> may not be enforceable */ $argument_list,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<IExpression>>>(
+        $argument_list as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
     );
   }

--- a/codegen/syntax/KeysetIntrinsicExpression.hack
+++ b/codegen/syntax/KeysetIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<63a3e44f8a1f226c162e0c56b2d6c24d>>
+ * @generated SignedSource<<106ba8351580a97e6f479a06214bd4b8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -99,11 +99,14 @@ final class KeysetIntrinsicExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $explicit_type,
-      /* HH_IGNORE_ERROR[4110] */ $left_bracket,
-      /* HH_IGNORE_ERROR[4110] */ $members,
-      /* HH_IGNORE_ERROR[4110] */ $right_bracket,
+      $keyword as KeysetToken,
+      $explicit_type as ?TypeArguments,
+      $left_bracket as LeftBracketToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $members as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_bracket as RightBracketToken,
       $source_ref,
     );
   }
@@ -147,7 +150,10 @@ final class KeysetIntrinsicExpression
       $keyword as KeysetToken,
       $explicit_type as ?TypeArguments,
       $left_bracket as LeftBracketToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<IExpression>> may not be enforceable */ $members,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $members as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_bracket as RightBracketToken,
     );
   }

--- a/codegen/syntax/KeysetTypeSpecifier.hack
+++ b/codegen/syntax/KeysetTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7f104333205c57d90221f3dc1252d771>>
+ * @generated SignedSource<<37508b9aa09314f13dc1248046e098e4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -97,11 +97,11 @@ final class KeysetTypeSpecifier extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_angle,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $trailing_comma,
-      /* HH_IGNORE_ERROR[4110] */ $right_angle,
+      $keyword as KeysetToken,
+      $left_angle as LessThanToken,
+      $type as ITypeSpecifier,
+      $trailing_comma,
+      $right_angle as GreaterThanToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/LambdaExpression.hack
+++ b/codegen/syntax/LambdaExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<29ed3005c47a47905b1ba5ef2bed0d62>>
+ * @generated SignedSource<<53d3c66bc52630f3f896cee468880038>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -98,11 +98,11 @@ final class LambdaExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $async,
-      /* HH_IGNORE_ERROR[4110] */ $signature,
-      /* HH_IGNORE_ERROR[4110] */ $arrow,
-      /* HH_IGNORE_ERROR[4110] */ $body,
+      $attribute_spec as ?OldAttributeSpecification,
+      $async as ?AsyncToken,
+      $signature,
+      $arrow as EqualEqualGreaterThanToken,
+      $body as ILambdaBody,
       $source_ref,
     );
   }

--- a/codegen/syntax/LambdaExpression.hack
+++ b/codegen/syntax/LambdaExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>>
+ * @generated SignedSource<<097a1f1e47bfd77ce63c58fe0740f31a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;

--- a/codegen/syntax/LambdaSignature.hack
+++ b/codegen/syntax/LambdaSignature.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b06835941dda372887312edf013c5109>>
+ * @generated SignedSource<<14570b7cb058cb66262c993f1ecb67c6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -117,13 +117,16 @@ final class LambdaSignature extends Node implements ILambdaSignature {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $parameters,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $contexts,
-      /* HH_IGNORE_ERROR[4110] */ $colon,
-      /* HH_IGNORE_ERROR[4110] */ $readonly_return,
-      /* HH_IGNORE_ERROR[4110] */ $type,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IParameter>>>(
+        $parameters as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
+      $contexts as ?Contexts,
+      $colon as ?ColonToken,
+      $readonly_return as ?ReadonlyToken,
+      $type as ?ITypeSpecifier,
       $source_ref,
     );
   }
@@ -173,7 +176,10 @@ final class LambdaSignature extends Node implements ILambdaSignature {
     }
     return new static(
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<IParameter>> may not be enforceable */ $parameters,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IParameter>>>(
+        $parameters as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
       $contexts as ?Contexts,
       $colon as ?ColonToken,

--- a/codegen/syntax/LikeTypeSpecifier.hack
+++ b/codegen/syntax/LikeTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<941aa8f9de40fb233269411d3d530084>>
+ * @generated SignedSource<<4d20283ec81b909f381b9c339a1e4685>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -60,11 +60,8 @@ final class LikeTypeSpecifier extends Node implements ITypeSpecifier {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $tilde,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      $source_ref,
-    );
+    return
+      new static($tilde as TildeToken, $type as ITypeSpecifier, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/ListExpression.hack
+++ b/codegen/syntax/ListExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7f79c315696ea1693da504b1dfb3c5a6>>
+ * @generated SignedSource<<e762a335e1c9bb42cac5968a671d12ed>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -84,10 +84,13 @@ final class ListExpression extends Node implements ILambdaBody, IExpression {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $members,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
+      $keyword as ListToken,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<?IExpression>>>(
+        $members as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
       $source_ref,
     );
   }
@@ -125,7 +128,10 @@ final class ListExpression extends Node implements ILambdaBody, IExpression {
     return new static(
       $keyword as ListToken,
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<?IExpression>> may not be enforceable */ $members,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<?IExpression>>>(
+        $members as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
     );
   }

--- a/codegen/syntax/LiteralExpression.hack
+++ b/codegen/syntax/LiteralExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f9d7c4ad4a1fe6b617bd61400e3398dd>>
+ * @generated SignedSource<<41b802f511e67bf68df696e705ddc935>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -47,7 +47,7 @@ final class LiteralExpression extends Node implements ILambdaBody, IExpression {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(/* HH_IGNORE_ERROR[4110] */ $expression, $source_ref);
+    return new static($expression, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/MarkupSection.hack
+++ b/codegen/syntax/MarkupSection.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1299c5885611d1a45ddc84170416f090>>
+ * @generated SignedSource<<80a7593a69a4911e3420ff68cce0c4cb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -59,8 +59,8 @@ final class MarkupSection extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $hashbang,
-      /* HH_IGNORE_ERROR[4110] */ $suffix,
+      $hashbang as ?HashbangToken,
+      $suffix as ?MarkupSuffix,
       $source_ref,
     );
   }

--- a/codegen/syntax/MarkupSuffix.hack
+++ b/codegen/syntax/MarkupSuffix.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<795022f12a88558f4b0ab25510e45ae9>>
+ * @generated SignedSource<<1d3916b9ddacd9d1928d5e1850650ecb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -61,8 +61,8 @@ final class MarkupSuffix extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $less_than_question,
-      /* HH_IGNORE_ERROR[4110] */ $name,
+      $less_than_question as LessThanQuestionToken,
+      $name as NameToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/MemberSelectionExpression.hack
+++ b/codegen/syntax/MemberSelectionExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f79933a32f03a1ac2a8cccc0ccd6561a>>
+ * @generated SignedSource<<e87cdfdfcc8d9f602bb041ad4da4cf57>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,9 +75,9 @@ final class MemberSelectionExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $object,
-      /* HH_IGNORE_ERROR[4110] */ $operator,
-      /* HH_IGNORE_ERROR[4110] */ $name,
+      $object as IExpression,
+      $operator as MinusGreaterThanToken,
+      $name as IExpression,
       $source_ref,
     );
   }

--- a/codegen/syntax/MethodishDeclaration.hack
+++ b/codegen/syntax/MethodishDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e3a04ad4b403c4061b136d837a2b70c8>>
+ * @generated SignedSource<<4cec254e49fcc712bbb4997d7b708998>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -89,10 +89,10 @@ abstract class MethodishDeclarationGeneratedBase
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute,
-      /* HH_IGNORE_ERROR[4110] */ $function_decl_header,
-      /* HH_IGNORE_ERROR[4110] */ $function_body,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $attribute as ?OldAttributeSpecification,
+      $function_decl_header as FunctionDeclarationHeader,
+      $function_body as ?CompoundStatement,
+      $semicolon as ?SemicolonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/MethodishTraitResolution.hack
+++ b/codegen/syntax/MethodishTraitResolution.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8b66bbd041711dafdeda91a06ffc369c>>
+ * @generated SignedSource<<14173b4d02247fee1e685e52c653a4f8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -101,11 +101,11 @@ final class MethodishTraitResolution
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute,
-      /* HH_IGNORE_ERROR[4110] */ $function_decl_header,
-      /* HH_IGNORE_ERROR[4110] */ $equal,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $attribute,
+      $function_decl_header,
+      $equal,
+      $name,
+      $semicolon,
       $source_ref,
     );
   }

--- a/codegen/syntax/ModuleDeclaration.hack
+++ b/codegen/syntax/ModuleDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1d1fb415307f0976061bdb3cbad664a8>>
+ * @generated SignedSource<<589a6f001bcc405f13627a0e9823358c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -133,14 +133,14 @@ final class ModuleDeclaration extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $new_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $module_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $exports,
-      /* HH_IGNORE_ERROR[4110] */ $imports,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $attribute_spec as ?OldAttributeSpecification,
+      $new_keyword as NewToken,
+      $module_keyword as ModuleToken,
+      $name as ModuleName,
+      $left_brace as LeftBraceToken,
+      $exports,
+      $imports,
+      $right_brace as RightBraceToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/ModuleExports.hack
+++ b/codegen/syntax/ModuleExports.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<54f7c7fd94e8ce26e0d0f5e21a2a65ec>>
+ * @generated SignedSource<<620aadd00bffc91a9642c0c4fcc095ed>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,10 @@ final class ModuleExports extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $exports_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $exports,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $exports_keyword,
+      $left_brace,
+      $exports,
+      $right_brace,
       $source_ref,
     );
   }

--- a/codegen/syntax/ModuleImports.hack
+++ b/codegen/syntax/ModuleImports.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4cce7c2ecfcdefa1bd56e2cbd86295cd>>
+ * @generated SignedSource<<96bdea20a6df3de34ee12ec2da1d4fde>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,10 @@ final class ModuleImports extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $imports_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $imports,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $imports_keyword,
+      $left_brace,
+      $imports,
+      $right_brace,
       $source_ref,
     );
   }

--- a/codegen/syntax/ModuleMembershipDeclaration.hack
+++ b/codegen/syntax/ModuleMembershipDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<30ce5c85ba4149a8bac7eb3b682dea3e>>
+ * @generated SignedSource<<e6e04aa77bf1dcdeca6401206c983495>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class ModuleMembershipDeclaration extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $module_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $module_keyword as ModuleToken,
+      $name as ModuleName,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/ModuleName.hack
+++ b/codegen/syntax/ModuleName.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<b9b93431bd62ffaa7c83f249c7954a22>>
+ * @generated SignedSource<<35558e0c06821f8d651304e0d93d185d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -48,7 +48,13 @@ final class ModuleName extends Node {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(/* HH_IGNORE_ERROR[4110] */ $parts, $source_ref);
+    return new static(
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<NameToken>>>(
+        $parts as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $source_ref,
+    );
   }
 
   <<__Override>>
@@ -70,7 +76,10 @@ final class ModuleName extends Node {
       return $this;
     }
     return new static(
-      /* HH_FIXME[4110] NodeList<ListItem<NameToken>> may not be enforceable */ $parts,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<NameToken>>>(
+        $parts as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
     );
   }
 

--- a/codegen/syntax/NamespaceBody.hack
+++ b/codegen/syntax/NamespaceBody.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7237a6fcfb9ca940aecfdfdcfbaf63b1>>
+ * @generated SignedSource<<d6ed58a92284bf9897ed0072de063720>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class NamespaceBody extends Node implements INamespaceBody {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $declarations,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $left_brace as LeftBraceToken,
+      $declarations as ?NodeList<_>,
+      $right_brace as RightBraceToken,
       $source_ref,
     );
   }
@@ -110,7 +110,7 @@ final class NamespaceBody extends Node implements INamespaceBody {
     }
     return new static(
       $left_brace as LeftBraceToken,
-      /* HH_FIXME[4110] ?NodeList<Node> may not be enforceable */ $declarations,
+      $declarations as ?NodeList<_>,
       $right_brace as RightBraceToken,
     );
   }

--- a/codegen/syntax/NamespaceDeclaration.hack
+++ b/codegen/syntax/NamespaceDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c93aed426e2c015f63dc8838021e8999>>
+ * @generated SignedSource<<1a7e4fd270cf56553eb596b3694878dd>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -61,8 +61,8 @@ abstract class NamespaceDeclarationGeneratedBase extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $header,
-      /* HH_IGNORE_ERROR[4110] */ $body,
+      $header as NamespaceDeclarationHeader,
+      $body as INamespaceBody,
       $source_ref,
     );
   }

--- a/codegen/syntax/NamespaceDeclarationHeader.hack
+++ b/codegen/syntax/NamespaceDeclarationHeader.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<553566b3945022c4d17c65784014627f>>
+ * @generated SignedSource<<f55414d8b9e54fb54ac634aa4b896195>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -60,8 +60,8 @@ final class NamespaceDeclarationHeader extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $name,
+      $keyword as NamespaceToken,
+      $name as ?INameishNode,
       $source_ref,
     );
   }

--- a/codegen/syntax/NamespaceEmptyBody.hack
+++ b/codegen/syntax/NamespaceEmptyBody.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a55457938350d5df1ed27fa9d2b169ed>>
+ * @generated SignedSource<<ac2eee0876eaafd75edc9bd194f992d3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -48,7 +48,7 @@ final class NamespaceEmptyBody extends Node implements INamespaceBody {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(/* HH_IGNORE_ERROR[4110] */ $semicolon, $source_ref);
+    return new static($semicolon as SemicolonToken, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/NamespaceGroupUseDeclaration.hack
+++ b/codegen/syntax/NamespaceGroupUseDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<beba2fea88caac60f30b653f0ea1cdf2>>
+ * @generated SignedSource<<bd1f2db34a74125c7a2d9e77e885d28a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -123,13 +123,19 @@ final class NamespaceGroupUseDeclaration
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $kind,
-      /* HH_IGNORE_ERROR[4110] */ $prefix,
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $clauses,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as UseToken,
+      $kind as ?Token,
+      $prefix as QualifiedName,
+      $left_brace as LeftBraceToken,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<NamespaceUseClause>>,
+      >(
+        $clauses as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_brace as RightBraceToken,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -177,7 +183,13 @@ final class NamespaceGroupUseDeclaration
       $kind as ?Token,
       $prefix as QualifiedName,
       $left_brace as LeftBraceToken,
-      /* HH_FIXME[4110] NodeList<ListItem<NamespaceUseClause>> may not be enforceable */ $clauses,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<NamespaceUseClause>>,
+      >(
+        $clauses as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_brace as RightBraceToken,
       $semicolon as SemicolonToken,
     );

--- a/codegen/syntax/NamespaceUseClause.hack
+++ b/codegen/syntax/NamespaceUseClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8776f0cd238bba561e0cec9368d0b501>>
+ * @generated SignedSource<<b84a5f4ee7733b4f54f2b36976b1744a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -83,10 +83,10 @@ final class NamespaceUseClause extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $clause_kind,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $as,
-      /* HH_IGNORE_ERROR[4110] */ $alias,
+      $clause_kind as ?Token,
+      $name as INameishNode,
+      $as as ?AsToken,
+      $alias as ?NameToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/NamespaceUseDeclaration.hack
+++ b/codegen/syntax/NamespaceUseDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f7a8106abc5b825a8dc3496f6da08007>>
+ * @generated SignedSource<<00832e53cc653d93335dea7d4af0ba65>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -86,10 +86,16 @@ final class NamespaceUseDeclaration
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $kind,
-      /* HH_IGNORE_ERROR[4110] */ $clauses,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as UseToken,
+      $kind as ?Token,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<NamespaceUseClause>>,
+      >(
+        $clauses as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -126,7 +132,13 @@ final class NamespaceUseDeclaration
     return new static(
       $keyword as UseToken,
       $kind as ?Token,
-      /* HH_FIXME[4110] NodeList<ListItem<NamespaceUseClause>> may not be enforceable */ $clauses,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<NamespaceUseClause>>,
+      >(
+        $clauses as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $semicolon as SemicolonToken,
     );
   }

--- a/codegen/syntax/NullableAsExpression.hack
+++ b/codegen/syntax/NullableAsExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<40cdf15742608db8c47cbbb6e282c538>>
+ * @generated SignedSource<<37c09f31fa6388975d78aa2cb8c48dad>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,9 +75,9 @@ final class NullableAsExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_operand,
-      /* HH_IGNORE_ERROR[4110] */ $operator,
-      /* HH_IGNORE_ERROR[4110] */ $right_operand,
+      $left_operand as IExpression,
+      $operator as QuestionAsToken,
+      $right_operand as ITypeSpecifier,
       $source_ref,
     );
   }

--- a/codegen/syntax/NullableTypeSpecifier.hack
+++ b/codegen/syntax/NullableTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<56e1e3f1e8b1b13180dce338161b4c7f>>
+ * @generated SignedSource<<e32cfe60968d24188b16d7fdaae438f1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -61,8 +61,8 @@ final class NullableTypeSpecifier extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $question,
-      /* HH_IGNORE_ERROR[4110] */ $type,
+      $question as QuestionToken,
+      $type as ITypeSpecifier,
       $source_ref,
     );
   }

--- a/codegen/syntax/ObjectCreationExpression.hack
+++ b/codegen/syntax/ObjectCreationExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<35f96f3a147c57f8322a9e1d15bcc740>>
+ * @generated SignedSource<<ea6a07cedac2727db45d9b3dd4fe231a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -63,8 +63,8 @@ final class ObjectCreationExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $new_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $object,
+      $new_keyword as NewToken,
+      $object as ConstructorCall,
       $source_ref,
     );
   }

--- a/codegen/syntax/OldAttributeSpecification.hack
+++ b/codegen/syntax/OldAttributeSpecification.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c07d1de19cfbf9da725f6914eb22ca4e>>
+ * @generated SignedSource<<d563e94cb55ff6d70cfe9145b3d78918>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,15 @@ final class OldAttributeSpecification extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_double_angle,
-      /* HH_IGNORE_ERROR[4110] */ $attributes,
-      /* HH_IGNORE_ERROR[4110] */ $right_double_angle,
+      $left_double_angle as LessThanLessThanToken,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<ConstructorCall>>,
+      >(
+        $attributes as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_double_angle as GreaterThanGreaterThanToken,
       $source_ref,
     );
   }
@@ -108,7 +114,13 @@ final class OldAttributeSpecification extends Node {
     }
     return new static(
       $left_double_angle as LessThanLessThanToken,
-      /* HH_FIXME[4110] NodeList<ListItem<ConstructorCall>> may not be enforceable */ $attributes,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<ConstructorCall>>,
+      >(
+        $attributes as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_double_angle as GreaterThanGreaterThanToken,
     );
   }

--- a/codegen/syntax/ParameterDeclaration.hack
+++ b/codegen/syntax/ParameterDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1a479503fe3a347962036a518871ea84>>
+ * @generated SignedSource<<9a64a54d02f39c66855e31c159174148>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -122,13 +122,13 @@ final class ParameterDeclaration
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute,
-      /* HH_IGNORE_ERROR[4110] */ $visibility,
-      /* HH_IGNORE_ERROR[4110] */ $call_convention,
-      /* HH_IGNORE_ERROR[4110] */ $readonly,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $default_value,
+      $attribute as ?OldAttributeSpecification,
+      $visibility as ?Token,
+      $call_convention as ?InoutToken,
+      $readonly as ?ReadonlyToken,
+      $type as ?ITypeSpecifier,
+      $name as IExpression,
+      $default_value as ?SimpleInitializer,
       $source_ref,
     );
   }

--- a/codegen/syntax/ParenthesizedExpression.hack
+++ b/codegen/syntax/ParenthesizedExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5960a9d1035545c9850934bd5a0d8811>>
+ * @generated SignedSource<<0841e01f181ff21be71b12ff40d54243>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,9 +75,9 @@ final class ParenthesizedExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
+      $left_paren as LeftParenToken,
+      $expression as IExpression,
+      $right_paren as RightParenToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/PipeVariableExpression.hack
+++ b/codegen/syntax/PipeVariableExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<116e4210a5091b55933f236d557e7726>>
+ * @generated SignedSource<<112a30abe7e310384c2697b3bf04fbd1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -50,7 +50,7 @@ final class PipeVariableExpression
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(/* HH_IGNORE_ERROR[4110] */ $expression, $source_ref);
+    return new static($expression, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/PostfixUnaryExpression.hack
+++ b/codegen/syntax/PostfixUnaryExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8a1379e3cfea4ac768435a44d0ad44d2>>
+ * @generated SignedSource<<fc0b7044b1e7c32ee7b1924bd67b5b9b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -62,11 +62,7 @@ final class PostfixUnaryExpression
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $operand,
-      /* HH_IGNORE_ERROR[4110] */ $operator,
-      $source_ref,
-    );
+    return new static($operand as IExpression, $operator as Token, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/PrefixUnaryExpression.hack
+++ b/codegen/syntax/PrefixUnaryExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<213257e64112180c1196b9c24d3bb8ca>>
+ * @generated SignedSource<<bdd6989e34e426b1db05cb1a76dd43f1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -62,11 +62,7 @@ final class PrefixUnaryExpression
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $operator,
-      /* HH_IGNORE_ERROR[4110] */ $operand,
-      $source_ref,
-    );
+    return new static($operator as Token, $operand as IExpression, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/PrefixedCodeExpression.hack
+++ b/codegen/syntax/PrefixedCodeExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2751134e1cc70eebda6e780ec2b40f28>>
+ * @generated SignedSource<<6f3ce9109c4a2b90dde72ffd4158c858>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -87,10 +87,10 @@ final class PrefixedCodeExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $prefix,
-      /* HH_IGNORE_ERROR[4110] */ $left_backtick,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $right_backtick,
+      $prefix,
+      $left_backtick,
+      $expression,
+      $right_backtick,
       $source_ref,
     );
   }

--- a/codegen/syntax/PrefixedStringExpression.hack
+++ b/codegen/syntax/PrefixedStringExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<01ef30b0f374b1d5c9a71a9ad8aea7e6>>
+ * @generated SignedSource<<356cb111e17b30c3224784aa5c4b8c3c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -61,11 +61,7 @@ final class PrefixedStringExpression
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $str,
-      $source_ref,
-    );
+    return new static($name, $str, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/PropertyDeclaration.hack
+++ b/codegen/syntax/PropertyDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cb91e6a51e5c60784c1023c4f1a8890f>>
+ * @generated SignedSource<<9f34da091ba87b9e042af4e967efb2ca>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -98,11 +98,20 @@ final class PropertyDeclaration
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $modifiers,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $declarators,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $attribute_spec as ?OldAttributeSpecification,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<Token>>(
+        $modifiers as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $type as ?ITypeSpecifier,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<PropertyDeclarator>>,
+      >(
+        $declarators as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -143,9 +152,18 @@ final class PropertyDeclaration
     }
     return new static(
       $attribute_spec as ?OldAttributeSpecification,
-      /* HH_FIXME[4110] NodeList<Token> may not be enforceable */ $modifiers,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<Token>>(
+        $modifiers as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $type as ?ITypeSpecifier,
-      /* HH_FIXME[4110] NodeList<ListItem<PropertyDeclarator>> may not be enforceable */ $declarators,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<PropertyDeclarator>>,
+      >(
+        $declarators as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $semicolon as SemicolonToken,
     );
   }

--- a/codegen/syntax/PropertyDeclarator.hack
+++ b/codegen/syntax/PropertyDeclarator.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9acbc1ae19b71c76301a7ceba4a58315>>
+ * @generated SignedSource<<09defa3485299de37103218ba8a98d4a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -61,8 +61,8 @@ final class PropertyDeclarator extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $initializer,
+      $name as VariableToken,
+      $initializer as ?SimpleInitializer,
       $source_ref,
     );
   }

--- a/codegen/syntax/QualifiedName.hack
+++ b/codegen/syntax/QualifiedName.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx>>
+ * @generated SignedSource<<db74ac446320e7f013e77776603cd85b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;

--- a/codegen/syntax/QualifiedName.hack
+++ b/codegen/syntax/QualifiedName.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4579cd1ceb9bff63b706f9dc72f3fd3c>>
+ * @generated SignedSource<<541eaff8e49bd5eaad1a9c5f7ce7f85d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -50,7 +50,13 @@ final class QualifiedName
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(/* HH_IGNORE_ERROR[4110] */ $parts, $source_ref);
+    return new static(
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<?Token>>>(
+        $parts as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $source_ref,
+    );
   }
 
   <<__Override>>
@@ -72,7 +78,10 @@ final class QualifiedName
       return $this;
     }
     return new static(
-      /* HH_FIXME[4110] NodeList<ListItem<?Token>> may not be enforceable */ $parts,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<?Token>>>(
+        $parts as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
     );
   }
 

--- a/codegen/syntax/ReifiedTypeArgument.hack
+++ b/codegen/syntax/ReifiedTypeArgument.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<275b1489601875ab1bbaf9931d5ad376>>
+ * @generated SignedSource<<798961dba01f98bb1372fbc98595bc00>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -60,11 +60,7 @@ final class ReifiedTypeArgument extends Node implements ITypeSpecifier {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $reified,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      $source_ref,
-    );
+    return new static($reified, $type, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/RequireClause.hack
+++ b/codegen/syntax/RequireClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<826a6631b25eebc933ad97717e787801>>
+ * @generated SignedSource<<23d1462c02ab2d1fb1e5374d796063e2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,10 @@ final class RequireClause extends Node implements IClassBodyDeclaration {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $kind,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as RequireToken,
+      $kind as Token,
+      $name as ISimpleCreationSpecifier,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/ReturnStatement.hack
+++ b/codegen/syntax/ReturnStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<64e40af6229db1b770b0e52ce6f2e184>>
+ * @generated SignedSource<<e3cefbeb67595263f1de7752c1adecea>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -72,9 +72,9 @@ final class ReturnStatement extends Node implements IStatement {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as ReturnToken,
+      $expression as ?IExpression,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/SafeMemberSelectionExpression.hack
+++ b/codegen/syntax/SafeMemberSelectionExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ad4c8e209bba67672cccd8536edd6176>>
+ * @generated SignedSource<<39e903f97cf217f6432db62a312fe4c8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,9 +75,9 @@ final class SafeMemberSelectionExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $object,
-      /* HH_IGNORE_ERROR[4110] */ $operator,
-      /* HH_IGNORE_ERROR[4110] */ $name,
+      $object as IExpression,
+      $operator as QuestionMinusGreaterThanToken,
+      $name as NameToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/ScopeResolutionExpression.hack
+++ b/codegen/syntax/ScopeResolutionExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<083e35d2071ab9fb3e7e05bb0da6218b>>
+ * @generated SignedSource<<551a7336f977d52ab2296065ad8f883a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -74,12 +74,8 @@ final class ScopeResolutionExpression
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $qualifier,
-      /* HH_IGNORE_ERROR[4110] */ $operator,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      $source_ref,
-    );
+    return
+      new static($qualifier, $operator as ColonColonToken, $name, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/Script.hack
+++ b/codegen/syntax/Script.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<819e521e21ab5038912886707d5d60ee>>
+ * @generated SignedSource<<b8f4e4d9800abfd8550b89ce8ce850cc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -48,7 +48,7 @@ abstract class ScriptGeneratedBase extends Node {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(/* HH_IGNORE_ERROR[4110] */ $declarations, $source_ref);
+    return new static($declarations as NodeList<_>, $source_ref);
   }
 
   <<__Override>>
@@ -69,9 +69,7 @@ abstract class ScriptGeneratedBase extends Node {
     if ($declarations === $this->_declarations) {
       return $this;
     }
-    return new static(
-      /* HH_FIXME[4110] NodeList<Node> may not be enforceable */ $declarations,
-    );
+    return new static($declarations as NodeList<_>);
   }
 
   public function getDeclarationsUNTYPED(): ?Node {

--- a/codegen/syntax/ShapeExpression.hack
+++ b/codegen/syntax/ShapeExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7068c7f8c09700f5a6431aad8af2ffae>>
+ * @generated SignedSource<<58d49b80fbc7548c96d4ef6d0298e42d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,16 @@ final class ShapeExpression extends Node implements ILambdaBody, IExpression {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $fields,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
+      $keyword as ShapeToken,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<FieldInitializer>>,
+      >(
+        $fields as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
       $source_ref,
     );
   }
@@ -126,7 +132,13 @@ final class ShapeExpression extends Node implements ILambdaBody, IExpression {
     return new static(
       $keyword as ShapeToken,
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<FieldInitializer>> may not be enforceable */ $fields,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<FieldInitializer>>,
+      >(
+        $fields as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
     );
   }

--- a/codegen/syntax/ShapeTypeSpecifier.hack
+++ b/codegen/syntax/ShapeTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e47048bc8ef421cedc2cdff0e9d5c88b>>
+ * @generated SignedSource<<1e59e31cefe34b54b4d8b8af15bc0a5f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -95,11 +95,17 @@ final class ShapeTypeSpecifier extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $fields,
-      /* HH_IGNORE_ERROR[4110] */ $ellipsis,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
+      $keyword as ShapeToken,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<FieldSpecifier>>,
+      >(
+        $fields as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $ellipsis as ?DotDotDotToken,
+      $right_paren as RightParenToken,
       $source_ref,
     );
   }
@@ -141,7 +147,13 @@ final class ShapeTypeSpecifier extends Node implements ITypeSpecifier {
     return new static(
       $keyword as ShapeToken,
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<FieldSpecifier>> may not be enforceable */ $fields,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<FieldSpecifier>>,
+      >(
+        $fields as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $ellipsis as ?DotDotDotToken,
       $right_paren as RightParenToken,
     );

--- a/codegen/syntax/SimpleInitializer.hack
+++ b/codegen/syntax/SimpleInitializer.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0a59e0f91b7cfe7f8dafe46adc655c85>>
+ * @generated SignedSource<<d6ffe03ff8cb736a4fdf516dc8fd2895>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -60,11 +60,7 @@ final class SimpleInitializer extends Node {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $equal,
-      /* HH_IGNORE_ERROR[4110] */ $value,
-      $source_ref,
-    );
+    return new static($equal as EqualToken, $value as IExpression, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/SimpleTypeSpecifier.hack
+++ b/codegen/syntax/SimpleTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f5e82198817cbe5ab496e965b36620ad>>
+ * @generated SignedSource<<c9c9bb44af0502479e3448c5544d89fc>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -50,7 +50,7 @@ final class SimpleTypeSpecifier
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(/* HH_IGNORE_ERROR[4110] */ $specifier, $source_ref);
+    return new static($specifier, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/SoftTypeSpecifier.hack
+++ b/codegen/syntax/SoftTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<99833ac638a55613e95bd4a97b1f8c5b>>
+ * @generated SignedSource<<d5dc294c3de1d5c24a3b70a2da82dbe1>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -60,11 +60,7 @@ final class SoftTypeSpecifier extends Node implements ITypeSpecifier {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $at,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      $source_ref,
-    );
+    return new static($at as AtToken, $type as ITypeSpecifier, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/SubscriptExpression.hack
+++ b/codegen/syntax/SubscriptExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<084703282ea48f976125e11d6d6e1dd1>>
+ * @generated SignedSource<<b7a2e3ab66809db6371e96d784ba520b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -86,10 +86,10 @@ final class SubscriptExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $receiver,
-      /* HH_IGNORE_ERROR[4110] */ $left_bracket,
-      /* HH_IGNORE_ERROR[4110] */ $index,
-      /* HH_IGNORE_ERROR[4110] */ $right_bracket,
+      $receiver as IExpression,
+      $left_bracket as LeftBracketToken,
+      $index as ?IExpression,
+      $right_bracket as RightBracketToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/SwitchFallthrough.hack
+++ b/codegen/syntax/SwitchFallthrough.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<553686b37007df8502615b4c2000f866>>
+ * @generated SignedSource<<a51be8c05c52281f3eff51d3396003ee>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -59,11 +59,7 @@ final class SwitchFallthrough extends Node implements IStatement {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
-      $source_ref,
-    );
+    return new static($keyword, $semicolon, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/SwitchSection.hack
+++ b/codegen/syntax/SwitchSection.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<720112a9ff6c7d84e63c827c8fc39d16>>
+ * @generated SignedSource<<5152ecc1b48699b4a3a4c9764486bae4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,15 @@ final class SwitchSection extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $labels,
-      /* HH_IGNORE_ERROR[4110] */ $statements,
-      /* HH_IGNORE_ERROR[4110] */ $fallthrough,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ISwitchLabel>>(
+        $labels as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<IStatement>>(
+        $statements as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $fallthrough as ?SwitchFallthrough,
       $source_ref,
     );
   }
@@ -111,8 +117,14 @@ final class SwitchSection extends Node {
       return $this;
     }
     return new static(
-      /* HH_FIXME[4110] NodeList<ISwitchLabel> may not be enforceable */ $labels,
-      /* HH_FIXME[4110] ?NodeList<IStatement> may not be enforceable */ $statements,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ISwitchLabel>>(
+        $labels as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<IStatement>>(
+        $statements as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $fallthrough as ?SwitchFallthrough,
     );
   }

--- a/codegen/syntax/SwitchStatement.hack
+++ b/codegen/syntax/SwitchStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<68cbbbb7f14b956ef08aa3fb1575c7db>>
+ * @generated SignedSource<<018a3e1cf602b0237624c4a9071670d2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -123,13 +123,16 @@ final class SwitchStatement
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $sections,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $keyword as SwitchToken,
+      $left_paren as LeftParenToken,
+      $expression as IExpression,
+      $right_paren as RightParenToken,
+      $left_brace as LeftBraceToken,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<SwitchSection>>(
+        $sections as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_brace as RightBraceToken,
       $source_ref,
     );
   }
@@ -178,7 +181,10 @@ final class SwitchStatement
       $expression as IExpression,
       $right_paren as RightParenToken,
       $left_brace as LeftBraceToken,
-      /* HH_FIXME[4110] NodeList<SwitchSection> may not be enforceable */ $sections,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<SwitchSection>>(
+        $sections as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_brace as RightBraceToken,
     );
   }

--- a/codegen/syntax/ThrowStatement.hack
+++ b/codegen/syntax/ThrowStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<78fafa63385ec69d12b5ce7f87dfd69f>>
+ * @generated SignedSource<<92dff1d852ec1c88e8cf7bfc724fc4a6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class ThrowStatement extends Node implements IStatement {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as ThrowToken,
+      $expression as IExpression,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/TraitUse.hack
+++ b/codegen/syntax/TraitUse.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a07a6b06d5a22e22bc88f074aceff338>>
+ * @generated SignedSource<<de3eecd36754aec2beb8924a46e19779>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,12 @@ final class TraitUse extends Node implements IClassBodyDeclaration {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $names,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as UseToken,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<ITypeSpecifier>>>(
+        $names as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -108,7 +111,10 @@ final class TraitUse extends Node implements IClassBodyDeclaration {
     }
     return new static(
       $keyword as UseToken,
-      /* HH_FIXME[4110] NodeList<ListItem<ITypeSpecifier>> may not be enforceable */ $names,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<ITypeSpecifier>>>(
+        $names as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $semicolon as SemicolonToken,
     );
   }

--- a/codegen/syntax/TryStatement.hack
+++ b/codegen/syntax/TryStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<9d5aa391a4b8409fbb9366e2d7763041>>
+ * @generated SignedSource<<782b61a2d33148e9fe5f7e26a1c8d23f>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -83,10 +83,13 @@ final class TryStatement extends Node implements IStatement {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $compound_statement,
-      /* HH_IGNORE_ERROR[4110] */ $catch_clauses,
-      /* HH_IGNORE_ERROR[4110] */ $finally_clause,
+      $keyword as TryToken,
+      $compound_statement as CompoundStatement,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<CatchClause>>(
+        $catch_clauses as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $finally_clause as ?FinallyClause,
       $source_ref,
     );
   }
@@ -127,7 +130,10 @@ final class TryStatement extends Node implements IStatement {
     return new static(
       $keyword as TryToken,
       $compound_statement as CompoundStatement,
-      /* HH_FIXME[4110] ?NodeList<CatchClause> may not be enforceable */ $catch_clauses,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<CatchClause>>(
+        $catch_clauses as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $finally_clause as ?FinallyClause,
     );
   }

--- a/codegen/syntax/TupleExpression.hack
+++ b/codegen/syntax/TupleExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5fb563a6382b05c5892b5fe02d868019>>
+ * @generated SignedSource<<312df398508be483895327bf29cc52b4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,13 @@ final class TupleExpression extends Node implements ILambdaBody, IExpression {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $items,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
+      $keyword as TupleToken,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $items as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
       $source_ref,
     );
   }
@@ -125,7 +128,10 @@ final class TupleExpression extends Node implements ILambdaBody, IExpression {
     return new static(
       $keyword as TupleToken,
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<IExpression>> may not be enforceable */ $items,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $items as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
     );
   }

--- a/codegen/syntax/TupleTypeExplicitSpecifier.hack
+++ b/codegen/syntax/TupleTypeExplicitSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1713e3dd953eee9499acfe2160353710>>
+ * @generated SignedSource<<3bf6215bcb8acfc256006e18d7156b36>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -82,13 +82,7 @@ final class TupleTypeExplicitSpecifier extends Node implements ITypeSpecifier {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_angle,
-      /* HH_IGNORE_ERROR[4110] */ $types,
-      /* HH_IGNORE_ERROR[4110] */ $right_angle,
-      $source_ref,
-    );
+    return new static($keyword, $left_angle, $types, $right_angle, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/TupleTypeSpecifier.hack
+++ b/codegen/syntax/TupleTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<78a4bed284f08d0bf760eb8499d6ea1a>>
+ * @generated SignedSource<<3947ee3d62b6e180ddfe96f9161ac54b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,12 @@ final class TupleTypeSpecifier extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $types,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<ITypeSpecifier>>>(
+        $types as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
       $source_ref,
     );
   }
@@ -108,7 +111,10 @@ final class TupleTypeSpecifier extends Node implements ITypeSpecifier {
     }
     return new static(
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] NodeList<ListItem<ITypeSpecifier>> may not be enforceable */ $types,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<ITypeSpecifier>>>(
+        $types as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
     );
   }

--- a/codegen/syntax/TypeArguments.hack
+++ b/codegen/syntax/TypeArguments.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8da116ce9939abde432f646389ec149e>>
+ * @generated SignedSource<<cebc8ec780f83d7ddfb9dfeb14e5e502>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,12 @@ final class TypeArguments extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_angle,
-      /* HH_IGNORE_ERROR[4110] */ $types,
-      /* HH_IGNORE_ERROR[4110] */ $right_angle,
+      $left_angle as LessThanToken,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ITypeSpecifier>>,
+      >($types as ?NodeList<_>, 'Open for sound approaches that are not O(n).'),
+      $right_angle as GreaterThanToken,
       $source_ref,
     );
   }
@@ -108,7 +111,10 @@ final class TypeArguments extends Node {
     }
     return new static(
       $left_angle as LessThanToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<ITypeSpecifier>> may not be enforceable */ $types,
+      \HH\FIXME\UNSAFE_CAST<
+        ?NodeList<Node>,
+        ?NodeList<ListItem<ITypeSpecifier>>,
+      >($types as ?NodeList<_>, 'Open for sound approaches that are not O(n).'),
       $right_angle as GreaterThanToken,
     );
   }

--- a/codegen/syntax/TypeConstDeclaration.hack
+++ b/codegen/syntax/TypeConstDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<43dc34063df95b97465b3082458bb66e>>
+ * @generated SignedSource<<66d07e5bd3983fc74cd8e1618e3ea09b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -156,16 +156,22 @@ final class TypeConstDeclaration extends Node implements IClassBodyDeclaration {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $modifiers,
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $type_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $type_parameters,
-      /* HH_IGNORE_ERROR[4110] */ $type_constraints,
-      /* HH_IGNORE_ERROR[4110] */ $equal,
-      /* HH_IGNORE_ERROR[4110] */ $type_specifier,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $attribute_spec as ?OldAttributeSpecification,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<AbstractToken>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $keyword as ConstToken,
+      $type_keyword as TypeToken,
+      $name as NameToken,
+      $type_parameters,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<TypeConstraint>>(
+        $type_constraints as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $equal as ?EqualToken,
+      $type_specifier as ?ITypeSpecifier,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -229,12 +235,18 @@ final class TypeConstDeclaration extends Node implements IClassBodyDeclaration {
     }
     return new static(
       $attribute_spec as ?OldAttributeSpecification,
-      /* HH_FIXME[4110] ?NodeList<AbstractToken> may not be enforceable */ $modifiers,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<AbstractToken>>(
+        $modifiers as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $keyword as ConstToken,
       $type_keyword as TypeToken,
       $name as NameToken,
       $type_parameters as ?Node,
-      /* HH_FIXME[4110] ?NodeList<TypeConstraint> may not be enforceable */ $type_constraints,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<TypeConstraint>>(
+        $type_constraints as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $equal as ?EqualToken,
       $type_specifier as ?ITypeSpecifier,
       $semicolon as SemicolonToken,

--- a/codegen/syntax/TypeConstant.hack
+++ b/codegen/syntax/TypeConstant.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<dbdd4d7f98772aa8aed03aca1baafb68>>
+ * @generated SignedSource<<0fb219e9c7ae7fdf1e7d8bb1e8482338>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class TypeConstant extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_type,
-      /* HH_IGNORE_ERROR[4110] */ $separator,
-      /* HH_IGNORE_ERROR[4110] */ $right_type,
+      $left_type as ITypeSpecifier,
+      $separator as ColonColonToken,
+      $right_type as NameToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/TypeConstraint.hack
+++ b/codegen/syntax/TypeConstraint.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8e3130923200461713699d8467cb78a0>>
+ * @generated SignedSource<<c77d7c2539f403d8d56047af664b9061>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -60,11 +60,7 @@ final class TypeConstraint extends Node {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      $source_ref,
-    );
+    return new static($keyword as Token, $type as ITypeSpecifier, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/TypeInRefinement.hack
+++ b/codegen/syntax/TypeInRefinement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<bf73c8c5983b114b6f9e83fc985ecd64>>
+ * @generated SignedSource<<f6f29949b3eaeb47a64974d73b226216>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -109,12 +109,12 @@ final class TypeInRefinement extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $type_parameters,
-      /* HH_IGNORE_ERROR[4110] */ $constraints,
-      /* HH_IGNORE_ERROR[4110] */ $equal,
-      /* HH_IGNORE_ERROR[4110] */ $type,
+      $keyword,
+      $name,
+      $type_parameters,
+      $constraints,
+      $equal,
+      $type,
       $source_ref,
     );
   }

--- a/codegen/syntax/TypeParameter.hack
+++ b/codegen/syntax/TypeParameter.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5bbf01c659f1322fc0ed8c2ec221d7c7>>
+ * @generated SignedSource<<b2bc4156598fb7cdd8ae0736247f22a4>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -104,12 +104,15 @@ final class TypeParameter extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $attribute_spec,
-      /* HH_IGNORE_ERROR[4110] */ $reified,
-      /* HH_IGNORE_ERROR[4110] */ $variance,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $param_params,
-      /* HH_IGNORE_ERROR[4110] */ $constraints,
+      $attribute_spec as ?OldAttributeSpecification,
+      $reified as ?ReifyToken,
+      $variance as ?Token,
+      $name as NameToken,
+      $param_params as ?TypeParameters,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<TypeConstraint>>(
+        $constraints as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $source_ref,
     );
   }
@@ -163,7 +166,10 @@ final class TypeParameter extends Node {
       $variance as ?Token,
       $name as NameToken,
       $param_params as ?TypeParameters,
-      /* HH_FIXME[4110] ?NodeList<TypeConstraint> may not be enforceable */ $constraints,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<TypeConstraint>>(
+        $constraints as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
     );
   }
 

--- a/codegen/syntax/TypeParameters.hack
+++ b/codegen/syntax/TypeParameters.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<be5588083f034876c47fa58b5f3e5ca8>>
+ * @generated SignedSource<<f5b78da0c98f2c793892a61b335b811c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,12 @@ final class TypeParameters extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_angle,
-      /* HH_IGNORE_ERROR[4110] */ $parameters,
-      /* HH_IGNORE_ERROR[4110] */ $right_angle,
+      $left_angle as LessThanToken,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<TypeParameter>>>(
+        $parameters as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_angle as GreaterThanToken,
       $source_ref,
     );
   }
@@ -108,7 +111,10 @@ final class TypeParameters extends Node {
     }
     return new static(
       $left_angle as LessThanToken,
-      /* HH_FIXME[4110] NodeList<ListItem<TypeParameter>> may not be enforceable */ $parameters,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<TypeParameter>>>(
+        $parameters as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_angle as GreaterThanToken,
     );
   }

--- a/codegen/syntax/TypeRefinement.hack
+++ b/codegen/syntax/TypeRefinement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5d70129e8b4a9122aa71ad95ebd43544>>
+ * @generated SignedSource<<0e637bb09e27c70449fb908f98440c48>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -97,11 +97,11 @@ final class TypeRefinement extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $members,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $type,
+      $keyword,
+      $left_brace,
+      $members,
+      $right_brace,
       $source_ref,
     );
   }

--- a/codegen/syntax/UnionTypeSpecifier.hack
+++ b/codegen/syntax/UnionTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<028f4c05cca130f366f784220004bf90>>
+ * @generated SignedSource<<0cf54f7c06f601503ee1d8ae44f7c48c>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -69,12 +69,7 @@ final class UnionTypeSpecifier extends Node implements ITypeSpecifier {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $types,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      $source_ref,
-    );
+    return new static($left_paren, $types, $right_paren, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/UnsetStatement.hack
+++ b/codegen/syntax/UnsetStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<106e5e1afe6fadc716d6a81e92f1bcf1>>
+ * @generated SignedSource<<27e67b347db6610b2e8e484f6f827a05>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -97,11 +97,14 @@ final class UnsetStatement extends Node implements IStatement {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $variables,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as UnsetToken,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<IExpression>>>(
+        $variables as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -141,7 +144,10 @@ final class UnsetStatement extends Node implements IStatement {
     return new static(
       $keyword as UnsetToken,
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] NodeList<ListItem<IExpression>> may not be enforceable */ $variables,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<IExpression>>>(
+        $variables as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
       $semicolon as SemicolonToken,
     );

--- a/codegen/syntax/UpcastExpression.hack
+++ b/codegen/syntax/UpcastExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<29057dcf897c6c9a36eebc7c19f14239>>
+ * @generated SignedSource<<9db21892d305e027ad8ccacffc28e0c2>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -70,12 +70,7 @@ final class UpcastExpression extends Node implements ILambdaBody, IExpression {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_operand,
-      /* HH_IGNORE_ERROR[4110] */ $operator,
-      /* HH_IGNORE_ERROR[4110] */ $right_operand,
-      $source_ref,
-    );
+    return new static($left_operand, $operator, $right_operand, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/UsingStatementBlockScoped.hack
+++ b/codegen/syntax/UsingStatementBlockScoped.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<ee5007e50596ad3370d6d4ac92259eb1>>
+ * @generated SignedSource<<85e9b50ae34d153811076063b33c30a0>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -109,12 +109,15 @@ final class UsingStatementBlockScoped extends Node implements IStatement {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $await_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $using_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $expressions,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $body,
+      $await_keyword as ?AwaitToken,
+      $using_keyword as UsingToken,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<IExpression>>>(
+        $expressions as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
+      $body as CompoundStatement,
       $source_ref,
     );
   }
@@ -160,7 +163,10 @@ final class UsingStatementBlockScoped extends Node implements IStatement {
       $await_keyword as ?AwaitToken,
       $using_keyword as UsingToken,
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] NodeList<ListItem<IExpression>> may not be enforceable */ $expressions,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<IExpression>>>(
+        $expressions as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
       $body as CompoundStatement,
     );

--- a/codegen/syntax/UsingStatementFunctionScoped.hack
+++ b/codegen/syntax/UsingStatementFunctionScoped.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<75403a071a8e5a8e393bb871af04d70e>>
+ * @generated SignedSource<<1ae625f14e2d5cb29ec322ff474b789a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,10 @@ final class UsingStatementFunctionScoped extends Node implements IStatement {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $await_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $using_keyword,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $await_keyword as ?AwaitToken,
+      $using_keyword as UsingToken,
+      $expression as IExpression,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/VariableExpression.hack
+++ b/codegen/syntax/VariableExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<129f2bedc5905455fa3a1caec562e099>>
+ * @generated SignedSource<<ab19a28ffc0b8480db80328dd26bbfde>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -49,7 +49,7 @@ final class VariableExpression
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(/* HH_IGNORE_ERROR[4110] */ $expression, $source_ref);
+    return new static($expression, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/VariadicParameter.hack
+++ b/codegen/syntax/VariadicParameter.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<04d78aa16cf9bd211d7f42f234c55f00>>
+ * @generated SignedSource<<e5b354c6876d1109ce76b2640b2666bb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,9 +75,9 @@ final class VariadicParameter
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $call_convention,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $ellipsis,
+      $call_convention,
+      $type as ?ITypeSpecifier,
+      $ellipsis as DotDotDotToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/VarrayIntrinsicExpression.hack
+++ b/codegen/syntax/VarrayIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<4e0f177b7cc4f66b320d25289b1b5a01>>
+ * @generated SignedSource<<41543b56a24801785e179dcc20183bf5>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -99,11 +99,14 @@ final class VarrayIntrinsicExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $explicit_type,
-      /* HH_IGNORE_ERROR[4110] */ $left_bracket,
-      /* HH_IGNORE_ERROR[4110] */ $members,
-      /* HH_IGNORE_ERROR[4110] */ $right_bracket,
+      $keyword as VarrayToken,
+      $explicit_type as ?TypeArguments,
+      $left_bracket as LeftBracketToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $members as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_bracket as RightBracketToken,
       $source_ref,
     );
   }
@@ -147,7 +150,10 @@ final class VarrayIntrinsicExpression
       $keyword as VarrayToken,
       $explicit_type as ?TypeArguments,
       $left_bracket as LeftBracketToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<IExpression>> may not be enforceable */ $members,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $members as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_bracket as RightBracketToken,
     );
   }

--- a/codegen/syntax/VarrayTypeSpecifier.hack
+++ b/codegen/syntax/VarrayTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<8843c658e8f8664b762105b5f6249bd1>>
+ * @generated SignedSource<<0b93932094333281206c8e6961686d25>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -97,11 +97,11 @@ final class VarrayTypeSpecifier extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_angle,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $trailing_comma,
-      /* HH_IGNORE_ERROR[4110] */ $right_angle,
+      $keyword as VarrayToken,
+      $left_angle as LessThanToken,
+      $type as ITypeSpecifier,
+      $trailing_comma as ?CommaToken,
+      $right_angle as GreaterThanToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/VectorIntrinsicExpression.hack
+++ b/codegen/syntax/VectorIntrinsicExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<dd233952b46735723f2d2b16596cbdb2>>
+ * @generated SignedSource<<20ee103bc6bad664a262bf9a3821d327>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -99,11 +99,14 @@ final class VectorIntrinsicExpression
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $explicit_type,
-      /* HH_IGNORE_ERROR[4110] */ $left_bracket,
-      /* HH_IGNORE_ERROR[4110] */ $members,
-      /* HH_IGNORE_ERROR[4110] */ $right_bracket,
+      $keyword as VecToken,
+      $explicit_type as ?TypeArguments,
+      $left_bracket as LeftBracketToken,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $members as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_bracket as RightBracketToken,
       $source_ref,
     );
   }
@@ -147,7 +150,10 @@ final class VectorIntrinsicExpression
       $keyword as VecToken,
       $explicit_type as ?TypeArguments,
       $left_bracket as LeftBracketToken,
-      /* HH_FIXME[4110] ?NodeList<ListItem<IExpression>> may not be enforceable */ $members,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<ListItem<IExpression>>>(
+        $members as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_bracket as RightBracketToken,
     );
   }

--- a/codegen/syntax/VectorTypeSpecifier.hack
+++ b/codegen/syntax/VectorTypeSpecifier.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<5016c2894db9ddec04070aca9358f174>>
+ * @generated SignedSource<<e79e78e8aa8d5af8339c8dd84afd10e7>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -97,11 +97,11 @@ final class VectorTypeSpecifier extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_angle,
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $trailing_comma,
-      /* HH_IGNORE_ERROR[4110] */ $right_angle,
+      $keyword as VecToken,
+      $left_angle as LessThanToken,
+      $type as ITypeSpecifier,
+      $trailing_comma,
+      $right_angle as GreaterThanToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/WhereClause.hack
+++ b/codegen/syntax/WhereClause.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f046b10c13696f0e712c2f26e9c63458>>
+ * @generated SignedSource<<30ed4c31dd755410f451486d07f6d243>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -61,8 +61,14 @@ final class WhereClause extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $constraints,
+      $keyword as WhereToken,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<WhereConstraint>>,
+      >(
+        $constraints as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $source_ref,
     );
   }
@@ -89,7 +95,13 @@ final class WhereClause extends Node {
     }
     return new static(
       $keyword as WhereToken,
-      /* HH_FIXME[4110] NodeList<ListItem<WhereConstraint>> may not be enforceable */ $constraints,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<WhereConstraint>>,
+      >(
+        $constraints as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
     );
   }
 

--- a/codegen/syntax/WhereConstraint.hack
+++ b/codegen/syntax/WhereConstraint.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<82c89e9b354650c7f73cd2b9746122d3>>
+ * @generated SignedSource<<fa4e470adaf0f1423b428a6dc4a7054b>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class WhereConstraint extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_type,
-      /* HH_IGNORE_ERROR[4110] */ $operator,
-      /* HH_IGNORE_ERROR[4110] */ $right_type,
+      $left_type as ITypeSpecifier,
+      $operator as Token,
+      $right_type as ITypeSpecifier,
       $source_ref,
     );
   }

--- a/codegen/syntax/WhileStatement.hack
+++ b/codegen/syntax/WhileStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c053aa583989efc8b1d2e470979a0e10>>
+ * @generated SignedSource<<3ecca2c7ae6bab01b12a88f0b26821da>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -99,11 +99,11 @@ final class WhileStatement
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $condition,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
-      /* HH_IGNORE_ERROR[4110] */ $body,
+      $keyword as WhileToken,
+      $left_paren as LeftParenToken,
+      $condition as IExpression,
+      $right_paren as RightParenToken,
+      $body as IStatement,
       $source_ref,
     );
   }

--- a/codegen/syntax/XHPCategoryDeclaration.hack
+++ b/codegen/syntax/XHPCategoryDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<78b113364cc5b8332ad5c3386461f178>>
+ * @generated SignedSource<<a495798b1a2faeff4368169f0a8b2820>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -74,12 +74,7 @@ final class XHPCategoryDeclaration
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $categories,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
-      $source_ref,
-    );
+    return new static($keyword, $categories, $semicolon, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/XHPChildrenDeclaration.hack
+++ b/codegen/syntax/XHPChildrenDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<76fe66240618fb18aa4c5590f281ef51>>
+ * @generated SignedSource<<8bd694f84a5bff72041b4fe4d03e952a>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,9 +75,9 @@ final class XHPChildrenDeclaration
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as ChildrenToken,
+      $expression,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/XHPChildrenParenthesizedList.hack
+++ b/codegen/syntax/XHPChildrenParenthesizedList.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<f0717ff9a79089f103ff80ab77e864d2>>
+ * @generated SignedSource<<5006cc5115ddb3505f2a21c47601f9c3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,9 +75,12 @@ final class XHPChildrenParenthesizedList
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_paren,
-      /* HH_IGNORE_ERROR[4110] */ $xhp_children,
-      /* HH_IGNORE_ERROR[4110] */ $right_paren,
+      $left_paren as LeftParenToken,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<IExpression>>>(
+        $xhp_children as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $right_paren as RightParenToken,
       $source_ref,
     );
   }
@@ -110,7 +113,10 @@ final class XHPChildrenParenthesizedList
     }
     return new static(
       $left_paren as LeftParenToken,
-      /* HH_FIXME[4110] NodeList<ListItem<IExpression>> may not be enforceable */ $xhp_children,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<IExpression>>>(
+        $xhp_children as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $right_paren as RightParenToken,
     );
   }

--- a/codegen/syntax/XHPClassAttribute.hack
+++ b/codegen/syntax/XHPClassAttribute.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<e639a795c5bd7f76912af4cc77957967>>
+ * @generated SignedSource<<af2fdb08e712de0a45385a8b040c8957>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,10 @@ final class XHPClassAttribute extends Node implements IXHPAttribute {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $type,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $initializer,
-      /* HH_IGNORE_ERROR[4110] */ $required,
+      $type as ITypeSpecifier,
+      $name as XHPElementNameToken,
+      $initializer as ?SimpleInitializer,
+      $required,
       $source_ref,
     );
   }

--- a/codegen/syntax/XHPClassAttributeDeclaration.hack
+++ b/codegen/syntax/XHPClassAttributeDeclaration.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<c8e11654904381dde1b922a3d3ec7443>>
+ * @generated SignedSource<<0520fe0589b0a3b3dd679cd9067b78e8>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -75,9 +75,12 @@ final class XHPClassAttributeDeclaration
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $attributes,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as AttributeToken,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<Node>>>(
+        $attributes as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }
@@ -110,7 +113,10 @@ final class XHPClassAttributeDeclaration
     }
     return new static(
       $keyword as AttributeToken,
-      /* HH_FIXME[4110] NodeList<ListItem<Node>> may not be enforceable */ $attributes,
+      \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<ListItem<Node>>>(
+        $attributes as NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $semicolon as SemicolonToken,
     );
   }

--- a/codegen/syntax/XHPClose.hack
+++ b/codegen/syntax/XHPClose.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<cdfcb5062da26eb6f148017d08ff05e0>>
+ * @generated SignedSource<<2baafe579c6f1a79cfac26fc9b6bc86d>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class XHPClose extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_angle,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $right_angle,
+      $left_angle as LessThanSlashToken,
+      $name as XHPElementNameToken,
+      $right_angle as GreaterThanToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/XHPEnumType.hack
+++ b/codegen/syntax/XHPEnumType.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<fb3b6fbf9d930f1b9b8ab5178ace8e0f>>
+ * @generated SignedSource<<5f67159e81cd49357d668a65b372a0f3>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -96,11 +96,14 @@ final class XHPEnumType extends Node implements ITypeSpecifier {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $like,
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $values,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $like as ?TildeToken,
+      $keyword as EnumToken,
+      $left_brace as LeftBraceToken,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<LiteralExpression>>,
+      >($values as NodeList<_>, 'Open for sound approaches that are not O(n).'),
+      $right_brace as RightBraceToken,
       $source_ref,
     );
   }
@@ -141,7 +144,10 @@ final class XHPEnumType extends Node implements ITypeSpecifier {
       $like as ?TildeToken,
       $keyword as EnumToken,
       $left_brace as LeftBraceToken,
-      /* HH_FIXME[4110] NodeList<ListItem<LiteralExpression>> may not be enforceable */ $values,
+      \HH\FIXME\UNSAFE_CAST<
+        NodeList<Node>,
+        NodeList<ListItem<LiteralExpression>>,
+      >($values as NodeList<_>, 'Open for sound approaches that are not O(n).'),
       $right_brace as RightBraceToken,
     );
   }

--- a/codegen/syntax/XHPExpression.hack
+++ b/codegen/syntax/XHPExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<2b30232ff9bc91d0802cf242673a3ecb>>
+ * @generated SignedSource<<b2a60abae723717fdf59d6f10352f017>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -71,9 +71,9 @@ final class XHPExpression extends Node implements ILambdaBody, IExpression {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $open,
-      /* HH_IGNORE_ERROR[4110] */ $body,
-      /* HH_IGNORE_ERROR[4110] */ $close,
+      $open as XHPOpen,
+      $body as ?NodeList<_>,
+      $close as ?XHPClose,
       $source_ref,
     );
   }
@@ -104,11 +104,8 @@ final class XHPExpression extends Node implements ILambdaBody, IExpression {
     ) {
       return $this;
     }
-    return new static(
-      $open as XHPOpen,
-      /* HH_FIXME[4110] ?NodeList<Node> may not be enforceable */ $body,
-      $close as ?XHPClose,
-    );
+    return
+      new static($open as XHPOpen, $body as ?NodeList<_>, $close as ?XHPClose);
   }
 
   public function getOpenUNTYPED(): ?Node {

--- a/codegen/syntax/XHPLateinit.hack
+++ b/codegen/syntax/XHPLateinit.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<a3e528b8b4e2107ce76b73de28e81fe5>>
+ * @generated SignedSource<<c469cedf5491f9f51ed71e20710af042>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -60,11 +60,7 @@ final class XHPLateinit extends Node {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $at,
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      $source_ref,
-    );
+    return new static($at as AtToken, $keyword as LateinitToken, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/XHPOpen.hack
+++ b/codegen/syntax/XHPOpen.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<243e065f3cdf52e50e7fcb9bbaa641c2>>
+ * @generated SignedSource<<d3213c78a38f020f200506c3c067b9e6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -84,10 +84,10 @@ final class XHPOpen extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_angle,
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $attributes,
-      /* HH_IGNORE_ERROR[4110] */ $right_angle,
+      $left_angle as LessThanToken,
+      $name as XHPElementNameToken,
+      $attributes as ?NodeList<_>,
+      $right_angle as Token,
       $source_ref,
     );
   }
@@ -126,7 +126,7 @@ final class XHPOpen extends Node {
     return new static(
       $left_angle as LessThanToken,
       $name as XHPElementNameToken,
-      /* HH_FIXME[4110] ?NodeList<Node> may not be enforceable */ $attributes,
+      $attributes as ?NodeList<_>,
       $right_angle as Token,
     );
   }

--- a/codegen/syntax/XHPRequired.hack
+++ b/codegen/syntax/XHPRequired.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<46705c8705d026255e35ca7d6fb77378>>
+ * @generated SignedSource<<a2cbe9c79685c8441737da43aa667206>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -60,11 +60,7 @@ final class XHPRequired extends Node {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $at,
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      $source_ref,
-    );
+    return new static($at as AtToken, $keyword as RequiredToken, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/XHPSimpleAttribute.hack
+++ b/codegen/syntax/XHPSimpleAttribute.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<7a129a32ff5c764728e4330a7a660ee4>>
+ * @generated SignedSource<<dc133428497c50c129423a55aea33369>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class XHPSimpleAttribute extends Node implements IXHPAttribute {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $name,
-      /* HH_IGNORE_ERROR[4110] */ $equal,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
+      $name as XHPElementNameToken,
+      $equal as EqualToken,
+      $expression,
       $source_ref,
     );
   }

--- a/codegen/syntax/XHPSimpleClassAttribute.hack
+++ b/codegen/syntax/XHPSimpleClassAttribute.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<0031d0c47275891b7a9c2c9c30b6f09f>>
+ * @generated SignedSource<<45556bfc5791b4810f3cb081a11b108e>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -48,7 +48,7 @@ final class XHPSimpleClassAttribute extends Node {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(/* HH_IGNORE_ERROR[4110] */ $type, $source_ref);
+    return new static($type as SimpleTypeSpecifier, $source_ref);
   }
 
   <<__Override>>

--- a/codegen/syntax/XHPSpreadAttribute.hack
+++ b/codegen/syntax/XHPSpreadAttribute.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<1f8fc7f2d9a70e828e518ffff09c6d06>>
+ * @generated SignedSource<<c1c7f40ca706b3bb36da95ee9b321beb>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -85,10 +85,10 @@ final class XHPSpreadAttribute extends Node {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $left_brace,
-      /* HH_IGNORE_ERROR[4110] */ $spread_operator,
-      /* HH_IGNORE_ERROR[4110] */ $expression,
-      /* HH_IGNORE_ERROR[4110] */ $right_brace,
+      $left_brace as LeftBraceToken,
+      $spread_operator as DotDotDotToken,
+      $expression as IExpression,
+      $right_brace as RightBraceToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/YieldBreakStatement.hack
+++ b/codegen/syntax/YieldBreakStatement.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<6e6f7f480fbda88fab58539d7fb20e14>>
+ * @generated SignedSource<<0328d493491ee657ec91e6bdca21e2b6>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -73,9 +73,9 @@ final class YieldBreakStatement extends Node implements IStatement {
       'width' => $offset - $initial_offset,
     );
     return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $break,
-      /* HH_IGNORE_ERROR[4110] */ $semicolon,
+      $keyword as YieldToken,
+      $break as BreakToken,
+      $semicolon as SemicolonToken,
       $source_ref,
     );
   }

--- a/codegen/syntax/YieldExpression.hack
+++ b/codegen/syntax/YieldExpression.hack
@@ -1,7 +1,7 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * @generated SignedSource<<495da4597cdf5cd7940e68966f534ff5>>
+ * @generated SignedSource<<7dffda834ccc88c474ca3e8c59e4faca>>
  */
 namespace Facebook\HHAST;
 use namespace Facebook\TypeAssert;
@@ -59,11 +59,7 @@ final class YieldExpression extends Node implements ILambdaBody, IExpression {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_IGNORE_ERROR[4110] */ $keyword,
-      /* HH_IGNORE_ERROR[4110] */ $operand,
-      $source_ref,
-    );
+    return new static($keyword as YieldToken, $operand, $source_ref);
   }
 
   <<__Override>>

--- a/src/Migrations/TypedMigrationStep.hack
+++ b/src/Migrations/TypedMigrationStep.hack
@@ -33,7 +33,11 @@ final class TypedMigrationStep<Tin as Node, Tout as Node>
     if (!\is_a($node, $this->tin)) {
       return $node;
     }
+    $node = \HH\FIXME\UNSAFE_CAST<Node, Tin>(
+      $node,
+      'is_a($node, $this->tin) ~= $node is Tin',
+    );
     $rewriter = $this->rewriter;
-    return $rewriter(/* HH_FIXME[4110] need reified generics */ $node);
+    return $rewriter($node);
   }
 }

--- a/src/__Private/NodeImplementationDetails.hack
+++ b/src/__Private/NodeImplementationDetails.hack
@@ -11,8 +11,8 @@ namespace Facebook\HHAST\__Private;
 
 use type Facebook\HHAST\Node;
 
-/* HH_IGNORE_ERROR[4047] not implementing abstract methods */
-abstract final class NodeImplementationDetails extends Node {
+<<__Sealed()>>
+abstract class NodeImplementationDetails extends Node {
   const string SYNTAX_KIND = 'hhast_nonimplementable';
   public static function getSourceRef(Node $node): ?SourceRef {
     return $node->sourceRef;

--- a/src/__Private/codegen/CodegenRelations.hack
+++ b/src/__Private/codegen/CodegenRelations.hack
@@ -398,7 +398,7 @@ final class CodegenRelations extends CodegenBase {
         }
     }
 
-    return /* HH_FIXME[4110] dynamic to real type */ $ret;
+    return \HH\FIXME\UNSAFE_CAST<dynamic, vec<dict<string, mixed>>>($ret);
   }
 
   // If some valid syntax isn't in the HHVM/Hack tests, use it here to make sure

--- a/src/__Private/codegen/CodegenSyntax.hack
+++ b/src/__Private/codegen/CodegenSyntax.hack
@@ -760,7 +760,8 @@ final class CodegenSyntax extends CodegenBase {
     $is_a_known_type = $is_node_listy && $rest === '<Node>' ||
       $is_list_itemy && $rest === '<?Node>';
 
-    return
-      $is_a_known_type ? $expression.' as '.$open_generic : $best_effort_fixme;
+    return $upper_bound === $expected_type
+      ? $expression.' as '.$open_generic
+      : $best_effort_fixme;
   }
 }

--- a/src/__Private/codegen/CodegenSyntax.hack
+++ b/src/__Private/codegen/CodegenSyntax.hack
@@ -735,7 +735,6 @@ final class CodegenSyntax extends CodegenBase {
 
     $base_type = Str\slice($expected_type, 0, $generic_left_angle);
     $open_generic = $base_type.'<_>';
-    $rest = Str\slice($expected_type, $generic_left_angle);
 
     $is_node_listy = $base_type === 'NodeList' || $base_type === '?NodeList';
     $is_list_itemy = $base_type === 'ListItem' || $base_type === '?ListItem';

--- a/src/__Private/codegen/CodegenSyntax.hack
+++ b/src/__Private/codegen/CodegenSyntax.hack
@@ -757,9 +757,6 @@ final class CodegenSyntax extends CodegenBase {
       $open_generic,
     );
 
-    $is_a_known_type = $is_node_listy && $rest === '<Node>' ||
-      $is_list_itemy && $rest === '<?Node>';
-
     return $upper_bound === $expected_type
       ? $expression.' as '.$open_generic
       : $best_effort_fixme;

--- a/src/__Private/type_alias_structure.hack
+++ b/src/__Private/type_alias_structure.hack
@@ -10,5 +10,5 @@
 namespace Facebook\HHAST\__Private;
 
 function type_alias_structure<T>(typename<T> $type): TypeStructure<T> {
-  return /* HH_IGNORE_ERROR[4104] */ type_structure($type);
+  return \HH\type_structure_for_alias($type);
 }

--- a/src/nodes/ListItem.hack
+++ b/src/nodes/ListItem.hack
@@ -121,7 +121,7 @@ final class ListItem<+T as ?Node> extends Node {
 
   public function getItem(): T {
     if ($this->_item === null) {
-      return /* HH_FIXME[4110] trust that T is nullable */ null;
+      return \HH\FIXME\UNSAFE_CAST<null, T>(null, 'trust that T is nullable');
     }
     return $this->_item;
   }

--- a/src/nodes/ListItem.hack
+++ b/src/nodes/ListItem.hack
@@ -68,11 +68,7 @@ final class ListItem<+T as ?Node> extends Node {
       'offset' => $initial_offset,
       'width' => $offset - $initial_offset,
     );
-    return new static(
-      /* HH_FIXME[4110] Expected T, got ?Node */ $item,
-      $separator as ?Token,
-      $source_ref,
-    );
+    return new static($item, $separator as ?Token, $source_ref);
   }
 
   <<__Override>>
@@ -99,7 +95,7 @@ final class ListItem<+T as ?Node> extends Node {
     if ($item === $this->_item && $separator === $this->_separator) {
       return $this;
     }
-    return new static(/* HH_FIXME[4110] */ $item, $separator);
+    return new static($item, $separator);
   }
 
   public function withItem<Tnode super T as Node>(

--- a/src/nodes/Node.hack
+++ b/src/nodes/Node.hack
@@ -76,10 +76,13 @@ abstract class Node implements IMemoizeParam {
     $out = dict[];
     foreach ($this->getChildren() as $k => $node) {
       if (\is_a($node, $what)) {
-        $out[$k] = $node;
+        $out[$k] = \HH\FIXME\UNSAFE_CAST<Node, T>(
+          $node,
+          'is_a($node, $what) ~= $node is T',
+        );
       }
     }
-    return /* HH_FIXME[4110] need reified generics */ $out;
+    return $out;
   }
 
   final public function getChildrenByType<<<__Enforceable>> reify T as Node>(
@@ -161,10 +164,13 @@ abstract class Node implements IMemoizeParam {
     $out = vec[];
     foreach ($this->_descendants as $node) {
       if (\is_a($node, $what)) {
-        $out[] = $node;
+        $out[] = \HH\FIXME\UNSAFE_CAST<Node, T>(
+          $node,
+          'is_a($node, $what) ~= $node is T',
+        );
       }
     }
-    return /* HH_FIXME[4110] need reified generics */ $out;
+    return $out;
   }
 
   final public function getDescendantsByType<<<__Enforceable>> reify T as Node>(
@@ -184,7 +190,10 @@ abstract class Node implements IMemoizeParam {
   ): ?T {
     foreach ($this->_descendants as $node) {
       if (\is_a($node, $what)) {
-        return /* HH_FIXME[4110] need reified generics */ $node;
+        return \HH\FIXME\UNSAFE_CAST<Node, T>(
+          $node,
+          'is_a($node, $what) ~= $node is T',
+        );
       }
     }
     return null;

--- a/src/nodes/NodeList.hack
+++ b/src/nodes/NodeList.hack
@@ -107,7 +107,7 @@ final class NodeList<+Titem as Node> extends Node {
         $type_hint,
       ) as nonnull
         |> \HH\FIXME\UNSAFE_CAST<Node, Titem>($$, 'Titem can not be enforced.');
-      ;
+
       $children[] = $child;
       $current_position += $child->getWidth();
     }

--- a/src/nodes/NodeList.hack
+++ b/src/nodes/NodeList.hack
@@ -105,18 +105,20 @@ final class NodeList<+Titem as Node> extends Node {
         $current_position,
         $source,
         $type_hint,
-      ) as nonnull;
+      ) as nonnull
+        |> \HH\FIXME\UNSAFE_CAST<Node, Titem>($$, 'Titem can not be enforced.');
+      ;
       $children[] = $child;
       $current_position += $child->getWidth();
     }
     return new NodeList(
-      /* HH_FIXME[4110] Expected vec<TItem>, got vec<Node> */ $children,
+      $children,
       shape(
         'file' => $file,
         'source' => $source,
         'offset' => $offset,
         'width' => $current_position - $offset,
-      )
+      ),
     );
   }
 
@@ -135,23 +137,32 @@ final class NodeList<+Titem as Node> extends Node {
         continue;
       }
       if ($new is NodeList<_>) {
+        $new = \HH\FIXME\UNSAFE_CAST<NodeList<Node>, NodeList<Titem>>(
+          $new,
+          'Signature inherited. Fixing the param type would take a lot of effort.',
+        );
         $new_children = Vec\concat($new_children, $new->getChildren());
         continue;
       }
-      $new_children[] = $new;
+      $new_children[] = \HH\FIXME\UNSAFE_CAST<Tret, Titem>(
+        $new,
+        'Signature inherited. Fixing the param type would take a lot of effort.',
+      );
     }
 
     if ($old_children === $new_children) {
       return $this;
     }
 
-    return new NodeList(
-      /* HH_FIXME[4110] Expected vec<TItem>, got vec<?Node>*/ Vec\filter_nulls($new_children)
-    );
+    return new NodeList(Vec\filter_nulls($new_children));
   }
 
   <<__Override>>
   protected function replaceImpl(int $old_id, Node $new): this {
+    $new = \HH\FIXME\UNSAFE_CAST<Node, Titem>(
+      $new,
+      'Signature inherited. Fixing the param type would take a lot of effort.',
+    );
     $children = $this->_children;
     foreach ($children as $idx => $child) {
       if ($child->getUniqueID() === $old_id) {
@@ -164,10 +175,7 @@ final class NodeList<+Titem as Node> extends Node {
       $children[$idx] = $child->replaceImpl($old_id, $new);
       break;
     }
-    return new self(
-      /* HH_FIXME[4110] Expected vec<TItem>, got vec<Node> */
-      Vec\filter_nulls($children)
-    );
+    return new self(Vec\filter_nulls($children));
   }
 
   public function replaceChild<Tchild super Titem as Node>(
@@ -180,9 +188,8 @@ final class NodeList<+Titem as Node> extends Node {
     if (!C\contains($this->_children, $old)) {
       return $this;
     }
-    return new NodeList(
-      Vec\map($this->_children, $c ==> $c === $old ? $new : $c),
-    );
+    return
+      new NodeList(Vec\map($this->_children, $c ==> $c === $old ? $new : $c));
   }
 
   public function insertBefore<Tchild super Titem as Node>(
@@ -228,9 +235,9 @@ final class NodeList<+Titem as Node> extends Node {
     return new NodeList($new);
   }
 
-  public function withoutItemWithChild<Tinner as Node>(
-    Tinner $inner,
-  ): this where Titem as ListItem<Tinner> {
+  public function withoutItemWithChild<Tinner as Node>(Tinner $inner): this
+  where
+    Titem as ListItem<Tinner> {
     $new = Vec\filter($this->_children, $c ==> $c->getItem() !== $inner);
     if ($new === $this->_children) {
       return $this;

--- a/src/nodes/Token.hack
+++ b/src/nodes/Token.hack
@@ -119,7 +119,9 @@ abstract class Token extends Node {
     string $_type_hint,
   ): Token {
     $leading_list = __Private\fold_map<dict<string, mixed>, Trivia, int>(
-      /* HH_FIXME[4110] need like types */ $json['leading'],
+      \HH\FIXME\UNSAFE_CAST<mixed, Traversable<dict<string, mixed>>>(
+        $json['leading'],
+      ),
       ($j, $p) ==> Trivia::fromJSON($j, $file, $p, $source, 'Node'),
       ($j, $p) ==> $j['width'] as int + $p,
       $offset,
@@ -142,7 +144,9 @@ abstract class Token extends Node {
     $token_text = Str\slice($source, $token_position, $token_width);
     $trailing_position = $token_position + $token_width;
     $trailing_list = __Private\fold_map<dict<string, mixed>, Trivia, int>(
-      /* HH_FIXME[4110] need like-types */ $json['trailing'],
+      \HH\FIXME\UNSAFE_CAST<mixed, Traversable<dict<string, mixed>>>(
+        $json['trailing'],
+      ),
       ($j, $p) ==> Trivia::fromJSON($j, $file, $p, $source, 'Node'),
       ($j, $p) ==> $j['width'] as int + $p,
       $trailing_position,

--- a/src/nodes/TokenWithFixedText.hack
+++ b/src/nodes/TokenWithFixedText.hack
@@ -39,8 +39,14 @@ abstract class TokenWithFixedText extends Token {
       return $this;
     }
     return new static(
-      /* HH_FIXME[4110] */ $leading,
-      /* HH_FIXME[4110] */ $trailing,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<Trivia>>(
+        $leading as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<Trivia>>(
+        $trailing as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       null,
     );
   }

--- a/src/nodes/TokenWithVariableText.hack
+++ b/src/nodes/TokenWithVariableText.hack
@@ -39,8 +39,14 @@ abstract class TokenWithVariableText extends Token {
       return $this;
     }
     return new static(
-      /* HH_FIXME[4110] */ $leading,
-      /* HH_FIXME[4110] */ $trailing,
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<Trivia>>(
+        $leading as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
+      \HH\FIXME\UNSAFE_CAST<?NodeList<Node>, ?NodeList<Trivia>>(
+        $trailing as ?NodeList<_>,
+        'Open for sound approaches that are not O(n).',
+      ),
       $this->getText(),
       null,
     );

--- a/src/nodes/WrapperNode.hack
+++ b/src/nodes/WrapperNode.hack
@@ -43,6 +43,9 @@ abstract class WrapperNode extends Node {
       return $this;
     }
 
-    return new static(/* HH_FIXME[4110] need <<__Enforceable>> */ $new);
+    return new static(\HH\FIXME\UNSAFE_CAST<Tret, this::TWrapped>(
+      $new,
+      'TWrapped can not be made enforceable, because of StatementList.',
+    ));
   }
 }

--- a/tests/ConfigurationRestrictionsTest.hack
+++ b/tests/ConfigurationRestrictionsTest.hack
@@ -185,11 +185,10 @@ final class ConfigurationRestrictionsTest extends HackTest {
   }
 
   private static function toTypeStructure<reify T>(): \HH\TypeStructure<mixed> {
-    /*HH_IGNORE_ERROR[4110]
-      All typestructures should be allowed, but TypeStructure<T> is invariant.
-      Putting a suppression comment here is
-      preferable over suppressing an entire vec of testcases.*/
-    return \HH\ReifiedGenerics\get_type_structure<T>();
+    return \HH\FIXME\UNSAFE_CAST<
+      \HH\TypeStructure<T>,
+      \HH\TypeStructure<mixed>,
+    >(\HH\ReifiedGenerics\get_type_structure<T>());
   }
 }
 


### PR DESCRIPTION
Fixes:
 - No more `HH_IGNORE_ERROR` directives in codegen.
 - No more `HH_IGNORE_ERROR` directives in hand rolled nodes.
 - Various `HH_IGNORE_ERROR` -> `HH\FIXME\UNSAFE_CAST<Ta, Tb>(...)` migrations.
   - It is not that I particularly like UNSAFE_CAST, but they are better than a 4110 fixme, right?
 - Remove `HH_IGNORE_ERROR` from declarations.