### PR TITLE
Fix config with multiple overrides for a single file

### DIFF
--- a/src/__Private/LintRunConfig.hack
+++ b/src/__Private/LintRunConfig.hack
@@ -166,8 +166,8 @@ final class LintRunConfig {
       Vec\map($this->configFile['roots'], $dir ==> $this->projectRoot.'/'.$dir);
   }
 
-  private function findOverride(string $file_path): ?self::TOverride {
-    return C\find(
+  private function findOverrides(string $file_path): vec<self::TOverride> {
+    return Vec\filter(
       $this->configFile['overrides'] ?? vec[],
       $override ==> C\find(
         $override['patterns'],
@@ -206,8 +206,7 @@ final class LintRunConfig {
     $blacklist = $this->configFile['disabledLinters'] ?? vec[];
     $autofix_blacklist = $this->configFile['disabledAutoFixes'] ?? vec[];
     $no_autofixes = $this->configFile['disableAllAutoFixes'] ?? false;
-    $override = $this->findOverride($file_path);
-    if ($override is nonnull) {
+    foreach ($this->findOverrides($file_path) as $override) {
       if ($override['disableAllLinters'] ?? false) {
         return shape(
           'linters' => keyset[],
@@ -264,7 +263,8 @@ final class LintRunConfig {
       $file_path is null ? null : $this->relativeFilePath($file_path)
       |> $$ is null
         ? null
-        : $this->findOverride($$)['linterConfigs'][$classname] ?? null;
+        // TODO: This doesn't support multiple overrides.
+        : C\first($this->findOverrides($$))['linterConfigs'][$classname] ?? null;
     if ($global_linter_config is null) {
       if ($file_linter_config is null) {
         return null;

--- a/test-data/hhast-lint.json
+++ b/test-data/hhast-lint.json
@@ -1,5 +1,6 @@
 {
   "roots": [ "." ],
+  "builtinLinters": "none",
   "extraLinters": [
     "Facebook\\HHAST\\Tests\\ValidConfigForLinter",
     "Facebook\\HHAST\\Tests\\InvalidConfigForLinter",
@@ -27,5 +28,33 @@
     "Facebook\\HHAST\\Tests\\ConfigTypeIsNotSupportedByTypeAssertLinter": {
       "impossible": []
     }
-  }
+  },
+  "overrides": [
+    {
+      "patterns": [
+        "single_override/*",
+        "multiple_overrides/*"
+      ],
+      "extraLinters": [
+        "Facebook\\HHAST\\NoEmptyStatementsLinter",
+        "Facebook\\HHAST\\UseStatementWIthoutKindLinter"
+      ],
+      "disabledLinters": [
+        "Facebook\\HHAST\\Tests\\ValidConfigForLinter",
+        "Facebook\\HHAST\\Tests\\InvalidConfigForLinter"
+      ]
+    },
+    {
+      "patterns": [
+        "multiple_overrides/*"
+      ],
+      "extraLinters": [
+        "Facebook\\HHAST\\NoFinalMethodInFinalClassLinter"
+      ],
+      "disabledLinters": [
+        "Facebook\\HHAST\\FinalOrAbstractClassLinter",
+        "Facebook\\HHAST\\Tests\\ConfigTypeIsNotSupportedByTypeAssertLinter"
+      ]
+    }
+  ]
 }

--- a/tests/LinterConfigTest.hack
+++ b/tests/LinterConfigTest.hack
@@ -146,4 +146,35 @@ final class LinterConfigTest extends TestCase {
       'specified an unsupported config type',
     );
   }
+
+  public function testSingleOverride(): void {
+    $lrc = static::getLintRunConfig();
+    $config = $lrc->getConfigForFile('single_override/test.hack');
+
+    expect($config)->toNotBeNull('Config could not be fetched');
+    expect($config)->toEqual(shape(
+      'linters' => keyset [
+        'Facebook\\HHAST\\FinalOrAbstractClassLinter',
+        'Facebook\\HHAST\\Tests\\ConfigTypeIsNotSupportedByTypeAssertLinter',
+        'Facebook\\HHAST\\NoEmptyStatementsLinter',
+        'Facebook\\HHAST\\UseStatementWIthoutKindLinter',
+      ],
+      'autoFixBlacklist' => keyset [],
+    ));
+  }
+
+  public function testMultipleOverrides(): void {
+    $lrc = static::getLintRunConfig();
+    $config = $lrc->getConfigForFile('multiple_overrides/test.hack');
+
+    expect($config)->toNotBeNull('Config could not be fetched');
+    expect($config)->toEqual(shape(
+      'linters' => keyset [
+        'Facebook\\HHAST\\NoEmptyStatementsLinter',
+        'Facebook\\HHAST\\UseStatementWIthoutKindLinter',
+        'Facebook\\HHAST\\NoFinalMethodInFinalClassLinter',
+      ],
+      'autoFixBlacklist' => keyset [],
+    ));
+  }
 }


### PR DESCRIPTION
This is a regression from
https://github.com/hhvm/hhast/commit/e6b406db4f4dbe0b7f6c53832d81e1e799faae87 that removes support for multiple overrides for a single file.

This restores the support for multiple overrides for the run config, but the `linterConfigs` section is still based on the override found.

I manually tested this PR to make sure we don't regress existing tests (and new tests are still passing).